### PR TITLE
Add mini player home screen widget

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -49,6 +49,18 @@
             </intent-filter>
         </service>
 
+        <receiver
+            android:name=".widget.MiniPlayerWidgetProvider"
+            android:exported="false"
+            android:label="Parachord Player">
+            <intent-filter>
+                <action android:name="android.appwidget.action.APPWIDGET_UPDATE" />
+            </intent-filter>
+            <meta-data
+                android:name="android.appwidget.provider"
+                android:resource="@xml/mini_player_widget_info" />
+        </receiver>
+
     </application>
 
 </manifest>

--- a/app/src/main/java/com/parachord/android/playback/PlaybackController.kt
+++ b/app/src/main/java/com/parachord/android/playback/PlaybackController.kt
@@ -20,6 +20,7 @@ import com.parachord.android.playback.handlers.AppleMusicPlaybackHandler
 import com.parachord.android.playback.handlers.PlaybackAction
 import com.parachord.android.resolver.ResolverManager
 import com.parachord.android.resolver.ResolverScoring
+import com.parachord.android.widget.MiniPlayerWidgetUpdater
 import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -55,6 +56,7 @@ class PlaybackController @Inject constructor(
     private val lastFmApi: LastFmApi,
     private val resolverManager: ResolverManager,
     private val resolverScoring: ResolverScoring,
+    private val widgetUpdater: MiniPlayerWidgetUpdater,
 ) {
     companion object {
         private const val TAG = "PlaybackController"
@@ -125,6 +127,7 @@ class PlaybackController @Inject constructor(
                 }
                 queuePersistence.startObserving()
                 scrobbleManager.startObserving()
+                widgetUpdater.startObserving()
             }
         }, MoreExecutors.directExecutor())
     }

--- a/app/src/main/java/com/parachord/android/widget/MiniPlayerWidgetProvider.kt
+++ b/app/src/main/java/com/parachord/android/widget/MiniPlayerWidgetProvider.kt
@@ -1,0 +1,164 @@
+package com.parachord.android.widget
+
+import android.app.PendingIntent
+import android.appwidget.AppWidgetManager
+import android.appwidget.AppWidgetProvider
+import android.content.ComponentName
+import android.content.Context
+import android.content.Intent
+import android.graphics.Bitmap
+import android.graphics.BitmapFactory
+import android.util.Log
+import android.widget.RemoteViews
+import com.parachord.android.R
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.launch
+import java.net.URL
+
+/**
+ * AppWidgetProvider for the Parachord mini player home screen widget.
+ *
+ * Shows album art, track title, artist, play/pause, skip previous/next,
+ * and a progress bar — matching the in-app mini player style.
+ *
+ * Button presses are sent as broadcast intents that this receiver handles
+ * directly by forwarding media commands to the MediaSession via
+ * [MiniPlayerWidgetUpdater].
+ */
+class MiniPlayerWidgetProvider : AppWidgetProvider() {
+
+    companion object {
+        private const val TAG = "MiniPlayerWidget"
+
+        const val ACTION_PLAY_PAUSE = "com.parachord.android.widget.PLAY_PAUSE"
+        const val ACTION_SKIP_NEXT = "com.parachord.android.widget.SKIP_NEXT"
+        const val ACTION_SKIP_PREVIOUS = "com.parachord.android.widget.SKIP_PREVIOUS"
+
+        /** Build the RemoteViews for the widget with the given state. */
+        fun buildRemoteViews(
+            context: Context,
+            title: String?,
+            artist: String?,
+            isPlaying: Boolean,
+            progress: Float,
+            artworkBitmap: Bitmap? = null,
+        ): RemoteViews {
+            val views = RemoteViews(context.packageName, R.layout.widget_mini_player)
+
+            // Track info
+            views.setTextViewText(R.id.widget_title, title ?: "Not playing")
+            views.setTextViewText(R.id.widget_artist, artist ?: "")
+
+            // Play/pause icon
+            views.setImageViewResource(
+                R.id.widget_play_pause,
+                if (isPlaying) R.drawable.ic_widget_pause else R.drawable.ic_widget_play,
+            )
+
+            // Progress bar (0–1000 scale)
+            views.setProgressBar(
+                R.id.widget_progress,
+                1000,
+                (progress.coerceIn(0f, 1f) * 1000).toInt(),
+                false,
+            )
+
+            // Album artwork
+            if (artworkBitmap != null) {
+                views.setImageViewBitmap(R.id.widget_artwork, artworkBitmap)
+            } else {
+                views.setImageViewResource(R.id.widget_artwork, R.drawable.widget_art_placeholder)
+            }
+
+            // Button intents
+            views.setOnClickPendingIntent(
+                R.id.widget_play_pause,
+                actionPendingIntent(context, ACTION_PLAY_PAUSE),
+            )
+            views.setOnClickPendingIntent(
+                R.id.widget_skip_next,
+                actionPendingIntent(context, ACTION_SKIP_NEXT),
+            )
+            views.setOnClickPendingIntent(
+                R.id.widget_skip_previous,
+                actionPendingIntent(context, ACTION_SKIP_PREVIOUS),
+            )
+
+            // Tap anywhere else opens the app
+            val launchIntent = context.packageManager.getLaunchIntentForPackage(context.packageName)
+            if (launchIntent != null) {
+                val launchPi = PendingIntent.getActivity(
+                    context, 0, launchIntent,
+                    PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE,
+                )
+                views.setOnClickPendingIntent(R.id.widget_root, launchPi)
+            }
+
+            return views
+        }
+
+        private fun actionPendingIntent(context: Context, action: String): PendingIntent {
+            val intent = Intent(context, MiniPlayerWidgetProvider::class.java).apply {
+                this.action = action
+            }
+            return PendingIntent.getBroadcast(
+                context, action.hashCode(), intent,
+                PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE,
+            )
+        }
+    }
+
+    private val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+
+    override fun onUpdate(
+        context: Context,
+        appWidgetManager: AppWidgetManager,
+        appWidgetIds: IntArray,
+    ) {
+        // Push current state to all widget instances
+        for (id in appWidgetIds) {
+            val views = buildRemoteViews(
+                context,
+                title = MiniPlayerWidgetUpdater.lastTitle,
+                artist = MiniPlayerWidgetUpdater.lastArtist,
+                isPlaying = MiniPlayerWidgetUpdater.lastIsPlaying,
+                progress = MiniPlayerWidgetUpdater.lastProgress,
+                artworkBitmap = MiniPlayerWidgetUpdater.lastArtworkBitmap,
+            )
+            appWidgetManager.updateAppWidget(id, views)
+        }
+    }
+
+    override fun onReceive(context: Context, intent: Intent) {
+        super.onReceive(context, intent)
+
+        when (intent.action) {
+            ACTION_PLAY_PAUSE -> {
+                Log.d(TAG, "Widget: play/pause")
+                sendMediaAction(context, "play_pause")
+            }
+            ACTION_SKIP_NEXT -> {
+                Log.d(TAG, "Widget: skip next")
+                sendMediaAction(context, "skip_next")
+            }
+            ACTION_SKIP_PREVIOUS -> {
+                Log.d(TAG, "Widget: skip previous")
+                sendMediaAction(context, "skip_previous")
+            }
+        }
+    }
+
+    /**
+     * Send a media action broadcast that [MiniPlayerWidgetUpdater] picks up
+     * to forward to the PlaybackController (which has Hilt injection).
+     */
+    private fun sendMediaAction(context: Context, action: String) {
+        val intent = Intent("com.parachord.android.WIDGET_MEDIA_ACTION").apply {
+            putExtra("action", action)
+            setPackage(context.packageName)
+        }
+        context.sendBroadcast(intent)
+    }
+}

--- a/app/src/main/java/com/parachord/android/widget/MiniPlayerWidgetUpdater.kt
+++ b/app/src/main/java/com/parachord/android/widget/MiniPlayerWidgetUpdater.kt
@@ -1,0 +1,178 @@
+package com.parachord.android.widget
+
+import android.appwidget.AppWidgetManager
+import android.content.BroadcastReceiver
+import android.content.ComponentName
+import android.content.Context
+import android.content.Intent
+import android.content.IntentFilter
+import android.graphics.Bitmap
+import android.graphics.BitmapFactory
+import android.os.Build
+import android.util.Log
+import android.util.LruCache
+import com.parachord.android.playback.PlaybackController
+import com.parachord.android.playback.PlaybackStateHolder
+import dagger.hilt.android.qualifiers.ApplicationContext
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.collectLatest
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import java.net.URL
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * Observes [PlaybackStateHolder] and pushes updates to the mini player widget.
+ *
+ * Also registers a broadcast receiver for widget button presses and forwards
+ * them to [PlaybackController]. This lives as a Hilt singleton so it can
+ * access injected dependencies that the plain [AppWidgetProvider] cannot.
+ */
+@Singleton
+class MiniPlayerWidgetUpdater @Inject constructor(
+    @ApplicationContext private val context: Context,
+    private val stateHolder: PlaybackStateHolder,
+    private val playbackController: PlaybackController,
+) {
+    companion object {
+        private const val TAG = "WidgetUpdater"
+
+        // Cached last-known state so the widget provider can read it
+        // during onUpdate() without needing Hilt.
+        @Volatile var lastTitle: String? = null
+        @Volatile var lastArtist: String? = null
+        @Volatile var lastIsPlaying: Boolean = false
+        @Volatile var lastProgress: Float = 0f
+        @Volatile var lastArtworkBitmap: Bitmap? = null
+    }
+
+    private val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+    private var observeJob: Job? = null
+
+    /** Simple in-memory cache for decoded artwork bitmaps keyed by URL. */
+    private val artworkCache = LruCache<String, Bitmap>(5)
+    private var lastArtworkUrl: String? = null
+
+    private val mediaActionReceiver = object : BroadcastReceiver() {
+        override fun onReceive(ctx: Context, intent: Intent) {
+            when (intent.getStringExtra("action")) {
+                "play_pause" -> playbackController.togglePlayPause()
+                "skip_next" -> playbackController.skipNext()
+                "skip_previous" -> playbackController.skipPrevious()
+            }
+        }
+    }
+
+    /** Start observing playback state and pushing widget updates. */
+    fun startObserving() {
+        if (observeJob != null) return
+
+        // Register for widget media action broadcasts
+        val filter = IntentFilter("com.parachord.android.WIDGET_MEDIA_ACTION")
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+            context.registerReceiver(mediaActionReceiver, filter, Context.RECEIVER_NOT_EXPORTED)
+        } else {
+            context.registerReceiver(mediaActionReceiver, filter)
+        }
+
+        observeJob = scope.launch {
+            stateHolder.state.collectLatest { state ->
+                val track = state.currentTrack
+                val title = track?.title
+                val artist = track?.artist
+                val isPlaying = state.isPlaying
+                val progress = if (state.duration > 0) {
+                    state.position.toFloat() / state.duration.toFloat()
+                } else {
+                    0f
+                }
+
+                // Update cached state
+                lastTitle = title
+                lastArtist = artist
+                lastIsPlaying = isPlaying
+                lastProgress = progress
+
+                // Fetch artwork if URL changed
+                val artworkUrl = track?.artworkUrl
+                if (artworkUrl != lastArtworkUrl) {
+                    lastArtworkUrl = artworkUrl
+                    lastArtworkBitmap = if (artworkUrl != null) {
+                        fetchArtwork(artworkUrl)
+                    } else {
+                        null
+                    }
+                }
+
+                pushUpdate()
+            }
+        }
+
+        // Also run a periodic position update for the progress bar
+        // (state only emits on changes, but position updates may be batched)
+        scope.launch {
+            while (true) {
+                delay(2000)
+                val state = stateHolder.state.value
+                if (state.isPlaying && state.duration > 0) {
+                    lastProgress = state.position.toFloat() / state.duration.toFloat()
+                    pushUpdate()
+                }
+            }
+        }
+    }
+
+    private fun pushUpdate() {
+        val manager = AppWidgetManager.getInstance(context)
+        val component = ComponentName(context, MiniPlayerWidgetProvider::class.java)
+        val ids = manager.getAppWidgetIds(component)
+        if (ids.isEmpty()) return
+
+        val views = MiniPlayerWidgetProvider.buildRemoteViews(
+            context,
+            title = lastTitle,
+            artist = lastArtist,
+            isPlaying = lastIsPlaying,
+            progress = lastProgress,
+            artworkBitmap = lastArtworkBitmap,
+        )
+
+        for (id in ids) {
+            manager.updateAppWidget(id, views)
+        }
+    }
+
+    private suspend fun fetchArtwork(url: String): Bitmap? = withContext(Dispatchers.IO) {
+        // Check cache first
+        artworkCache.get(url)?.let { return@withContext it }
+
+        try {
+            val connection = URL(url).openConnection()
+            connection.connectTimeout = 5000
+            connection.readTimeout = 5000
+            val stream = connection.getInputStream()
+            val original = BitmapFactory.decodeStream(stream)
+            stream.close()
+
+            // Scale down for widget display (48dp ~ 144px at xxxhdpi)
+            val scaled = if (original != null && (original.width > 200 || original.height > 200)) {
+                Bitmap.createScaledBitmap(original, 144, 144, true).also {
+                    if (it !== original) original.recycle()
+                }
+            } else {
+                original
+            }
+
+            scaled?.let { artworkCache.put(url, it) }
+            scaled
+        } catch (e: Exception) {
+            Log.w(TAG, "Failed to fetch widget artwork: $url", e)
+            null
+        }
+    }
+}

--- a/app/src/main/res/drawable/ic_widget_pause.xml
+++ b/app/src/main/res/drawable/ic_widget_pause.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24"
+    android:tint="#F3F4F6">
+    <path
+        android:fillColor="@android:color/white"
+        android:pathData="M6,19h4V5H6v14zM14,5v14h4V5h-4z" />
+</vector>

--- a/app/src/main/res/drawable/ic_widget_play.xml
+++ b/app/src/main/res/drawable/ic_widget_play.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24"
+    android:tint="#F3F4F6">
+    <path
+        android:fillColor="@android:color/white"
+        android:pathData="M8,5v14l11,-7z" />
+</vector>

--- a/app/src/main/res/drawable/ic_widget_skip_next.xml
+++ b/app/src/main/res/drawable/ic_widget_skip_next.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24"
+    android:tint="#9CA3AF">
+    <path
+        android:fillColor="@android:color/white"
+        android:pathData="M6,18l8.5,-6L6,6v12zM16,6v12h2V6h-2z" />
+</vector>

--- a/app/src/main/res/drawable/ic_widget_skip_previous.xml
+++ b/app/src/main/res/drawable/ic_widget_skip_previous.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24"
+    android:tint="#9CA3AF">
+    <path
+        android:fillColor="@android:color/white"
+        android:pathData="M6,6h2v12H6zM9.5,12l8.5,6V6z" />
+</vector>

--- a/app/src/main/res/drawable/widget_art_clip.xml
+++ b/app/src/main/res/drawable/widget_art_clip.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="rectangle">
+    <solid android:color="#FFFFFF" />
+    <corners android:radius="6dp" />
+</shape>

--- a/app/src/main/res/drawable/widget_art_placeholder.xml
+++ b/app/src/main/res/drawable/widget_art_placeholder.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="rectangle">
+    <solid android:color="#273441" />
+    <corners android:radius="6dp" />
+</shape>

--- a/app/src/main/res/drawable/widget_background.xml
+++ b/app/src/main/res/drawable/widget_background.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="rectangle">
+    <solid android:color="#E6161616" />
+    <corners android:radius="16dp" />
+</shape>

--- a/app/src/main/res/drawable/widget_button_ripple.xml
+++ b/app/src/main/res/drawable/widget_button_ripple.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<ripple xmlns:android="http://schemas.android.com/apk/res/android"
+    android:color="#33FFFFFF">
+    <item>
+        <shape android:shape="oval">
+            <solid android:color="@android:color/transparent" />
+        </shape>
+    </item>
+</ripple>

--- a/app/src/main/res/drawable/widget_progress_track.xml
+++ b/app/src/main/res/drawable/widget_progress_track.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layer-list xmlns:android="http://schemas.android.com/apk/res/android">
+    <item android:id="@android:id/background">
+        <shape android:shape="rectangle">
+            <solid android:color="#1AFFFFFF" />
+            <size android:height="3dp" />
+        </shape>
+    </item>
+    <item android:id="@android:id/progress">
+        <clip>
+            <shape android:shape="rectangle">
+                <solid android:color="#A78BFA" />
+                <size android:height="3dp" />
+            </shape>
+        </clip>
+    </item>
+</layer-list>

--- a/app/src/main/res/layout/widget_mini_player.xml
+++ b/app/src/main/res/layout/widget_mini_player.xml
@@ -1,0 +1,110 @@
+<?xml version="1.0" encoding="utf-8"?>
+<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/widget_root"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:background="@drawable/widget_background"
+    android:padding="12dp">
+
+    <!-- Album art -->
+    <ImageView
+        android:id="@+id/widget_artwork"
+        android:layout_width="48dp"
+        android:layout_height="48dp"
+        android:layout_alignParentStart="true"
+        android:layout_centerVertical="true"
+        android:background="@drawable/widget_art_placeholder"
+        android:clipToOutline="true"
+        android:contentDescription="Album artwork"
+        android:scaleType="centerCrop" />
+
+    <!-- Skip previous button -->
+    <ImageButton
+        android:id="@+id/widget_skip_previous"
+        android:layout_width="40dp"
+        android:layout_height="40dp"
+        android:layout_alignParentEnd="true"
+        android:layout_centerVertical="true"
+        android:layout_marginEnd="88dp"
+        android:background="@drawable/widget_button_ripple"
+        android:contentDescription="Previous"
+        android:scaleType="center"
+        android:src="@drawable/ic_widget_skip_previous" />
+
+    <!-- Play/pause button (center-right) -->
+    <ImageButton
+        android:id="@+id/widget_play_pause"
+        android:layout_width="44dp"
+        android:layout_height="44dp"
+        android:layout_alignParentEnd="true"
+        android:layout_centerVertical="true"
+        android:layout_marginEnd="40dp"
+        android:background="@drawable/widget_button_ripple"
+        android:contentDescription="Play"
+        android:scaleType="center"
+        android:src="@drawable/ic_widget_play" />
+
+    <!-- Skip next button -->
+    <ImageButton
+        android:id="@+id/widget_skip_next"
+        android:layout_width="40dp"
+        android:layout_height="40dp"
+        android:layout_alignParentEnd="true"
+        android:layout_centerVertical="true"
+        android:background="@drawable/widget_button_ripple"
+        android:contentDescription="Next"
+        android:scaleType="center"
+        android:src="@drawable/ic_widget_skip_next" />
+
+    <!-- Track info (between art and buttons) -->
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_centerVertical="true"
+        android:layout_marginStart="12dp"
+        android:layout_marginEnd="8dp"
+        android:layout_toStartOf="@id/widget_skip_previous"
+        android:layout_toEndOf="@id/widget_artwork"
+        android:orientation="vertical">
+
+        <!-- Track title -->
+        <TextView
+            android:id="@+id/widget_title"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:ellipsize="end"
+            android:maxLines="1"
+            android:text="Not playing"
+            android:textColor="#F3F4F6"
+            android:textSize="14sp"
+            android:textStyle="bold" />
+
+        <!-- Artist name -->
+        <TextView
+            android:id="@+id/widget_artist"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="1dp"
+            android:ellipsize="end"
+            android:maxLines="1"
+            android:text=""
+            android:textColor="#9CA3AF"
+            android:textSize="12sp" />
+
+    </LinearLayout>
+
+    <!-- Progress bar at bottom -->
+    <ProgressBar
+        android:id="@+id/widget_progress"
+        style="@android:style/Widget.ProgressBar.Horizontal"
+        android:layout_width="match_parent"
+        android:layout_height="3dp"
+        android:layout_alignParentBottom="true"
+        android:layout_marginStart="-12dp"
+        android:layout_marginEnd="-12dp"
+        android:layout_marginBottom="-10dp"
+        android:max="1000"
+        android:progress="0"
+        android:progressDrawable="@drawable/widget_progress_track" />
+
+</RelativeLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,4 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name">Parachord</string>
+    <string name="widget_description">Mini player with playback controls</string>
 </resources>

--- a/app/src/main/res/xml/mini_player_widget_info.xml
+++ b/app/src/main/res/xml/mini_player_widget_info.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<appwidget-provider xmlns:android="http://schemas.android.com/apk/res/android"
+    android:initialLayout="@layout/widget_mini_player"
+    android:minWidth="250dp"
+    android:minHeight="60dp"
+    android:minResizeWidth="180dp"
+    android:minResizeHeight="60dp"
+    android:maxResizeHeight="60dp"
+    android:resizeMode="horizontal"
+    android:targetCellWidth="4"
+    android:targetCellHeight="1"
+    android:updatePeriodMillis="0"
+    android:widgetCategory="home_screen"
+    android:description="@string/widget_description"
+    android:previewLayout="@layout/widget_mini_player" />


### PR DESCRIPTION
Adds an AppWidgetProvider-based home screen widget that mirrors the in-app mini player. Shows album art, track title, artist name, play/pause and skip buttons, and a progress bar — all using the dark player surface colors to match the app's always-dark player bar.

The widget receives real-time updates from PlaybackStateHolder via MiniPlayerWidgetUpdater (Hilt singleton). Button presses are forwarded to PlaybackController through internal broadcasts. Artwork is fetched and cached in-memory, scaled to widget size.

New files:
- widget/MiniPlayerWidgetProvider.kt — widget receiver + RemoteViews
- widget/MiniPlayerWidgetUpdater.kt — observes state, pushes updates
- res/layout/widget_mini_player.xml — widget layout
- res/xml/mini_player_widget_info.xml — widget metadata
- res/drawable/ — widget-specific drawables (background, icons, progress)

https://claude.ai/code/session_011fcjaKroC6JmkMbhVTUSKL