### PR TITLE
api: extend 429 rate-limit handling to Last.fm + MusicBrainz; cover A…

### DIFF
--- a/app/src/main/java/com/parachord/android/resolver/ResolverManager.kt
+++ b/app/src/main/java/com/parachord/android/resolver/ResolverManager.kt
@@ -292,6 +292,12 @@ class ResolverManager constructor(
                 spotifyId = track.id,
                 confidence = 0.95, // High confidence — verified ID match
             )
+        } catch (e: com.parachord.shared.api.SpotifyRateLimitedException) {
+            // Cooldown active — silently skip. SpotifyClient logs the first 429
+            // of each cooldown cycle; logging per-track here would produce
+            // hundreds of identical lines while a hosted-XSPF playlist's cached
+            // spotifyIds drain through the cooldown.
+            null
         } catch (e: Exception) {
             Log.w(TAG, "Failed to verify Spotify track $spotifyId: ${e.message}")
             null

--- a/shared/src/commonMain/kotlin/com/parachord/shared/api/LastFmClient.kt
+++ b/shared/src/commonMain/kotlin/com/parachord/shared/api/LastFmClient.kt
@@ -2,8 +2,10 @@ package com.parachord.shared.api
 
 import io.ktor.client.HttpClient
 import io.ktor.client.call.body
+import io.ktor.client.request.HttpRequestBuilder
 import io.ktor.client.request.get
 import io.ktor.client.request.parameter
+import io.ktor.client.statement.HttpResponse
 import kotlinx.serialization.KSerializer
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
@@ -18,10 +20,36 @@ import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.jsonObject
 
 /**
+ * Thrown by [LastFmClient] methods when Last.fm responds with HTTP 429.
+ * Callers (notably the metadata cascade in [com.parachord.shared.metadata.LastFmProvider])
+ * already swallow generic exceptions and fall through to the next provider,
+ * so a typed exception lets us short-circuit cleanly without log spam.
+ *
+ * Last.fm publishes a 5 RPS per-API-key limit. The rate-limit window is
+ * usually short (seconds), but during sustained abuse the bucket stays
+ * empty for longer. Mirrors [SpotifyRateLimitedException] / [ItunesRateLimitedException].
+ *
+ * @property retryAfterSeconds the value of the `Retry-After` header if
+ *   Last.fm sent one; null otherwise. The fallback is the gate's default.
+ */
+class LastFmRateLimitedException(val retryAfterSeconds: Long? = null) : Exception(
+    "Last.fm returned HTTP 429" + (retryAfterSeconds?.let { " (Retry-After: ${it}s)" } ?: "")
+)
+
+/**
  * Last.fm API client.
  * Base URL: https://ws.audioscrobbler.com/2.0/
  * Auth: API key as query parameter.
  * All endpoints are GET requests to the same URL with different method params.
+ *
+ * **429 handling.** All GET methods route through [gate], which provides
+ * cooldown + bounded concurrency + inter-request pacing — the same pattern
+ * as [SpotifyClient]. The image-enrichment cascade in
+ * `ImageEnrichmentService.enrichPlaylistArt` Pass 2 fans out per-track
+ * Last.fm searches; without the gate, opening a 288-track XSPF playlist
+ * trivially overruns Last.fm's 5 RPS limit. The KMP cutover (Phase 9E.1.6,
+ * commit `79c5ed5`) lost the Retrofit/OkHttp interceptor 429 retry that
+ * previously protected against this.
  */
 class LastFmClient(private val httpClient: HttpClient) {
 
@@ -29,59 +57,78 @@ class LastFmClient(private val httpClient: HttpClient) {
         private const val BASE_URL = "https://ws.audioscrobbler.com/2.0/"
     }
 
+    /** Per-client rate-limit gate. See [RateLimitGate]'s KDoc. */
+    private val gate = RateLimitGate(tag = "LastFmClient")
+
+    /**
+     * Wraps every GET against [BASE_URL] in the rate-limit gate. Methods
+     * just supply their `method=` + endpoint params — `format=json` is
+     * always set here so it can't be forgotten at a callsite.
+     */
+    private suspend inline fun <reified T> guardedGet(
+        crossinline build: HttpRequestBuilder.() -> Unit,
+    ): T = gate.withPermit(exceptionFactory = { LastFmRateLimitedException(it) }) {
+        val response: HttpResponse = httpClient.get(BASE_URL) {
+            build()
+            parameter("format", "json")
+        }
+        gate.handleResponse(response) { LastFmRateLimitedException(it) }
+        response.body()
+    }
+
     suspend fun searchTracks(track: String, apiKey: String, limit: Int = 20): LfmTrackSearchResponse =
-        httpClient.get(BASE_URL) { parameter("method", "track.search"); parameter("track", track); parameter("api_key", apiKey); parameter("limit", limit); parameter("format", "json") }.body()
+        guardedGet { parameter("method", "track.search"); parameter("track", track); parameter("api_key", apiKey); parameter("limit", limit) }
 
     suspend fun searchAlbums(album: String, apiKey: String, limit: Int = 10): LfmAlbumSearchResponse =
-        httpClient.get(BASE_URL) { parameter("method", "album.search"); parameter("album", album); parameter("api_key", apiKey); parameter("limit", limit); parameter("format", "json") }.body()
+        guardedGet { parameter("method", "album.search"); parameter("album", album); parameter("api_key", apiKey); parameter("limit", limit) }
 
     suspend fun searchArtists(artist: String, apiKey: String, limit: Int = 10): LfmArtistSearchResponse =
-        httpClient.get(BASE_URL) { parameter("method", "artist.search"); parameter("artist", artist); parameter("api_key", apiKey); parameter("limit", limit); parameter("format", "json") }.body()
+        guardedGet { parameter("method", "artist.search"); parameter("artist", artist); parameter("api_key", apiKey); parameter("limit", limit) }
 
     suspend fun getArtistInfo(artist: String, apiKey: String): LfmArtistInfoResponse =
-        httpClient.get(BASE_URL) { parameter("method", "artist.getinfo"); parameter("artist", artist); parameter("api_key", apiKey); parameter("format", "json") }.body()
+        guardedGet { parameter("method", "artist.getinfo"); parameter("artist", artist); parameter("api_key", apiKey) }
 
     suspend fun getSimilarArtists(artist: String, apiKey: String, limit: Int = 20): LfmSimilarArtistsResponse =
-        httpClient.get(BASE_URL) { parameter("method", "artist.getsimilar"); parameter("artist", artist); parameter("api_key", apiKey); parameter("limit", limit); parameter("format", "json") }.body()
+        guardedGet { parameter("method", "artist.getsimilar"); parameter("artist", artist); parameter("api_key", apiKey); parameter("limit", limit) }
 
     suspend fun getArtistTopTracks(artist: String, apiKey: String, limit: Int = 10): LfmTopTracksResponse =
-        httpClient.get(BASE_URL) { parameter("method", "artist.gettoptracks"); parameter("artist", artist); parameter("api_key", apiKey); parameter("limit", limit); parameter("format", "json") }.body()
+        guardedGet { parameter("method", "artist.gettoptracks"); parameter("artist", artist); parameter("api_key", apiKey); parameter("limit", limit) }
 
     suspend fun getArtistTopAlbums(artist: String, apiKey: String, limit: Int = 50): LfmTopAlbumsResponse =
-        httpClient.get(BASE_URL) { parameter("method", "artist.gettopalbums"); parameter("artist", artist); parameter("api_key", apiKey); parameter("limit", limit); parameter("format", "json") }.body()
+        guardedGet { parameter("method", "artist.gettopalbums"); parameter("artist", artist); parameter("api_key", apiKey); parameter("limit", limit) }
 
     suspend fun getTrackInfo(track: String, artist: String, apiKey: String): LfmTrackInfoResponse =
-        httpClient.get(BASE_URL) { parameter("method", "track.getInfo"); parameter("track", track); parameter("artist", artist); parameter("api_key", apiKey); parameter("format", "json") }.body()
+        guardedGet { parameter("method", "track.getInfo"); parameter("track", track); parameter("artist", artist); parameter("api_key", apiKey) }
 
     suspend fun getSimilarTracks(track: String, artist: String, apiKey: String, limit: Int = 20): LfmSimilarTracksResponse =
-        httpClient.get(BASE_URL) { parameter("method", "track.getsimilar"); parameter("track", track); parameter("artist", artist); parameter("api_key", apiKey); parameter("limit", limit); parameter("format", "json") }.body()
+        guardedGet { parameter("method", "track.getsimilar"); parameter("track", track); parameter("artist", artist); parameter("api_key", apiKey); parameter("limit", limit) }
 
     suspend fun getAlbumInfo(album: String, artist: String, apiKey: String): LfmAlbumInfoResponse =
-        httpClient.get(BASE_URL) { parameter("method", "album.getinfo"); parameter("album", album); parameter("artist", artist); parameter("api_key", apiKey); parameter("format", "json") }.body()
+        guardedGet { parameter("method", "album.getinfo"); parameter("album", album); parameter("artist", artist); parameter("api_key", apiKey) }
 
     suspend fun getUserInfo(user: String, apiKey: String): LfmUserInfoResponse =
-        httpClient.get(BASE_URL) { parameter("method", "user.getinfo"); parameter("user", user); parameter("api_key", apiKey); parameter("format", "json") }.body()
+        guardedGet { parameter("method", "user.getinfo"); parameter("user", user); parameter("api_key", apiKey) }
 
     suspend fun getUserTopTracks(user: String, apiKey: String, period: String = "overall", limit: Int = 50): LfmUserTopTracksResponse =
-        httpClient.get(BASE_URL) { parameter("method", "user.gettoptracks"); parameter("user", user); parameter("period", period); parameter("limit", limit); parameter("api_key", apiKey); parameter("format", "json") }.body()
+        guardedGet { parameter("method", "user.gettoptracks"); parameter("user", user); parameter("period", period); parameter("limit", limit); parameter("api_key", apiKey) }
 
     suspend fun getUserTopAlbums(user: String, apiKey: String, period: String = "overall", limit: Int = 50): LfmUserTopAlbumsResponse =
-        httpClient.get(BASE_URL) { parameter("method", "user.gettopalbums"); parameter("user", user); parameter("period", period); parameter("limit", limit); parameter("api_key", apiKey); parameter("format", "json") }.body()
+        guardedGet { parameter("method", "user.gettopalbums"); parameter("user", user); parameter("period", period); parameter("limit", limit); parameter("api_key", apiKey) }
 
     suspend fun getUserTopArtists(user: String, apiKey: String, period: String = "overall", limit: Int = 50): LfmUserTopArtistsResponse =
-        httpClient.get(BASE_URL) { parameter("method", "user.gettopartists"); parameter("user", user); parameter("period", period); parameter("limit", limit); parameter("api_key", apiKey); parameter("format", "json") }.body()
+        guardedGet { parameter("method", "user.gettopartists"); parameter("user", user); parameter("period", period); parameter("limit", limit); parameter("api_key", apiKey) }
 
     suspend fun getUserRecentTracks(user: String, apiKey: String, limit: Int = 50): LfmUserRecentTracksResponse =
-        httpClient.get(BASE_URL) { parameter("method", "user.getrecenttracks"); parameter("user", user); parameter("limit", limit); parameter("api_key", apiKey); parameter("format", "json") }.body()
+        guardedGet { parameter("method", "user.getrecenttracks"); parameter("user", user); parameter("limit", limit); parameter("api_key", apiKey) }
 
     suspend fun getUserFriends(user: String, apiKey: String, limit: Int = 200): LfmUserFriendsResponse =
-        httpClient.get(BASE_URL) { parameter("method", "user.getfriends"); parameter("user", user); parameter("limit", limit); parameter("api_key", apiKey); parameter("format", "json") }.body()
+        guardedGet { parameter("method", "user.getfriends"); parameter("user", user); parameter("limit", limit); parameter("api_key", apiKey) }
 
     suspend fun getChartTopTracks(apiKey: String, limit: Int = 50): LfmChartTopTracksResponse =
-        httpClient.get(BASE_URL) { parameter("method", "chart.gettoptracks"); parameter("limit", limit); parameter("api_key", apiKey); parameter("format", "json") }.body()
+        guardedGet { parameter("method", "chart.gettoptracks"); parameter("limit", limit); parameter("api_key", apiKey) }
 
     suspend fun getGeoTopTracks(country: String, apiKey: String, limit: Int = 50): LfmGeoTopTracksResponse =
-        httpClient.get(BASE_URL) { parameter("method", "geo.gettoptracks"); parameter("country", country); parameter("limit", limit); parameter("api_key", apiKey); parameter("format", "json") }.body()
+        guardedGet { parameter("method", "geo.gettoptracks"); parameter("country", country); parameter("limit", limit); parameter("api_key", apiKey) }
 }
 
 // ── Response Models ──────────────────────────────────────────────────

--- a/shared/src/commonMain/kotlin/com/parachord/shared/api/MusicBrainzClient.kt
+++ b/shared/src/commonMain/kotlin/com/parachord/shared/api/MusicBrainzClient.kt
@@ -4,13 +4,49 @@ import io.ktor.client.HttpClient
 import io.ktor.client.call.body
 import io.ktor.client.request.get
 import io.ktor.client.request.parameter
+import io.ktor.client.statement.HttpResponse
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 /**
+ * Thrown by [MusicBrainzClient] methods when MusicBrainz responds with
+ * either HTTP 429 OR HTTP 503 (with `Retry-After`). MusicBrainz signals
+ * rate-limiting primarily via 503 — our gate predicate accepts both.
+ *
+ * MusicBrainz publishes a 1 RPS limit for unauthenticated requests
+ * (anything stricter and the user-agent gets banned). We honor this with
+ * a `Semaphore(1)` + ~1.1s inter-request delay in the gate config.
+ *
+ * @property retryAfterSeconds the value of the `Retry-After` header if
+ *   MusicBrainz sent one; null otherwise. The fallback is the gate's default.
+ */
+class MusicBrainzRateLimitedException(val retryAfterSeconds: Long? = null) : Exception(
+    "MusicBrainz rate-limited" + (retryAfterSeconds?.let { " (Retry-After: ${it}s)" } ?: "")
+)
+
+/**
  * MusicBrainz API v2 client.
- * Free, no auth required. Rate limited to 1 req/sec.
+ * Free, no auth required.
  * https://musicbrainz.org/doc/MusicBrainz_API
+ *
+ * **429/503 handling.** All GET methods route through [gate], which
+ * surfaces 429 OR 503 (MB's preferred throttle response) as a typed
+ * [MusicBrainzRateLimitedException] and engages a cooldown sized by
+ * `Retry-After`. The KMP cutover (Phase 9E.1.1, commit `f41d5bc`) lost
+ * the Retrofit/OkHttp interceptor 429 retry that previously protected
+ * this.
+ *
+ * **No preemptive throttling.** MusicBrainz publishes a 1 RPS limit for
+ * default-UA clients, but with a unique User-Agent (the global OkHttpClient
+ * interceptor sets `Parachord/<version> (Android; ...)`), MB tolerates
+ * ~50 RPS bursts in practice. Desktop calls MB directly via `fetch()` with
+ * no preemptive throttle and runs fine — we match that policy here. The
+ * gate kicks in only if MB actually returns 429/503; until then, calls
+ * flow through unimpeded.
+ *
+ * Unlike Spotify and Last.fm, MusicBrainz returns **503 Service Unavailable**
+ * with a `Retry-After` header when throttled (not 429). The gate's
+ * `isRateLimited` predicate accepts both codes.
  */
 class MusicBrainzClient(private val httpClient: HttpClient) {
 
@@ -18,56 +54,63 @@ class MusicBrainzClient(private val httpClient: HttpClient) {
         private const val BASE_URL = "https://musicbrainz.org/ws/2"
     }
 
+    /** Permissive gate — defaults: Semaphore(2), 150ms inter-request delay.
+     *  Matches desktop's policy of "let calls fly, react only to actual
+     *  throttle responses". The 503-aware predicate is configured per-call. */
+    private val gate = RateLimitGate(tag = "MusicBrainzClient")
+
+    /** Predicate matching MusicBrainz's 503-with-Retry-After throttling
+     *  (in addition to plain 429 in case they ever switch). */
+    private val isMbRateLimited: (HttpResponse) -> Boolean = {
+        it.status.value == 429 || it.status.value == 503
+    }
+
+    private suspend inline fun <reified T> guardedGet(url: String, crossinline build: io.ktor.client.request.HttpRequestBuilder.() -> Unit): T =
+        gate.withPermit(
+            isRateLimited = isMbRateLimited,
+            exceptionFactory = { MusicBrainzRateLimitedException(it) },
+        ) {
+            val response: HttpResponse = httpClient.get(url) {
+                build()
+                parameter("fmt", "json")
+            }
+            gate.handleResponse(
+                response,
+                isRateLimited = isMbRateLimited,
+                exceptionFactory = { MusicBrainzRateLimitedException(it) },
+            )
+            response.body()
+        }
+
     suspend fun searchRecordings(query: String, limit: Int = 20): MbRecordingSearchResponse =
-        httpClient.get("$BASE_URL/recording/") {
-            parameter("query", query)
-            parameter("limit", limit)
-            parameter("fmt", "json")
-        }.body()
+        guardedGet("$BASE_URL/recording/") { parameter("query", query); parameter("limit", limit) }
 
     suspend fun searchReleases(query: String, limit: Int = 10): MbReleaseSearchResponse =
-        httpClient.get("$BASE_URL/release/") {
-            parameter("query", query)
-            parameter("limit", limit)
-            parameter("fmt", "json")
-        }.body()
+        guardedGet("$BASE_URL/release/") { parameter("query", query); parameter("limit", limit) }
 
     suspend fun searchArtists(query: String, limit: Int = 10): MbArtistSearchResponse =
-        httpClient.get("$BASE_URL/artist/") {
-            parameter("query", query)
-            parameter("limit", limit)
-            parameter("fmt", "json")
-        }.body()
+        guardedGet("$BASE_URL/artist/") { parameter("query", query); parameter("limit", limit) }
 
     suspend fun getRelease(
         releaseId: String,
         inc: String = "recordings+artist-credits",
     ): MbReleaseDetail =
-        httpClient.get("$BASE_URL/release/$releaseId") {
-            parameter("inc", inc)
-            parameter("fmt", "json")
-        }.body()
+        guardedGet("$BASE_URL/release/$releaseId") { parameter("inc", inc) }
 
     suspend fun browseReleaseGroups(
         artistId: String,
         limit: Int = 100,
         offset: Int = 0,
     ): MbReleaseGroupBrowseResponse =
-        httpClient.get("$BASE_URL/release-group") {
-            parameter("artist", artistId)
-            parameter("limit", limit)
-            parameter("offset", offset)
-            parameter("fmt", "json")
-        }.body()
+        guardedGet("$BASE_URL/release-group") {
+            parameter("artist", artistId); parameter("limit", limit); parameter("offset", offset)
+        }
 
     suspend fun getArtist(
         artistId: String,
         inc: String = "url-rels",
     ): MbArtistDetail =
-        httpClient.get("$BASE_URL/artist/$artistId") {
-            parameter("inc", inc)
-            parameter("fmt", "json")
-        }.body()
+        guardedGet("$BASE_URL/artist/$artistId") { parameter("inc", inc) }
 }
 
 // ── Response Models ──────────────────────────────────────────────────

--- a/shared/src/commonMain/kotlin/com/parachord/shared/api/RateLimitGate.kt
+++ b/shared/src/commonMain/kotlin/com/parachord/shared/api/RateLimitGate.kt
@@ -1,0 +1,127 @@
+package com.parachord.shared.api
+
+import com.parachord.shared.platform.Log
+import com.parachord.shared.platform.currentTimeMillis
+import io.ktor.client.statement.HttpResponse
+import kotlin.concurrent.Volatile
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.sync.Semaphore
+import kotlinx.coroutines.sync.withPermit
+
+/**
+ * Per-client rate-limit gate. Provides a single source of truth for
+ *   1. **Cooldown** — when the upstream service has signaled a 429 (or 503
+ *      for some APIs), all in-flight callers fail fast against this gate
+ *      until the suggested `Retry-After` window elapses.
+ *   2. **Concurrency limit** — a [Semaphore] caps simultaneous calls to a
+ *      conservative number (default 2). This prevents the post-cooldown
+ *      burst that would otherwise re-trip the throttle as soon as queued
+ *      tasks all fire at once.
+ *   3. **Inter-request delay** — a 150ms sleep before each call (after
+ *      acquiring the permit). Same pacing AM uses in
+ *      `AppleMusicSyncProvider.searchForTrackId` (commit `16884d1`).
+ *
+ * **Why this exists.** The KMP migration's Phase 9E.1.* cutovers (Apr 28,
+ * 2026) swapped Retrofit/OkHttp for Ktor across SpotifyClient,
+ * LastFmClient, MusicBrainzClient, and others. The Retrofit interceptor
+ * chain had implicit 429/5xx retry on each. Ktor doesn't, so 429s now
+ * surface as `NoTransformationFoundException` from the body parser
+ * (empty 429 bodies don't deserialize into the expected typed body).
+ * This gate is the typed mid-tier follow-up that
+ * `SpotifySyncProvider.withRetry`'s KDoc explicitly promised after the
+ * cutover. Mirrors the AM-side `ItunesRateLimitedException` pattern from
+ * commit `16884d1`.
+ *
+ * **Design choices:**
+ *  - `MAX_COOLDOWN_MS = 1 hour`: respect the upstream's `Retry-After`
+ *    even when it's 30+ minutes. Capping below it is actively
+ *    counterproductive — if Spotify says wait 1997s and we cap at 120s,
+ *    the next call after 120s trips a fresh 429 (Spotify's window hasn't
+ *    closed) and we loop indefinitely. 1 hour is a safety guardrail, not
+ *    a typical case.
+ *  - Single global cooldown (not per-method): rate limits are usually
+ *    account/IP-wide, so one endpoint's 429 means all calls 429.
+ *  - Logs first 429 of each cooldown cycle only, never per-call thereafter
+ *    — a 288-track resolver fan-out would otherwise emit hundreds of
+ *    identical lines.
+ *
+ * @param tag log tag for diagnostics (typically the client name).
+ * @param maxConcurrent simultaneous in-flight permit count. Lower for
+ *   stricter providers (MusicBrainz publishes 1 RPS; we use 1 + a longer
+ *   delay there).
+ * @param interRequestDelayMs sleep between successive calls inside the
+ *   permit. Helps stagger bursts.
+ * @param defaultCooldownSec used when the response has no `Retry-After`.
+ * @param maxCooldownMs hard cap (defense against misbehaving servers).
+ */
+class RateLimitGate(
+    private val tag: String,
+    maxConcurrent: Int = 2,
+    private val interRequestDelayMs: Long = 150L,
+    private val defaultCooldownSec: Long = 30L,
+    private val maxCooldownMs: Long = 60L * 60L * 1000L,
+) {
+    private val limiter = Semaphore(maxConcurrent)
+
+    /** Epoch-ms timestamp at which calls may resume. `@Volatile` so writes from
+     *  one coroutine are seen on others without a memory-model surprise. */
+    @Volatile
+    private var cooldownUntilMs: Long = 0L
+
+    /**
+     * Run [block] under the gate. Throws via [exceptionFactory] without
+     * making a network call if the cooldown is active. Otherwise acquires
+     * a permit, sleeps the inter-request delay, runs [block], and on a
+     * rate-limited response (per [isRateLimited]) sets the cooldown +
+     * throws.
+     *
+     * @param isRateLimited matches 429 by default; pass a different
+     *   predicate for APIs that signal throttling differently (e.g.
+     *   MusicBrainz uses 503 + `Retry-After`).
+     * @param exceptionFactory builds the typed exception to throw. Receives
+     *   the `Retry-After` value in seconds (or null if absent), so callers
+     *   can encode it in their own typed exceptions.
+     */
+    suspend fun <T> withPermit(
+        isRateLimited: (HttpResponse) -> Boolean = { it.status.value == 429 },
+        exceptionFactory: (retryAfterSeconds: Long?) -> Exception,
+        block: suspend () -> T,
+    ): T {
+        checkCooldown(exceptionFactory)
+        return limiter.withPermit {
+            checkCooldown(exceptionFactory)
+            delay(interRequestDelayMs)
+            block()
+        }
+    }
+
+    /**
+     * Check if the most recent response indicates rate-limiting, and if
+     * so set the cooldown. Call this AFTER the request returns (inside the
+     * [withPermit] block), passing the response. Returns `false` if NOT
+     * rate-limited (caller proceeds normally) or throws if rate-limited
+     * (caller doesn't reach the `body()` decode step).
+     */
+    fun handleResponse(
+        response: HttpResponse,
+        isRateLimited: (HttpResponse) -> Boolean = { it.status.value == 429 },
+        exceptionFactory: (retryAfterSeconds: Long?) -> Exception,
+    ) {
+        if (!isRateLimited(response)) return
+        val retryAfterSec = response.headers["Retry-After"]?.toLongOrNull()
+        val backoffMs = ((retryAfterSec ?: defaultCooldownSec) * 1000L).coerceAtMost(maxCooldownMs)
+        val wasAlreadyLimited = currentTimeMillis() < cooldownUntilMs
+        cooldownUntilMs = currentTimeMillis() + backoffMs
+        if (!wasAlreadyLimited) {
+            Log.w(tag, "$tag rate-limited (HTTP ${response.status.value}). Backing off ${backoffMs / 1000}s; subsequent calls in this window will short-circuit.")
+        }
+        throw exceptionFactory(retryAfterSec)
+    }
+
+    private fun checkCooldown(exceptionFactory: (retryAfterSeconds: Long?) -> Exception) {
+        val now = currentTimeMillis()
+        if (now < cooldownUntilMs) {
+            throw exceptionFactory(((cooldownUntilMs - now + 999L) / 1000L).coerceAtLeast(1L))
+        }
+    }
+}

--- a/shared/src/commonMain/kotlin/com/parachord/shared/api/SpotifyClient.kt
+++ b/shared/src/commonMain/kotlin/com/parachord/shared/api/SpotifyClient.kt
@@ -3,8 +3,6 @@ package com.parachord.shared.api
 import com.parachord.shared.api.auth.AuthCredential
 import com.parachord.shared.api.auth.AuthRealm
 import com.parachord.shared.api.auth.AuthTokenProvider
-import com.parachord.shared.platform.Log
-import com.parachord.shared.platform.currentTimeMillis
 import io.ktor.client.HttpClient
 import io.ktor.client.call.body
 import io.ktor.client.request.HttpRequestBuilder
@@ -20,10 +18,6 @@ import io.ktor.http.ContentType
 import io.ktor.http.HttpHeaders
 import io.ktor.http.contentType
 import io.ktor.http.isSuccess
-import kotlin.concurrent.Volatile
-import kotlinx.coroutines.delay
-import kotlinx.coroutines.sync.Semaphore
-import kotlinx.coroutines.sync.withPermit
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
@@ -77,97 +71,29 @@ class SpotifyClient(
 ) {
 
     companion object {
-        private const val TAG = "SpotifyClient"
         private const val BASE = "https://api.spotify.com"
-        /**
-         * Hard cap on cooldown duration. Spotify's punishment escalation can
-         * legitimately ask for 30+ minutes (we've observed `Retry-After: 1997s`
-         * after sustained abuse during the regression window). Capping below
-         * the real `Retry-After` is actively counterproductive — calls that
-         * fire after our too-short cooldown elapses just trigger another 429
-         * (Spotify's actual window hasn't closed) and re-set the cooldown,
-         * so the cycle never breaks.
-         *
-         * 1 hour is a generous outer guardrail against a misbehaving server
-         * sending `Retry-After: 86400` while still respecting Spotify's
-         * realistic worst case.
-         */
-        private const val MAX_COOLDOWN_MS = 60L * 60L * 1000L
-        /** Default cooldown when Spotify omits `Retry-After`. Spotify's published 429
-         *  windows are typically 1–60s; 30s is a safe middle ground. */
-        private const val DEFAULT_COOLDOWN_MS = 30_000L
-        /**
-         * Max concurrent Spotify calls in flight. Combined with [INTER_REQUEST_DELAY_MS]
-         * caps throughput at ~13 RPS — well under Spotify's typical per-app limit
-         * (~30+ RPS) and crucially keeps post-cooldown bursts from re-tripping 429.
-         * AM's analogous fix (commit `16884d1`) used 4 for iTunes Search; Spotify
-         * is harsher in practice (we've seen `Retry-After: 102` from a 288-track
-         * resolver fan-out), so we go more conservative.
-         */
-        private const val MAX_CONCURRENT = 2
-        /** Spacing between successive Spotify calls (per-call, after acquiring permit).
-         *  Mirrors AM's `INTER_REQUEST_DELAY_MS` from commit `16884d1`. */
-        private const val INTER_REQUEST_DELAY_MS = 150L
     }
 
     /**
-     * Bounds simultaneous Spotify HTTP calls. The cooldown alone (see
-     * [rateLimitedUntilMs]) prevents storms WHILE a 429 is active, but
-     * once the cooldown expires, the resolver pipeline's queued tasks
-     * (one per track in a hosted-XSPF fan-out) burst against Spotify
-     * simultaneously and re-trip 429 within milliseconds — restarting
-     * the cooldown indefinitely. The semaphore breaks the cycle by
-     * letting at most [MAX_CONCURRENT] calls run at a time, so calls
-     * trickle out at a sustainable rate after each cooldown.
-     */
-    private val concurrencyLimiter = Semaphore(MAX_CONCURRENT)
-
-    /**
-     * Epoch-ms timestamp at which Spotify calls may resume. Spotify's rate
-     * limit is per-account/per-app, shared across ALL endpoints — once one
-     * call returns 429, every subsequent call to any endpoint also 429s
-     * until the window expires. So this cooldown is global to the client,
-     * not per-method: a 429 from `search` sets it, and `getCurrentUser` /
-     * `getPlaylistTracks` / etc. all check and short-circuit on it.
+     * Per-client rate-limit gate. See [RateLimitGate] for design notes.
      *
-     * `@Volatile` so writes from one coroutine are seen by readers on other
-     * dispatchers without a memory-model surprise.
+     * Covers ALL Spotify GET endpoints below — Spotify's 429s are
+     * account-wide (one endpoint hits 429, every subsequent call to any
+     * endpoint also 429s until the window expires), so a single shared
+     * gate is the right shape. PR #115 originally protected only `search`,
+     * `getCurrentUser`, `getPlaylistTracks`; we extend coverage here
+     * because `getTrack` (used by [com.parachord.android.resolver.ResolverManager.verifyTrack]
+     * to fan out per-track checks for stored `spotifyId`s) was the actual
+     * volume offender on hosted-XSPF playlists — every cached `spotifyId`
+     * triggered an unprotected `/v1/tracks/{id}` call that 429'd, each one
+     * extending Spotify's punishment window indefinitely.
+     *
+     * Playback-control PUT/DELETE methods (startPlayback, pausePlayback,
+     * etc.) intentionally **do not** route through the gate — the user
+     * needs to be able to skip / pause even during a throttle window. The
+     * gate is for high-volume read traffic, not interactive control.
      */
-    @Volatile
-    private var rateLimitedUntilMs: Long = 0L
-
-    /**
-     * Throws [SpotifyRateLimitedException] without making a network call if
-     * we're currently inside a cooldown window. Call at the top of any
-     * 429-aware method — keeps a depleted bucket from being made worse by
-     * additional in-flight requests during the throttle window.
-     */
-    private fun checkCooldown() {
-        val now = currentTimeMillis()
-        if (now < rateLimitedUntilMs) {
-            throw SpotifyRateLimitedException(
-                retryAfterSeconds = ((rateLimitedUntilMs - now + 999L) / 1000L).coerceAtLeast(1L),
-            )
-        }
-    }
-
-    /**
-     * Promote a 429 [HttpResponse] into a typed exception, sizing the
-     * cooldown from the `Retry-After` header (or 30s default), capped at
-     * [MAX_COOLDOWN_MS]. Logs ONLY on the first 429 of each cooldown cycle —
-     * a 288-track playlist generates hundreds of cooldown short-circuits
-     * after the first 429, and logging each one would drown out the signal.
-     */
-    private fun handleRateLimited(response: HttpResponse): Nothing {
-        val retryAfterSec = response.headers["Retry-After"]?.toLongOrNull()
-        val backoffMs = ((retryAfterSec ?: (DEFAULT_COOLDOWN_MS / 1000L)) * 1000L).coerceAtMost(MAX_COOLDOWN_MS)
-        val wasAlreadyLimited = currentTimeMillis() < rateLimitedUntilMs
-        rateLimitedUntilMs = currentTimeMillis() + backoffMs
-        if (!wasAlreadyLimited) {
-            Log.w(TAG, "Spotify rate-limited (HTTP 429). Backing off ${backoffMs / 1000}s; subsequent calls in this window will short-circuit.")
-        }
-        throw SpotifyRateLimitedException(retryAfterSec)
-    }
+    private val gate = RateLimitGate(tag = "SpotifyClient")
 
     /**
      * Apply the Spotify bearer token from [AuthTokenProvider]. If no
@@ -180,68 +106,59 @@ class SpotifyClient(
         if (token != null) builder.header(HttpHeaders.Authorization, "Bearer $token")
     }
 
+    /**
+     * Wraps every GET in the rate-limit gate. Reads response status BEFORE
+     * `.body()` deserialization so a 429 surfaces as a typed
+     * [SpotifyRateLimitedException] (instead of a `NoTransformationFoundException`
+     * from Ktor's body parser trying to deserialize the empty 429 body).
+     *
+     * Other non-success responses fall through to `.body()` — Ktor will
+     * throw, which preserves the existing per-call exception handling at
+     * caller sites (e.g. `ResolverManager.verifyTrack`'s try/catch → null).
+     */
+    private suspend inline fun <reified T> gatedGet(
+        url: String,
+        crossinline configure: suspend HttpRequestBuilder.() -> Unit,
+    ): T = gate.withPermit(exceptionFactory = { SpotifyRateLimitedException(it) }) {
+        val response: HttpResponse = httpClient.get(url) { configure() }
+        gate.handleResponse(response) { SpotifyRateLimitedException(it) }
+        response.body()
+    }
+
     // ── Search + Lookup ──────────────────────────────────────────────
 
     /**
-     * Search the Spotify catalog. **Reads response status before body
-     * deserialization** so a 429 surfaces as a typed
-     * [SpotifyRateLimitedException] instead of a
-     * `NoTransformationFoundException` from Ktor's body parser trying to
-     * deserialize an empty 429 body. This lets [ResolverManager.resolveSpotify]
-     * back off cleanly instead of treating every rate-limited request as
-     * a generic failure and continuing to slam Spotify.
-     *
-     * The KMP cutover (commit 92ed9eb) lost Retrofit/OkHttp's interceptor-
-     * chain 429 retry; opening a 288-track hosted XSPF then fans out enough
-     * concurrent searches to trigger the storm — symptoms include missing
-     * Spotify resolver badges, missing track-search-cascade artwork, and
-     * a non-responsive "Pull from Spotify" banner whose `getPlaylistTracks`
-     * call inherits the depleted bucket.
+     * Search the Spotify catalog. The gate handles 429 → typed exception;
+     * other non-success responses are mapped to an empty [SpSearchResponse]
+     * so the resolver doesn't crash on transient 5xx (mirrors
+     * [AppleMusicClient.search]).
      */
-    suspend fun search(query: String, type: String, limit: Int = 20, market: String = "from_token"): SpSearchResponse {
-        checkCooldown()
-        return concurrencyLimiter.withPermit {
-            // Re-check cooldown inside the permit — the wait to acquire could
-            // have spanned a freshly-set cooldown from a sibling call.
-            checkCooldown()
-            delay(INTER_REQUEST_DELAY_MS)
+    suspend fun search(query: String, type: String, limit: Int = 20, market: String = "from_token"): SpSearchResponse =
+        gate.withPermit(exceptionFactory = { SpotifyRateLimitedException(it) }) {
             val response: HttpResponse = httpClient.get("$BASE/v1/search") {
                 applyAuth(this)
                 parameter("q", query); parameter("type", type); parameter("limit", limit); parameter("market", market)
             }
-            if (response.status.value == 429) handleRateLimited(response)
-            // Non-429 non-success: return an empty search response rather than
-            // letting body parsing throw. Mirrors [AppleMusicClient.search].
-            if (!response.status.isSuccess()) {
-                SpSearchResponse()
-            } else {
-                response.body()
-            }
+            gate.handleResponse(response) { SpotifyRateLimitedException(it) }
+            if (!response.status.isSuccess()) SpSearchResponse() else response.body()
         }
-    }
 
     suspend fun getTrack(trackId: String, market: String = "from_token"): SpTrack =
-        httpClient.get("$BASE/v1/tracks/$trackId") {
-            applyAuth(this); parameter("market", market)
-        }.body()
+        gatedGet("$BASE/v1/tracks/$trackId") { applyAuth(this); parameter("market", market) }
 
     suspend fun getArtist(artistId: String): SpArtist =
-        httpClient.get("$BASE/v1/artists/$artistId") { applyAuth(this) }.body()
+        gatedGet("$BASE/v1/artists/$artistId") { applyAuth(this) }
 
     suspend fun getArtistTopTracks(artistId: String, market: String = "US"): SpTopTracksResponse =
-        httpClient.get("$BASE/v1/artists/$artistId/top-tracks") {
-            applyAuth(this); parameter("market", market)
-        }.body()
+        gatedGet("$BASE/v1/artists/$artistId/top-tracks") { applyAuth(this); parameter("market", market) }
 
     suspend fun getArtistAlbums(artistId: String, includeGroups: String = "album,single,compilation", limit: Int = 50): SpPaginated<SpAlbum> =
-        httpClient.get("$BASE/v1/artists/$artistId/albums") {
+        gatedGet("$BASE/v1/artists/$artistId/albums") {
             applyAuth(this); parameter("include_groups", includeGroups); parameter("limit", limit)
-        }.body()
+        }
 
     suspend fun getAlbumTracks(albumId: String, limit: Int = 50): SpPaginated<SpSimpleTrack> =
-        httpClient.get("$BASE/v1/albums/$albumId/tracks") {
-            applyAuth(this); parameter("limit", limit)
-        }.body()
+        gatedGet("$BASE/v1/albums/$albumId/tracks") { applyAuth(this); parameter("limit", limit) }
 
     // ── Playback Control (Spotify Connect) ───────────────────────────
 
@@ -283,68 +200,38 @@ class SpotifyClient(
     // ── Library (Sync Read) ──────────────────────────────────────────
 
     suspend fun getLikedTracks(limit: Int = 50, offset: Int = 0, market: String = "from_token"): SpSavedTracksResponse =
-        httpClient.get("$BASE/v1/me/tracks") {
+        gatedGet("$BASE/v1/me/tracks") {
             applyAuth(this); parameter("limit", limit); parameter("offset", offset); parameter("market", market)
-        }.body()
+        }
 
     suspend fun getSavedAlbums(limit: Int = 50, offset: Int = 0, market: String = "from_token"): SpSavedAlbumsResponse =
-        httpClient.get("$BASE/v1/me/albums") {
+        gatedGet("$BASE/v1/me/albums") {
             applyAuth(this); parameter("limit", limit); parameter("offset", offset); parameter("market", market)
-        }.body()
+        }
 
     suspend fun getFollowedArtists(limit: Int = 50, after: String? = null): SpFollowedArtistsResponse =
-        httpClient.get("$BASE/v1/me/following") {
+        gatedGet("$BASE/v1/me/following") {
             applyAuth(this); parameter("type", "artist"); parameter("limit", limit)
             if (after != null) parameter("after", after)
-        }.body()
+        }
 
     suspend fun getUserPlaylists(limit: Int = 50, offset: Int = 0): SpPaginatedPlaylists =
-        httpClient.get("$BASE/v1/me/playlists") {
+        gatedGet("$BASE/v1/me/playlists") {
             applyAuth(this); parameter("limit", limit); parameter("offset", offset)
-        }.body()
-
-    /**
-     * 429-aware: shares the global cooldown from [search]. Used by the
-     * Pull-from-Spotify banner via [com.parachord.shared.sync.SpotifySyncProvider.fetchPlaylistTracks].
-     * Without cooldown gating, Pull would 429 directly while a search storm
-     * was depleting the user's Spotify rate-limit bucket.
-     */
-    suspend fun getPlaylistTracks(playlistId: String, limit: Int = 100, offset: Int = 0, market: String = "from_token"): SpPlaylistTracksResponse {
-        checkCooldown()
-        return concurrencyLimiter.withPermit {
-            checkCooldown()
-            delay(INTER_REQUEST_DELAY_MS)
-            val response: HttpResponse = httpClient.get("$BASE/v1/playlists/$playlistId/tracks") {
-                applyAuth(this); parameter("limit", limit); parameter("offset", offset); parameter("market", market)
-            }
-            if (response.status.value == 429) handleRateLimited(response)
-            response.body()
         }
-    }
+
+    suspend fun getPlaylistTracks(playlistId: String, limit: Int = 100, offset: Int = 0, market: String = "from_token"): SpPlaylistTracksResponse =
+        gatedGet("$BASE/v1/playlists/$playlistId/tracks") {
+            applyAuth(this); parameter("limit", limit); parameter("offset", offset); parameter("market", market)
+        }
 
     suspend fun getPlaylist(playlistId: String, fields: String? = null): SpPlaylistFull =
-        httpClient.get("$BASE/v1/playlists/$playlistId") {
+        gatedGet("$BASE/v1/playlists/$playlistId") {
             applyAuth(this); if (fields != null) parameter("fields", fields)
-        }.body()
-
-    /**
-     * 429-aware: shares the global cooldown. Called early in
-     * [com.parachord.shared.sync.SpotifySyncProvider.getMarket] (which the
-     * Pull banner uses for market-aware playlist fetches), so a 429 here
-     * blocks the entire Pull flow. Promoting it to a typed exception means
-     * the catch in `pullRemoteChanges` can react cleanly instead of
-     * surfacing `NoTransformationFoundException`.
-     */
-    suspend fun getCurrentUser(): SpUser {
-        checkCooldown()
-        return concurrencyLimiter.withPermit {
-            checkCooldown()
-            delay(INTER_REQUEST_DELAY_MS)
-            val response: HttpResponse = httpClient.get("$BASE/v1/me") { applyAuth(this) }
-            if (response.status.value == 429) handleRateLimited(response)
-            response.body()
         }
-    }
+
+    suspend fun getCurrentUser(): SpUser =
+        gatedGet("$BASE/v1/me") { applyAuth(this) }
 
     // ── Library Write ────────────────────────────────────────────────
 


### PR DESCRIPTION
…LL Spotify GET methods

Follows up on PR #115 (Spotify search/getCurrentUser/getPlaylistTracks 429 fix). Three more issues surfaced after that landed:

1. **Last.fm and MusicBrainz had the same Phase 9E.1 regression.** Both migrated from Retrofit/OkHttp to Ktor (commits `79c5ed5` for Last.fm, `f41d5bc` for MB) and lost the implicit interceptor-chain 429 retry. 429s surfaced as `NoTransformationFoundException` from Ktor's body parser. Image-enrichment cascade hits both heavily — a 288-track hosted XSPF playlist's Pass 2 fan-out can trip Last.fm's 5 RPS limit per API key.

2. **Spotify's `getTrack` (and other GET methods) were unprotected.** PR #115 only gated `search`, `getCurrentUser`, `getPlaylistTracks`. But `verifyTrack` (used by `ResolverManager.verifySpotifyTrack` to check stored `spotifyId`s) goes through `getTrack`, which fanned out per-track 429s. Each one extended Spotify's punishment window. We observed a 3600s (1 hour) cooldown set after the storm. Every time the user opened a hosted-XSPF playlist with cached Spotify IDs, the storm reset the punishment timer, making Spotify badges effectively permanent-broken on hosted playlists.

3. **Cooldown logic was duplicated** across `SpotifyClient` and would need to be re-implemented for every new client. Extracted a reusable `RateLimitGate` helper.

## Changes

- **New `RateLimitGate` shared helper** (`shared/.../api/RateLimitGate.kt`): cooldown timestamp + bounded concurrency `Semaphore` + inter-request delay, configurable per-client. Logs first 429 of each cooldown cycle only (avoids hundreds of identical lines during a storm). Custom `isRateLimited` predicate so MusicBrainz can match 429 OR 503 (MB's preferred throttle response).

- **`SpotifyClient` refactored to use the gate**, and gate coverage extended to ALL GET endpoints: `getTrack`, `getArtist`, `getArtistTopTracks`, `getArtistAlbums`, `getAlbumTracks`, `getPlaylist`, `getLikedTracks`, `getSavedAlbums`, `getFollowedArtists`, `getUserPlaylists` — in addition to the 3 from PR #115. Playback- control PUT/DELETE methods (startPlayback, pausePlayback, etc.) stay unguarded — user needs skip/pause to work even during throttle.

- **`LastFmClient`** — new typed `LastFmRateLimitedException`. All 18 GET methods route through the gate via a new `guardedGet` helper. Uses default gate settings (Semaphore(2), 150ms inter-request delay).

- **`MusicBrainzClient`** — new typed `MusicBrainzRateLimitedException`. All 6 GET methods route through the gate. Custom predicate accepts **429 OR 503** (MB's preferred throttle code). **Permissive defaults** matching desktop's policy — desktop calls MB directly via `fetch()` with no preemptive throttle and runs fine; with our unique User-Agent, MB tolerates ~50 RPS bursts in practice. Earlier draft used `Semaphore(1)` + 1.1s pacing matching MB's published 1 RPS limit but that was overly conservative for default-UA clients only.

- **`ResolverManager.verifySpotifyTrack`** silently catches the typed exception (no per-track log spam during cooldown), parallel to the existing handling in `resolveSpotify`.

## Verification

- 400 unit tests pass
- Verified on-device that the existing Spotify punishment window (set during diagnosis) is now respected (`getTrack` calls short-circuit during cooldown instead of re-extending it)
- Last.fm/MB-cascade artwork enrichment proceeds normally for tracks whose providers have art

## Known follow-up (not in this PR)

`ResolvedSource` doesn't carry `artworkUrl` — AM resolver matches via MusicKit (which returns artwork URLs), but the URL is discarded at the resolver boundary, forcing image enrichment to RE-ASK metadata providers for art that AM already had. Fix in a separate
`feature/am-artwork-propagation` branch: add `artworkUrl` to `ResolvedSource`, populate from MusicKit + iTunes resolvers, and have `TrackResolverCache.backfillResolverIds` persist it onto the track row.