### PR TITLE
Fix Apple Music queue auto-advance not triggering on track end

### DIFF
--- a/app/src/main/assets/js/musickit-bridge.html
+++ b/app/src/main/assets/js/musickit-bridge.html
@@ -237,6 +237,16 @@
             if (window.MusicKitBridge) {
                 MusicKitBridge.onPlaybackStateChange(json);
             }
+            // Detect track completion — MusicKit JS v3 transitions to
+            // "ended" (or "completed") state when a track finishes.
+            // The "mediaItemDidEndPlaying" event is iOS-only and does not
+            // exist in MusicKit JS, so this is the reliable path.
+            if (state === MusicKit.PlaybackStates.ended ||
+                state === MusicKit.PlaybackStates.completed) {
+                if (window.MusicKitBridge) {
+                    MusicKitBridge.onTrackEnded(JSON.stringify({ ended: true }));
+                }
+            }
         });
 
         music.addEventListener('authorizationStatusDidChange', function(event) {

--- a/app/src/main/java/com/parachord/android/playback/PlaybackController.kt
+++ b/app/src/main/java/com/parachord/android/playback/PlaybackController.kt
@@ -545,9 +545,18 @@ class PlaybackController @Inject constructor(
         acquireExternalPlaybackWakeLock()
         val handler = router.getAppleMusicHandler()
 
+        // Guard against multiple end-of-track signals arriving from different
+        // detection paths (JS playbackStateDidChange, JS mediaItemDidEndPlaying,
+        // or the polling safety net). Without this, concurrent signals would
+        // call skipNextInternal() multiple times, skipping tracks in the queue.
+        val trackEndHandled = java.util.concurrent.atomic.AtomicBoolean(false)
+
         // Register track-ended callback from MusicKit JS
         handler.musicKitBridge.onTrackEnded = {
-            scope.launch { skipNextInternal(userInitiated = false) }
+            if (trackEndHandled.compareAndSet(false, true)) {
+                Log.d(TAG, "Apple Music track ended (JS callback)")
+                scope.launch { skipNextInternal(userInitiated = false) }
+            }
         }
 
         appleMusicPollingJob = scope.launch {
@@ -572,7 +581,7 @@ class PlaybackController @Inject constructor(
                 }
 
                 // Safety-net track completion detection
-                if (handler.isOurTrackDone()) {
+                if (handler.isOurTrackDone() && trackEndHandled.compareAndSet(false, true)) {
                     Log.d(TAG, "Apple Music track done (safety net)")
                     skipNextInternal(userInitiated = false)
                     break

--- a/app/src/main/java/com/parachord/android/playback/handlers/MusicKitWebBridge.kt
+++ b/app/src/main/java/com/parachord/android/playback/handlers/MusicKitWebBridge.kt
@@ -535,6 +535,13 @@ class MusicKitWebBridge @Inject constructor(
                 // JS bridge already sends values in milliseconds
                 _position.value = state.position.toLong()
                 _duration.value = state.duration.toLong()
+                // Detect ended state as a safety net — the JS side also fires
+                // onTrackEnded for this, but duplicates are harmless and this
+                // ensures we catch it even if the JS callback is missed.
+                if (state.state == "ended" || state.state == "completed") {
+                    Log.d(TAG, "Playback state is '${state.state}', firing onTrackEnded")
+                    onTrackEnded?.invoke()
+                }
             } catch (e: Exception) {
                 Log.e(TAG, "Failed to parse playback state: $jsonStr", e)
             }


### PR DESCRIPTION
The JS bridge was listening for `mediaItemDidEndPlaying` to detect track
completion, but this event is iOS MusicKit-only and does not exist in
MusicKit JS v3. Additionally, the polling safety net could fail when
MusicKit resets position/duration to 0 after a track ends.

Fix by detecting the "ended" state in the `playbackStateDidChange` event
(which does fire reliably in MusicKit JS v3) and triggering onTrackEnded
from there. Added the same detection in the Kotlin-side callback as a
secondary safety net, and added an AtomicBoolean guard to prevent
double-advance when multiple detection paths fire simultaneously.

https://claude.ai/code/session_011fcjaKroC6JmkMbhVTUSKL