### PR TITLE
Report real track duration to Android Auto during external playback

### DIFF
--- a/app/src/main/java/com/parachord/android/playback/PlaybackService.kt
+++ b/app/src/main/java/com/parachord/android/playback/PlaybackService.kt
@@ -632,7 +632,7 @@ class PlaybackService : MediaLibraryService() {
     class ExternalPlaybackForwardingPlayer(
         private val delegate: ExoPlayer,
         private val playbackController: PlaybackController,
-        @Suppress("unused") private val stateHolder: PlaybackStateHolder,
+        private val stateHolder: PlaybackStateHolder,
     ) : ForwardingPlayer(delegate) {
 
         /** When true, next/prev commands are available and routed to PlaybackController. */
@@ -651,6 +651,28 @@ class PlaybackService : MediaLibraryService() {
                     .build()
             }
             return super.getAvailableCommands()
+        }
+
+        /**
+         * Report the real track duration (from [PlaybackStateHolder]) during
+         * external playback instead of the silence-loop file's duration.
+         * Without this override, Android Auto's progress bar shows 10:00 for
+         * every Spotify / Apple Music track.
+         */
+        override fun getDuration(): Long {
+            if (externalMode) {
+                val real = stateHolder.state.value.duration
+                if (real > 0L) return real
+            }
+            return super.getDuration()
+        }
+
+        override fun getContentDuration(): Long {
+            if (externalMode) {
+                val real = stateHolder.state.value.duration
+                if (real > 0L) return real
+            }
+            return super.getContentDuration()
         }
 
         override fun play() {


### PR DESCRIPTION
ExternalPlaybackForwardingPlayer now overrides getDuration() and getContentDuration() to return PlaybackState.duration during external (Spotify / Apple Music) playback instead of delegating to ExoPlayer, which would otherwise report the silence-loop WAV's duration. Auto's progress bar was showing 10:00 for every streaming track.

Native playback (local / SoundCloud) is unchanged — ExoPlayer's real duration passes through when externalMode is false.

https://claude.ai/code/session_01MRDJQ3KezRV9sQ5vK7RwLf