### PR TITLE
spotify: handle 429 rate-limit (regression from Phase 9E.1.8 Ktor cutover)

### DIFF
--- a/app/src/main/java/com/parachord/android/resolver/ResolverManager.kt
+++ b/app/src/main/java/com/parachord/android/resolver/ResolverManager.kt
@@ -233,6 +233,12 @@ class ResolverManager constructor(
         } catch (e: com.parachord.shared.api.auth.ReauthRequiredException) {
             Log.w(TAG, "Spotify resolve: reauth required for '$query' — user must reconnect")
             null
+        } catch (e: com.parachord.shared.api.SpotifyRateLimitedException) {
+            // 429 (rate limit). Silently skip — `SpotifyClient` already logged
+            // the first 429 of the cooldown cycle; logging per-track here would
+            // produce hundreds of identical lines while a hosted XSPF's
+            // resolver fan-out drains through the cooldown.
+            null
         } catch (e: Exception) {
             Log.w(TAG, "Spotify resolve failed for '$query': ${e.message}")
             null

--- a/shared/src/commonMain/kotlin/com/parachord/shared/api/SpotifyClient.kt
+++ b/shared/src/commonMain/kotlin/com/parachord/shared/api/SpotifyClient.kt
@@ -3,6 +3,8 @@ package com.parachord.shared.api
 import com.parachord.shared.api.auth.AuthCredential
 import com.parachord.shared.api.auth.AuthRealm
 import com.parachord.shared.api.auth.AuthTokenProvider
+import com.parachord.shared.platform.Log
+import com.parachord.shared.platform.currentTimeMillis
 import io.ktor.client.HttpClient
 import io.ktor.client.call.body
 import io.ktor.client.request.HttpRequestBuilder
@@ -17,8 +19,35 @@ import io.ktor.client.statement.HttpResponse
 import io.ktor.http.ContentType
 import io.ktor.http.HttpHeaders
 import io.ktor.http.contentType
+import io.ktor.http.isSuccess
+import kotlin.concurrent.Volatile
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.sync.Semaphore
+import kotlinx.coroutines.sync.withPermit
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
+
+/**
+ * Thrown by [SpotifyClient.search] when Spotify responds with HTTP 429.
+ * Callers (notably [com.parachord.android.resolver.ResolverManager.resolveSpotify])
+ * catch this to set a session-level cooldown so subsequent searches
+ * short-circuit while Spotify's rate-limit window expires — better not
+ * to hammer Spotify into extending the throttle.
+ *
+ * Mirrors the [ItunesRateLimitedException] pattern from commit `16884d1`
+ * for Apple Music's iTunes Search after the same KMP-migration regression:
+ * Retrofit/OkHttp's interceptor-chain 429 retry was lost when Spotify cut
+ * over to Ktor (commit `92ed9eb`, Phase 9E.1.8). The
+ * [com.parachord.shared.sync.SpotifySyncProvider.withRetry] KDoc explicitly
+ * documents this regression — this typed exception is the followup.
+ *
+ * @property retryAfterSeconds value of the `Retry-After` header if Spotify
+ *   sent one; null otherwise. Callers may use this to size their cooldown.
+ */
+class SpotifyRateLimitedException(val retryAfterSeconds: Long? = null) : Exception(
+    "Spotify returned HTTP 429" +
+        (retryAfterSeconds?.let { " (Retry-After: ${it}s)" } ?: "")
+)
 
 /**
  * Spotify Web API client. Cross-platform (commonMain).
@@ -48,7 +77,96 @@ class SpotifyClient(
 ) {
 
     companion object {
+        private const val TAG = "SpotifyClient"
         private const val BASE = "https://api.spotify.com"
+        /**
+         * Hard cap on cooldown duration. Spotify's punishment escalation can
+         * legitimately ask for 30+ minutes (we've observed `Retry-After: 1997s`
+         * after sustained abuse during the regression window). Capping below
+         * the real `Retry-After` is actively counterproductive — calls that
+         * fire after our too-short cooldown elapses just trigger another 429
+         * (Spotify's actual window hasn't closed) and re-set the cooldown,
+         * so the cycle never breaks.
+         *
+         * 1 hour is a generous outer guardrail against a misbehaving server
+         * sending `Retry-After: 86400` while still respecting Spotify's
+         * realistic worst case.
+         */
+        private const val MAX_COOLDOWN_MS = 60L * 60L * 1000L
+        /** Default cooldown when Spotify omits `Retry-After`. Spotify's published 429
+         *  windows are typically 1–60s; 30s is a safe middle ground. */
+        private const val DEFAULT_COOLDOWN_MS = 30_000L
+        /**
+         * Max concurrent Spotify calls in flight. Combined with [INTER_REQUEST_DELAY_MS]
+         * caps throughput at ~13 RPS — well under Spotify's typical per-app limit
+         * (~30+ RPS) and crucially keeps post-cooldown bursts from re-tripping 429.
+         * AM's analogous fix (commit `16884d1`) used 4 for iTunes Search; Spotify
+         * is harsher in practice (we've seen `Retry-After: 102` from a 288-track
+         * resolver fan-out), so we go more conservative.
+         */
+        private const val MAX_CONCURRENT = 2
+        /** Spacing between successive Spotify calls (per-call, after acquiring permit).
+         *  Mirrors AM's `INTER_REQUEST_DELAY_MS` from commit `16884d1`. */
+        private const val INTER_REQUEST_DELAY_MS = 150L
+    }
+
+    /**
+     * Bounds simultaneous Spotify HTTP calls. The cooldown alone (see
+     * [rateLimitedUntilMs]) prevents storms WHILE a 429 is active, but
+     * once the cooldown expires, the resolver pipeline's queued tasks
+     * (one per track in a hosted-XSPF fan-out) burst against Spotify
+     * simultaneously and re-trip 429 within milliseconds — restarting
+     * the cooldown indefinitely. The semaphore breaks the cycle by
+     * letting at most [MAX_CONCURRENT] calls run at a time, so calls
+     * trickle out at a sustainable rate after each cooldown.
+     */
+    private val concurrencyLimiter = Semaphore(MAX_CONCURRENT)
+
+    /**
+     * Epoch-ms timestamp at which Spotify calls may resume. Spotify's rate
+     * limit is per-account/per-app, shared across ALL endpoints — once one
+     * call returns 429, every subsequent call to any endpoint also 429s
+     * until the window expires. So this cooldown is global to the client,
+     * not per-method: a 429 from `search` sets it, and `getCurrentUser` /
+     * `getPlaylistTracks` / etc. all check and short-circuit on it.
+     *
+     * `@Volatile` so writes from one coroutine are seen by readers on other
+     * dispatchers without a memory-model surprise.
+     */
+    @Volatile
+    private var rateLimitedUntilMs: Long = 0L
+
+    /**
+     * Throws [SpotifyRateLimitedException] without making a network call if
+     * we're currently inside a cooldown window. Call at the top of any
+     * 429-aware method — keeps a depleted bucket from being made worse by
+     * additional in-flight requests during the throttle window.
+     */
+    private fun checkCooldown() {
+        val now = currentTimeMillis()
+        if (now < rateLimitedUntilMs) {
+            throw SpotifyRateLimitedException(
+                retryAfterSeconds = ((rateLimitedUntilMs - now + 999L) / 1000L).coerceAtLeast(1L),
+            )
+        }
+    }
+
+    /**
+     * Promote a 429 [HttpResponse] into a typed exception, sizing the
+     * cooldown from the `Retry-After` header (or 30s default), capped at
+     * [MAX_COOLDOWN_MS]. Logs ONLY on the first 429 of each cooldown cycle —
+     * a 288-track playlist generates hundreds of cooldown short-circuits
+     * after the first 429, and logging each one would drown out the signal.
+     */
+    private fun handleRateLimited(response: HttpResponse): Nothing {
+        val retryAfterSec = response.headers["Retry-After"]?.toLongOrNull()
+        val backoffMs = ((retryAfterSec ?: (DEFAULT_COOLDOWN_MS / 1000L)) * 1000L).coerceAtMost(MAX_COOLDOWN_MS)
+        val wasAlreadyLimited = currentTimeMillis() < rateLimitedUntilMs
+        rateLimitedUntilMs = currentTimeMillis() + backoffMs
+        if (!wasAlreadyLimited) {
+            Log.w(TAG, "Spotify rate-limited (HTTP 429). Backing off ${backoffMs / 1000}s; subsequent calls in this window will short-circuit.")
+        }
+        throw SpotifyRateLimitedException(retryAfterSec)
     }
 
     /**
@@ -64,11 +182,43 @@ class SpotifyClient(
 
     // ── Search + Lookup ──────────────────────────────────────────────
 
-    suspend fun search(query: String, type: String, limit: Int = 20, market: String = "from_token"): SpSearchResponse =
-        httpClient.get("$BASE/v1/search") {
-            applyAuth(this)
-            parameter("q", query); parameter("type", type); parameter("limit", limit); parameter("market", market)
-        }.body()
+    /**
+     * Search the Spotify catalog. **Reads response status before body
+     * deserialization** so a 429 surfaces as a typed
+     * [SpotifyRateLimitedException] instead of a
+     * `NoTransformationFoundException` from Ktor's body parser trying to
+     * deserialize an empty 429 body. This lets [ResolverManager.resolveSpotify]
+     * back off cleanly instead of treating every rate-limited request as
+     * a generic failure and continuing to slam Spotify.
+     *
+     * The KMP cutover (commit 92ed9eb) lost Retrofit/OkHttp's interceptor-
+     * chain 429 retry; opening a 288-track hosted XSPF then fans out enough
+     * concurrent searches to trigger the storm — symptoms include missing
+     * Spotify resolver badges, missing track-search-cascade artwork, and
+     * a non-responsive "Pull from Spotify" banner whose `getPlaylistTracks`
+     * call inherits the depleted bucket.
+     */
+    suspend fun search(query: String, type: String, limit: Int = 20, market: String = "from_token"): SpSearchResponse {
+        checkCooldown()
+        return concurrencyLimiter.withPermit {
+            // Re-check cooldown inside the permit — the wait to acquire could
+            // have spanned a freshly-set cooldown from a sibling call.
+            checkCooldown()
+            delay(INTER_REQUEST_DELAY_MS)
+            val response: HttpResponse = httpClient.get("$BASE/v1/search") {
+                applyAuth(this)
+                parameter("q", query); parameter("type", type); parameter("limit", limit); parameter("market", market)
+            }
+            if (response.status.value == 429) handleRateLimited(response)
+            // Non-429 non-success: return an empty search response rather than
+            // letting body parsing throw. Mirrors [AppleMusicClient.search].
+            if (!response.status.isSuccess()) {
+                SpSearchResponse()
+            } else {
+                response.body()
+            }
+        }
+    }
 
     suspend fun getTrack(trackId: String, market: String = "from_token"): SpTrack =
         httpClient.get("$BASE/v1/tracks/$trackId") {
@@ -153,18 +303,48 @@ class SpotifyClient(
             applyAuth(this); parameter("limit", limit); parameter("offset", offset)
         }.body()
 
-    suspend fun getPlaylistTracks(playlistId: String, limit: Int = 100, offset: Int = 0, market: String = "from_token"): SpPlaylistTracksResponse =
-        httpClient.get("$BASE/v1/playlists/$playlistId/tracks") {
-            applyAuth(this); parameter("limit", limit); parameter("offset", offset); parameter("market", market)
-        }.body()
+    /**
+     * 429-aware: shares the global cooldown from [search]. Used by the
+     * Pull-from-Spotify banner via [com.parachord.shared.sync.SpotifySyncProvider.fetchPlaylistTracks].
+     * Without cooldown gating, Pull would 429 directly while a search storm
+     * was depleting the user's Spotify rate-limit bucket.
+     */
+    suspend fun getPlaylistTracks(playlistId: String, limit: Int = 100, offset: Int = 0, market: String = "from_token"): SpPlaylistTracksResponse {
+        checkCooldown()
+        return concurrencyLimiter.withPermit {
+            checkCooldown()
+            delay(INTER_REQUEST_DELAY_MS)
+            val response: HttpResponse = httpClient.get("$BASE/v1/playlists/$playlistId/tracks") {
+                applyAuth(this); parameter("limit", limit); parameter("offset", offset); parameter("market", market)
+            }
+            if (response.status.value == 429) handleRateLimited(response)
+            response.body()
+        }
+    }
 
     suspend fun getPlaylist(playlistId: String, fields: String? = null): SpPlaylistFull =
         httpClient.get("$BASE/v1/playlists/$playlistId") {
             applyAuth(this); if (fields != null) parameter("fields", fields)
         }.body()
 
-    suspend fun getCurrentUser(): SpUser =
-        httpClient.get("$BASE/v1/me") { applyAuth(this) }.body()
+    /**
+     * 429-aware: shares the global cooldown. Called early in
+     * [com.parachord.shared.sync.SpotifySyncProvider.getMarket] (which the
+     * Pull banner uses for market-aware playlist fetches), so a 429 here
+     * blocks the entire Pull flow. Promoting it to a typed exception means
+     * the catch in `pullRemoteChanges` can react cleanly instead of
+     * surfacing `NoTransformationFoundException`.
+     */
+    suspend fun getCurrentUser(): SpUser {
+        checkCooldown()
+        return concurrencyLimiter.withPermit {
+            checkCooldown()
+            delay(INTER_REQUEST_DELAY_MS)
+            val response: HttpResponse = httpClient.get("$BASE/v1/me") { applyAuth(this) }
+            if (response.status.value == 429) handleRateLimited(response)
+            response.body()
+        }
+    }
 
     // ── Library Write ────────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary

Restores 429 rate-limit handling on Spotify API calls that was lost when commit `92ed9eb` (Phase 9E.1.8) migrated Spotify from Retrofit/OkHttp to Ktor. The KDoc on `SpotifySyncProvider.withRetry` explicitly documents this regression and promises a "typed SpHttpException mid-tier in the shared client" follow-up — this is that follow-up. Mirrors the AM-side `ItunesRateLimitedException` pattern from commit \`16884d1\`.

## Symptoms (root cause: rate-limit storm + no recovery)

Opening a 288-track hosted XSPF playlist (e.g. SiriusXMU Rewind) fans out concurrent Spotify search calls in the resolver pipeline. Without 429 handling:

- Spotify resolver badges never appear on track rows
- Pull-from-Spotify banner clicks fail instantly with no visible state change (`_isPulling` flips true→false faster than UI can render)
- Track-search-cascade artwork (Pass 2 of `enrichPlaylistArt`) doesn't pull from Spotify when MB / Last.fm don't have art

The Ktor body parser hits an empty 429 body and throws `NoTransformationFoundException`, which the per-track try/catch swallows — so the loop just retries the next track and gets another 429. Spotify's punishment escalates (we observed `Retry-After: 1997s` ≈ 33 min after sustained abuse).

## Changes (all in shared `SpotifyClient`)

- **`SpotifyRateLimitedException(retryAfterSeconds)`** — read response status before `.body()` so 429s surface as a typed exception. Same shape as AM's `ItunesRateLimitedException`.
- **Global cooldown.** Spotify's 429 is account-wide; one endpoint's 429 means all calls 429. `checkCooldown()` short-circuits in-cooldown calls without hitting the network. Applied to `.search()`, `.getCurrentUser()`, `.getPlaylistTracks()` — covers both the resolver path AND the Pull-from-Spotify path (which goes through `getMarket()` → `getCurrentUser()`).
- **Bounded concurrency.** `Semaphore(2)` + 150ms inter-request delay. Prevents post-cooldown bursts from re-tripping 429 (we observed: cooldown expires, queued resolver tasks fire 4-at-a-time, instant 429, fresh cooldown, infinite loop). Conservative versus AM's `HYDRATE_MAX_CONCURRENCY = 4` because Spotify's punishment escalation is harsher.
- **`MAX_COOLDOWN_MS` raised 2 min → 1 hour.** The original 2-min cap was actively counterproductive: when Spotify said "wait 1997s" we'd cap at 120s, the next call after 120s would trip a fresh 429 (Spotify's window hadn't closed), and we'd loop indefinitely. Respecting the full `Retry-After` lets the bucket actually refill server-side.

Caller-side: `ResolverManager.resolveSpotify` catches the typed exception silently to avoid log spam — a 288-track resolver fan-out would otherwise emit hundreds of identical lines during cooldown. First 429 of each cooldown cycle still logs once at `SpotifyClient` level.

## Verification

- ✅ 400 unit tests pass
- ✅ AM playback canary unaffected (different client, different code path)
- ✅ Spotify badges populate on SiriusXMU after cooldown elapses
- ✅ Pull-from-Spotify banner succeeds after cooldown elapses
- ✅ SiriusXMU artwork enrichment Pass 2 completes (cascades through MB → Last.fm → Spotify, all three working — Last.fm and MusicBrainz have the same regression but their throttle limits aren't being hit in practice)

## Test plan

- [ ] Open SiriusXMU (or any 100+ track hosted XSPF), wait for resolver pipeline to complete; confirm Spotify badges appear gradually (not all at once)
- [ ] On a Spotify-mirrored playlist with stale local snapshot, tap "Pull from Spotify"; confirm it fetches and updates
- [ ] Verify AM playback still works (canary; Spotify cooldown is in a different client and shouldn't affect MusicKit)

## Known follow-ups (not in this PR)

The same Phase 9E.1 regression pattern exists on **`LastFmClient`** and **`MusicBrainzClient`** (and to a lesser extent `SeatGeekClient` / `TicketmasterClient`) — none of them surface 429/5xx as typed exceptions. Last.fm and MusicBrainz are particularly impactful because they're part of the metadata cascade for image enrichment. Would benefit from the same pattern in follow-up PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)