### PR TITLE
AM artwork propagation + persist Spotify rate-limit cooldown across restarts

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -545,6 +545,61 @@ The desktop supports dark/light mode toggle. Android should follow system theme 
 - **Clean build if all else fails:** `./gradlew clean installDebug`
 - **adb path** (not in shell PATH by default): `/Users/jherskowitz/Library/Android/sdk/platform-tools/adb`
 
+### Working in a git worktree (`.worktrees/<branch>/`) — MANDATORY rules
+
+This project uses git worktrees for in-progress branches. Cost: every cwd-sensitive command requires explicit attention. Skipping these checks burns hours of debugging "why aren't my changes deploying?" — multiple confirmed instances on this codebase, May 2026. **The general agent guidance to "avoid `cd` and use absolute paths" does NOT apply when the workspace is a worktree** — it's actively dangerous, because `./gradlew` resolves the project from cwd.
+
+**Rule 1 — Every gradle (or any project-rooted) command MUST cd into the worktree first.**
+
+```bash
+cd /Users/jherskowitz/Development/parachord/parachord-android/.worktrees/<branch> && ./gradlew installDebug
+```
+
+Do NOT rely on the Bash tool's "working directory persists between commands" behavior — empirically, it does not reliably hold across multi-call sessions in this environment. Re-`cd` on every gradle invocation. The 30-character prefix is cheap; silently building the wrong tree is not. If you need to run several commands in the worktree, chain them with `&&` in a single Bash call rather than relying on persistence.
+
+**Alternative if `cd` is genuinely impossible:** `./gradlew --project-dir <worktree-path> <task>` — explicitly tells gradle which project to build. Equivalent safety, slightly more verbose.
+
+**Rule 2 — Verify the APK was actually rebuilt before claiming success.**
+
+The output of `./gradlew installDebug` reports `<N> actionable tasks: <X> executed, <Y> up-to-date`. After source edits:
+- `1 executed, 57 up-to-date` ⇒ **only `installDebug` ran**, gradle thinks nothing else changed. Almost always means it's building from the wrong project root (your edits are in a different worktree). **STOP. Do not trust this build.**
+- `<5 executed` after non-trivial source edits ⇒ suspicious. Investigate.
+- `<full-count> executed` (e.g. `58 executed`) on a small edit ⇒ also suspicious — may indicate the build is on a different worktree where gradle's cache is cold.
+
+Cross-check the APK file mtime:
+
+```bash
+ls -la <worktree>/app/build/outputs/apk/debug/app-debug.apk
+```
+
+If mtime is older than your most recent source edit, the build did not include your changes regardless of what gradle's exit code said.
+
+**Rule 3 — Warning paths in gradle output are diagnostic.**
+
+Gradle prints compile warnings as `file:///<absolute-path>/...`. Scan one or two:
+- `file:///.../parachord-android/.worktrees/<branch>/app/...` ⇒ correct (worktree)
+- `file:///.../parachord-android/app/...` (no `.worktrees/`) ⇒ wrong (main repo) — your build is going to the wrong tree
+
+This is the fastest tell that you ran gradle from the wrong dir. Look at it on every build.
+
+**Rule 4 — UI-visible state is NOT a signal that fresh code deployed.**
+
+DB columns persist across APK reinstalls (SQLite lives in app data, untouched by `installDebug`). DataStore / SharedPreferences also persist. So if some piece of UI is reading from a previously-populated DB column or a cached pref, it will display correctly even if the APK has zero current code. **"Feature X is visible on the device" is consistent with both "new code deployed" and "old data still in DB."**
+
+To verify a build deployed, choose a signal the new code is *required* to actively produce:
+- A new logcat tag/string that didn't exist before (`adb logcat | grep <new-string>`)
+- A behavior change observable only when the new code runs (a new badge appearing, a previously-broken interaction working)
+- Process PID change (`adb shell pidof <package>`) confirming the install restarted the process — but this only confirms restart, not that the APK contents changed
+
+Do NOT use as deployment confirmation:
+- Cached UI state (artwork loading, persisted preferences, DB-row-derived chips)
+- Logs from before the install timestamp
+- Anything that worked under the previous build too
+
+**Rule 5 — Edit tool paths are absolute and route to where you point them.**
+
+The Edit/Write tools take absolute paths. If you're working in a worktree, every `file_path` argument must include `.worktrees/<branch>/`. A path missing that prefix writes to the main repo's working tree — which gradle (run from main) will then build, but if anyone else is running gradle from the worktree, they won't see the edit. Always start file paths with `/Users/.../parachord-android/.worktrees/<branch>/...` when the active branch lives in a worktree.
+
 ## Tech Stack (Android)
 
 - **Language:** Kotlin (KMP shared module for cross-platform business logic)

--- a/app/src/main/java/com/parachord/android/resolver/ResolverManager.kt
+++ b/app/src/main/java/com/parachord/android/resolver/ResolverManager.kt
@@ -68,30 +68,27 @@ class ResolverManager constructor(
     val resolvers: StateFlow<List<ResolverInfo>> = _resolvers.asStateFlow()
 
     /**
-     * Proactively ensure the Spotify access token is fresh.
-     * Debounced to once per 5 minutes to avoid unnecessary API calls.
+     * No-op kept for binary/source compatibility with callers that still
+     * invoke this from `resolve()`. The proactive `GET /v1/me` probe used
+     * to live here, intended to refresh stale tokens at the top of every
+     * resolve fan-out.
      *
-     * Per Phase 9E.1.8 the global `OAuthRefreshPlugin` (registered for
-     * `api.spotify.com`) handles 401-driven refresh + retry transparently.
-     * `getCurrentUser()` here is a cheap probe — when the stored token is
-     * stale, the plugin sees the 401, refreshes via [OAuthManager], and
-     * the call succeeds with the new token. No manual refresh needed.
+     * **Why it's gone:** `OAuthRefreshPlugin` (registered for
+     * `api.spotify.com` in [com.parachord.shared.api.HttpClientFactory])
+     * already handles 401-driven refresh + retry per-request transparently.
+     * The probe was redundant — and worse, *harmful* during Spotify abuse
+     * windows. Spotify's 429 punishment can run 3600s; every cold start
+     * fired this probe ungated, spent the first available rate-budget
+     * slot on a no-value `/me` call, and Spotify often answered with a
+     * fresh `Retry-After: 3600` that re-armed the in-process gate. The
+     * cooldown is now persisted across restarts (see
+     * [com.parachord.shared.api.RateLimitGate.loadCooldownEpochMs]) and
+     * the per-request refresh handles staleness, so this probe has no
+     * remaining purpose.
      */
+    @Suppress("unused")
     suspend fun ensureTokensFresh() {
-        val now = System.currentTimeMillis()
-        if (now - lastTokenCheck < TOKEN_CHECK_INTERVAL_MS) return
-        lastTokenCheck = now
-
-        val token = settingsStore.getSpotifyAccessToken()
-        if (!token.isNullOrBlank()) {
-            try {
-                spotifyClient.getCurrentUser()
-            } catch (e: com.parachord.shared.api.auth.ReauthRequiredException) {
-                Log.w(TAG, "Spotify proactive token check: reauth required (refresh failed)")
-            } catch (_: Exception) {
-                // Network error etc — resolve() will handle individual failures
-            }
-        }
+        // Intentionally empty — see KDoc.
     }
 
     /**
@@ -217,16 +214,38 @@ class ResolverManager constructor(
         }
 
         // Also run the regular resolve pipeline for other sources
-        // (with target title/artist for confidence scoring)
-        val others = resolve(query, targetTitle, targetArtist)
-            .filter { it.resolver !in results.map { r -> r.resolver } }
-        results.addAll(others)
-
-        results
+        // (with target title/artist for confidence scoring). When the cascade
+        // produces a result for the SAME resolver as a hint (e.g. cascade's
+        // AM search resolves a track for which we already have an AM ID
+        // hint), backfill the hint with the cascade's artworkUrl. Hints are
+        // ID-authoritative but don't carry artwork; the cascade's resolver
+        // calls (MusicKit search, Spotify search) DO return artwork, and
+        // discarding it via the resolver-name filter forces the downstream
+        // image-enrichment cascade to RE-ASK metadata providers. Same root
+        // cause as the AM-artwork-propagation work in [resolveAppleMusic] /
+        // [searchSpotifyTrack].
+        val cascadeResults = resolve(query, targetTitle, targetArtist)
+        val cascadeByResolver = cascadeResults.associateBy { it.resolver }
+        val mergedHints = results.map { hint ->
+            if (hint.artworkUrl == null) {
+                val cascadeArt = cascadeByResolver[hint.resolver]?.artworkUrl
+                if (cascadeArt != null) hint.copy(artworkUrl = cascadeArt) else hint
+            } else hint
+        }
+        val others = cascadeResults.filter { it.resolver !in mergedHints.map { r -> r.resolver } }
+        mergedHints + others
     }
 
     private suspend fun resolveSpotify(query: String): ResolvedSource? {
-        if (settingsStore.getSpotifyAccessToken().isNullOrBlank()) return null
+        val token = settingsStore.getSpotifyAccessToken()
+        if (token.isNullOrBlank()) {
+            // Diagnostic: previously this short-circuited silently, making it
+            // impossible to tell from logs whether Spotify was disconnected,
+            // rate-limited, or just not configured. One log per resolve fan-out
+            // is fine — the user only sees this when something is actually wrong.
+            Log.d(TAG, "Spotify resolve: no access token (disconnected or refresh failed) — skipping '$query'")
+            return null
+        }
 
         return try {
             searchSpotifyTrack(query)
@@ -257,6 +276,9 @@ class ResolverManager constructor(
         val track = response.tracks?.items
             ?.firstOrNull { it.isPlayable != false }
             ?: return null
+        // Spotify returns images in descending size order; take the first
+        // for the highest-resolution album art.
+        val albumArt = track.album?.images?.firstOrNull()?.url
         return ResolvedSource(
             url = "spotify:track:${track.id}",
             sourceType = "spotify",
@@ -267,6 +289,7 @@ class ResolverManager constructor(
             matchedTitle = track.name,
             matchedArtist = track.artistName,
             matchedDurationMs = track.durationMs,
+            artworkUrl = albumArt,
         )
     }
 
@@ -291,6 +314,7 @@ class ResolverManager constructor(
                 spotifyUri = "spotify:track:${track.id}",
                 spotifyId = track.id,
                 confidence = 0.95, // High confidence — verified ID match
+                artworkUrl = track.album?.images?.firstOrNull()?.url,
             )
         } catch (e: com.parachord.shared.api.SpotifyRateLimitedException) {
             // Cooldown active — silently skip. SpotifyClient logs the first 429
@@ -322,6 +346,10 @@ class ResolverManager constructor(
                         confidence = 0.9, // Default — overridden by scoreConfidence() in resolve()
                         matchedTitle = best.title,
                         matchedArtist = best.artist,
+                        // Carry MusicKit's artwork URL so ImageEnrichmentService
+                        // persists it onto the track row instead of re-asking
+                        // the metadata cascade for art it could've had for free.
+                        artworkUrl = best.artworkUrl,
                     )
                 }
             } catch (e: Exception) {
@@ -356,6 +384,10 @@ class ResolverManager constructor(
 
                 Log.d(TAG, "Apple Music (iTunes) matched '${best.trackName}' by ${best.artistName}")
 
+                // iTunes returns artworkUrl100 (100x100). Substitute to 600x600
+                // for a higher-quality URL, matching what `bestImageUrl` does
+                // for AM library responses elsewhere in the app.
+                val artwork600 = best.artworkUrl100?.replace("100x100", "600x600")
                 ResolvedSource(
                     url = best.trackViewUrl ?: "applemusic:song:${best.trackId}",
                     sourceType = "applemusic",
@@ -365,6 +397,7 @@ class ResolverManager constructor(
                     matchedTitle = best.trackName,
                     matchedArtist = best.artistName,
                     matchedDurationMs = best.trackTimeMillis,
+                    artworkUrl = artwork600,
                 )
             } catch (e: Exception) {
                 Log.w(TAG, "iTunes search failed for '$query': ${e.message}")
@@ -395,6 +428,11 @@ class ResolverManager constructor(
                 matchedTitle = track.title,
                 matchedArtist = track.artist,
                 matchedDurationMs = track.duration,
+                // Local files store their artworkUrl on the track row (either
+                // a content:// URI from MediaScanner's albumart resolution or
+                // a file:// URI from ID3 embedded art). Surface it so the
+                // resolver carries an authoritative-for-this-track URL.
+                artworkUrl = track.artworkUrl,
             )
         } catch (e: Exception) {
             Log.w(TAG, "Local file resolve failed: ${e.message}")

--- a/app/src/main/java/com/parachord/android/resolver/TrackResolverCache.kt
+++ b/app/src/main/java/com/parachord/android/resolver/TrackResolverCache.kt
@@ -35,6 +35,7 @@ import kotlinx.coroutines.sync.withPermit
  */
 class TrackResolverCache constructor(
     private val resolverManager: ResolverManager,
+    private val resolverScoring: ResolverScoring,
     private val libraryRepository: LibraryRepository,
     private val settingsStore: SettingsStore,
     private val mbidEnrichment: MbidEnrichmentService,
@@ -265,19 +266,41 @@ class TrackResolverCache constructor(
         val spotifyUri = valid.firstOrNull { it.resolver == "spotify" }?.spotifyUri
         val appleMusicId = valid.firstOrNull { it.resolver == "applemusic" }?.appleMusicId
         val soundcloudId = valid.firstOrNull { it.resolver == "soundcloud" }?.soundcloudId
-        // Skip the DB write entirely when there's nothing new to fill.
-        if (spotifyId == null && spotifyUri == null && appleMusicId == null && soundcloudId == null) return
-        try {
-            playlistTrackDao.backfillResolverIds(
-                playlistId = playlistId,
-                position = position,
-                spotifyId = spotifyId,
-                spotifyUri = spotifyUri,
-                appleMusicId = appleMusicId,
-                soundcloudId = soundcloudId,
-            )
-        } catch (e: Exception) {
-            Log.w(TAG, "Failed to backfill playlist_track resolver IDs for '${track.title}': ${e.message}")
+        if (spotifyId != null || spotifyUri != null || appleMusicId != null || soundcloudId != null) {
+            try {
+                playlistTrackDao.backfillResolverIds(
+                    playlistId = playlistId,
+                    position = position,
+                    spotifyId = spotifyId,
+                    spotifyUri = spotifyUri,
+                    appleMusicId = appleMusicId,
+                    soundcloudId = soundcloudId,
+                )
+            } catch (e: Exception) {
+                Log.w(TAG, "Failed to backfill playlist_track resolver IDs for '${track.title}': ${e.message}")
+            }
+        }
+
+        // Persist artwork from the highest-priority resolver that surfaced
+        // one — respecting the user's configured resolver order via
+        // [ResolverScoring.selectBest], NOT a hardcoded provider order.
+        // Hosted-XSPF tracks come in with `trackArtworkUrl = null` (XSPF
+        // has no per-track image data), so the resolver pipeline's first
+        // successful result populates the row. `enrichPlaylistArt` Pass 1/2
+        // then has nothing to do for these — the resolver already gave us
+        // what we needed without an extra MB → Last.fm → Spotify metadata
+        // cascade per track.
+        val artworkSources = valid.filter { it.artworkUrl != null }
+        val bestArtworkSource = if (artworkSources.isNotEmpty()) {
+            resolverScoring.selectBest(artworkSources)
+        } else null
+        val artwork = bestArtworkSource?.artworkUrl
+        if (artwork != null) {
+            try {
+                playlistTrackDao.updateTrackArtwork(playlistId, position, artwork)
+            } catch (e: Exception) {
+                Log.w(TAG, "Failed to backfill playlist_track artwork for '${track.title}': ${e.message}")
+            }
         }
     }
 
@@ -323,12 +346,31 @@ class TrackResolverCache constructor(
         val spotifyUri = validSources.firstOrNull { it.resolver == "spotify" }?.spotifyUri
         val appleMusicId = validSources.firstOrNull { it.resolver == "applemusic" }?.appleMusicId
         val soundcloudId = validSources.firstOrNull { it.resolver == "soundcloud" }?.soundcloudId
-        // Only call DB if there's something new to fill in
-        if ((spotifyId != null && track.spotifyId.isNullOrBlank()) ||
+
+        // Pick the artwork URL from the highest-priority resolver source that
+        // surfaced one — same selection logic as the playlist-track backfill.
+        // [ResolverScoring.selectBest] honors the user's configured resolver
+        // priority order rather than hardcoding Spotify/AM. Library tracks
+        // (e.g. local-only files surfaced through Last.fm/MB metadata) get
+        // the same benefit as playlist tracks: the resolver pipeline's first
+        // successful artwork hit lands on `tracks.artworkUrl` so Coil has
+        // something to render without forcing the metadata cascade to fire
+        // every time the row is shown.
+        val artworkSources = validSources.filter { it.artworkUrl != null }
+        val bestArtworkSource = if (artworkSources.isNotEmpty()) {
+            resolverScoring.selectBest(artworkSources)
+        } else null
+        val artworkUrl = bestArtworkSource?.artworkUrl
+
+        // Only call DB if there's something new to fill in. The COALESCE
+        // queries on the DB side are no-ops when the column is already set,
+        // but skipping the call entirely saves a transaction.
+        val needsIdBackfill = (spotifyId != null && track.spotifyId.isNullOrBlank()) ||
             (spotifyUri != null && track.spotifyUri.isNullOrBlank()) ||
             (appleMusicId != null && track.appleMusicId.isNullOrBlank()) ||
             (soundcloudId != null && track.soundcloudId.isNullOrBlank())
-        ) {
+        val needsArtworkBackfill = artworkUrl != null && track.artworkUrl.isNullOrBlank()
+        if (needsIdBackfill || needsArtworkBackfill) {
             try {
                 libraryRepository.backfillTrackResolverIds(
                     trackId = track.id,
@@ -336,6 +378,7 @@ class TrackResolverCache constructor(
                     spotifyUri = spotifyUri,
                     appleMusicId = appleMusicId,
                     soundcloudId = soundcloudId,
+                    artworkUrl = artworkUrl,
                 )
             } catch (e: Exception) {
                 Log.w(TAG, "Failed to backfill resolver IDs for '${track.title}': ${e.message}")

--- a/shared/src/commonMain/kotlin/com/parachord/shared/api/RateLimitGate.kt
+++ b/shared/src/commonMain/kotlin/com/parachord/shared/api/RateLimitGate.kt
@@ -4,7 +4,11 @@ import com.parachord.shared.platform.Log
 import com.parachord.shared.platform.currentTimeMillis
 import io.ktor.client.statement.HttpResponse
 import kotlin.concurrent.Volatile
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.sync.Semaphore
 import kotlinx.coroutines.sync.withPermit
 
@@ -53,6 +57,17 @@ import kotlinx.coroutines.sync.withPermit
  *   permit. Helps stagger bursts.
  * @param defaultCooldownSec used when the response has no `Retry-After`.
  * @param maxCooldownMs hard cap (defense against misbehaving servers).
+ * @param loadCooldownEpochMs optional callback invoked once at construction
+ *   to rehydrate the cooldown across process restarts. When the upstream
+ *   service hands us a long `Retry-After` (Spotify's abuse window can be
+ *   3600s), an in-memory-only gate would erase the cooldown on the next
+ *   process restart and probe the server cold — Spotify often responds with
+ *   a *fresh* 3600s, restarting the user's punishment clock. Persisting the
+ *   epoch-ms timestamp lets the gate honor the original window across
+ *   restarts and stop pestering an already-angry upstream. Pass null on
+ *   tests / clients where persistence isn't needed.
+ * @param saveCooldownEpochMs optional callback fired (fire-and-forget) on
+ *   every cooldown write. Paired with [loadCooldownEpochMs].
  */
 class RateLimitGate(
     private val tag: String,
@@ -60,13 +75,22 @@ class RateLimitGate(
     private val interRequestDelayMs: Long = 150L,
     private val defaultCooldownSec: Long = 30L,
     private val maxCooldownMs: Long = 60L * 60L * 1000L,
+    loadCooldownEpochMs: (() -> Long)? = null,
+    private val saveCooldownEpochMs: (suspend (Long) -> Unit)? = null,
 ) {
     private val limiter = Semaphore(maxConcurrent)
 
+    /** Background scope for fire-and-forget cooldown persistence writes.
+     *  Kept tiny — only ever does a single `setLong` per 429 cycle. */
+    private val persistScope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+
     /** Epoch-ms timestamp at which calls may resume. `@Volatile` so writes from
-     *  one coroutine are seen on others without a memory-model surprise. */
+     *  one coroutine are seen on others without a memory-model surprise.
+     *  Hydrated from disk via [loadCooldownEpochMs] at construction so
+     *  process restarts inherit any active server-side cooldown rather than
+     *  cold-probing into a fresh punishment cycle. */
     @Volatile
-    private var cooldownUntilMs: Long = 0L
+    private var cooldownUntilMs: Long = loadCooldownEpochMs?.invoke() ?: 0L
 
     /**
      * Run [block] under the gate. Throws via [exceptionFactory] without
@@ -111,7 +135,14 @@ class RateLimitGate(
         val retryAfterSec = response.headers["Retry-After"]?.toLongOrNull()
         val backoffMs = ((retryAfterSec ?: defaultCooldownSec) * 1000L).coerceAtMost(maxCooldownMs)
         val wasAlreadyLimited = currentTimeMillis() < cooldownUntilMs
-        cooldownUntilMs = currentTimeMillis() + backoffMs
+        val newCooldown = currentTimeMillis() + backoffMs
+        cooldownUntilMs = newCooldown
+        // Persist (fire-and-forget) so the cooldown survives a process
+        // restart. See class KDoc for why this matters with abuse-window
+        // upstreams that hand out 3600s `Retry-After` values.
+        saveCooldownEpochMs?.let { save ->
+            persistScope.launch { runCatching { save(newCooldown) } }
+        }
         if (!wasAlreadyLimited) {
             Log.w(tag, "$tag rate-limited (HTTP ${response.status.value}). Backing off ${backoffMs / 1000}s; subsequent calls in this window will short-circuit.")
         }

--- a/shared/src/commonMain/kotlin/com/parachord/shared/api/SpotifyClient.kt
+++ b/shared/src/commonMain/kotlin/com/parachord/shared/api/SpotifyClient.kt
@@ -68,6 +68,22 @@ class SpotifyRateLimitedException(val retryAfterSeconds: Long? = null) : Excepti
 class SpotifyClient(
     private val httpClient: HttpClient,
     private val tokens: AuthTokenProvider,
+    /**
+     * Read/write the persisted cooldown epoch-ms across process restarts.
+     * Wired via Koin to a `KvStore`-backed pair (key
+     * `spotify_rate_limit_cooldown_ms`). Pass null on tests / non-Android
+     * surfaces where persistence isn't desired.
+     *
+     * Why this exists: Spotify's abuse window can run 1+ hours
+     * (`Retry-After: 3600`). An in-memory-only gate erases that on every
+     * process restart and probes Spotify cold the moment the next resolve
+     * fan-out fires, which Spotify often answers with a *fresh* 3600s
+     * window — restarting the punishment clock. Persisting the cooldown
+     * lets a restarted process honor the original window without poking
+     * an already-angry upstream.
+     */
+    loadCooldownEpochMs: (() -> Long)? = null,
+    saveCooldownEpochMs: (suspend (Long) -> Unit)? = null,
 ) {
 
     companion object {
@@ -93,7 +109,11 @@ class SpotifyClient(
      * needs to be able to skip / pause even during a throttle window. The
      * gate is for high-volume read traffic, not interactive control.
      */
-    private val gate = RateLimitGate(tag = "SpotifyClient")
+    private val gate = RateLimitGate(
+        tag = "SpotifyClient",
+        loadCooldownEpochMs = loadCooldownEpochMs,
+        saveCooldownEpochMs = saveCooldownEpochMs,
+    )
 
     /**
      * Apply the Spotify bearer token from [AuthTokenProvider]. If no

--- a/shared/src/commonMain/kotlin/com/parachord/shared/di/SharedModule.kt
+++ b/shared/src/commonMain/kotlin/com/parachord/shared/di/SharedModule.kt
@@ -11,9 +11,14 @@ import com.parachord.shared.api.SmartLinksClient
 import com.parachord.shared.api.SpotifyClient
 import com.parachord.shared.api.TicketmasterClient
 import com.parachord.shared.api.createHttpClient
+import com.parachord.shared.store.KvStore
 import kotlinx.serialization.json.Json
 import org.koin.core.module.dsl.singleOf
 import org.koin.dsl.module
+
+/** KvStore key for persisting [SpotifyClient]'s rate-limit gate cooldown
+ *  epoch-ms. */
+private const val SPOTIFY_GATE_COOLDOWN_KEY = "spotify_rate_limit_cooldown_ms"
 
 /**
  * Shared Koin module — provides cross-platform dependencies.
@@ -38,7 +43,19 @@ val sharedModule = module {
     // Registered with OAuthRefreshPlugin in HttpClientFactory — 401s on
     // api.spotify.com get refreshed + retried automatically. Phase 9E.1.8
     // is the OAuth refresh canary cutover.
-    single { SpotifyClient(get(), get()) }
+    //
+    // Cooldown persistence: the rate-limit gate's cooldown is stored to
+    // KvStore so a 3600s `Retry-After` from Spotify's abuse window survives
+    // a process restart. See SpotifyClient KDoc for why this matters.
+    single {
+        val kv: KvStore = get()
+        SpotifyClient(
+            httpClient = get(),
+            tokens = get(),
+            loadCooldownEpochMs = { kv.getLong(SPOTIFY_GATE_COOLDOWN_KEY, 0L) },
+            saveCooldownEpochMs = { value -> kv.setLong(SPOTIFY_GATE_COOLDOWN_KEY, value) },
+        )
+    }
     single { LastFmClient(get()) }
     single { MusicBrainzClient(get()) }
     single { TicketmasterClient(get()) }

--- a/shared/src/commonMain/kotlin/com/parachord/shared/repository/LibraryRepository.kt
+++ b/shared/src/commonMain/kotlin/com/parachord/shared/repository/LibraryRepository.kt
@@ -290,6 +290,14 @@ class LibraryRepository(
     /**
      * Backfill resolver IDs on a stored track from resolution results.
      * Only fills in IDs that are currently null/blank — never overwrites.
+     *
+     * Also persists [artworkUrl] when supplied. The underlying
+     * `tracks.updateArtworkById` query is COALESCE-style (only writes when
+     * the row's `artworkUrl` is NULL/empty), so callers can pass artwork
+     * defensively without risking overwriting user-imported album art.
+     * Used by `TrackResolverCache.backfillResolverIds` to capture artwork
+     * surfaced by `ResolvedSource.artworkUrl` during the resolver pipeline,
+     * which is faster + cheaper than re-asking the metadata cascade later.
      */
     suspend fun backfillTrackResolverIds(
         trackId: String,
@@ -297,8 +305,12 @@ class LibraryRepository(
         spotifyUri: String?,
         appleMusicId: String?,
         soundcloudId: String?,
+        artworkUrl: String? = null,
     ) {
         trackDao.backfillResolverIds(trackId, spotifyId, spotifyUri, appleMusicId, soundcloudId)
+        if (artworkUrl != null) {
+            trackDao.updateArtworkById(trackId, artworkUrl)
+        }
     }
 
     /** Convert a PlaylistTrack to a Track for playback. */

--- a/shared/src/commonMain/kotlin/com/parachord/shared/resolver/ResolverModels.kt
+++ b/shared/src/commonMain/kotlin/com/parachord/shared/resolver/ResolverModels.kt
@@ -32,6 +32,25 @@ data class ResolvedSource(
     val matchedArtist: String? = null,
     /** Duration in ms from the resolver's result (for confidence scoring). */
     val matchedDurationMs: Long? = null,
+    /**
+     * Album/track artwork URL surfaced by the resolver, when available.
+     *
+     * Apple Music (via MusicKit JS or iTunes Search), Spotify, and Last.fm
+     * all return artwork URLs alongside their track-search results. Without
+     * this field, that data was discarded at the resolver boundary, forcing
+     * [com.parachord.shared.metadata.ImageEnrichmentService.enrichPlaylistArt]
+     * to RE-ASK metadata providers for art the resolver had moments earlier
+     * — wasteful and a problem when those providers rate-limit (the
+     * primary symptom is a hosted-XSPF playlist whose tracks resolve via
+     * AM but whose mosaic still says "no art" because the cascade
+     * fell through).
+     *
+     * Persisted onto `playlist_tracks.trackArtworkUrl` /
+     * `tracks.artworkUrl` by [com.parachord.android.resolver.TrackResolverCache.backfillResolverIds]
+     * when set, so the next render of the row displays it without any
+     * additional network traffic.
+     */
+    val artworkUrl: String? = null,
 )
 
 // ── Confidence Scoring ──────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Two related fixes (mixed because they share a file: `ResolverManager.kt`).

### 1. AM artwork propagation through the resolver pipeline

Hosted XSPF playlists (notably **SiriusXMU Rewind**) were rendering "no art" in the mosaic because tracks resolved via Apple Music but the downstream `ImageEnrichmentService` cascade (MB → Last.fm → Spotify) was rate-limited. The resolver had the artwork URL in its search response and threw it away — forcing the cascade to re-fetch what it already had.

- `ResolvedSource` gains `artworkUrl: String?`; populated by MusicKit, iTunes, Spotify search, Spotify ID-verify, and local-files resolver paths
- `TrackResolverCache.backfillResolverIds` (TrackEntity / library path) and `backfillPlaylistTrackResolverIds` (playlist-tracks path) both persist the highest-priority resolver's artwork via `ResolverScoring.selectBest` — honors user resolver-priority preference, no hardcoded provider order
- `ResolverManager.resolveWithHints` merges cascade-discovered artwork onto ID-hint sources so direct-ID matches don't lose artwork the cascade has already fetched
- `LibraryRepository.backfillTrackResolverIds` accepts an optional `artworkUrl` and writes via the COALESCE-safe `tracks.updateArtworkById`

### 2. Persist Spotify rate-limit gate cooldown across restarts

Spotify's abuse window can issue `Retry-After: 3600s`. The old in-memory-only gate erased that on every process restart and probed Spotify cold — Spotify often answered with a *fresh* 3600s, restarting the user's punishment clock indefinitely. The user could be stuck in a permanent punishment loop just by relaunching the app.

- `RateLimitGate` accepts optional `loadCooldownEpochMs` / `saveCooldownEpochMs` callbacks; hydrates from disk at construction, fire-and-forget persists on every cooldown write
- `SpotifyClient` wires callbacks via Koin to a `KvStore`-backed `Long` (`spotify_rate_limit_cooldown_ms`)
- `ResolverManager.ensureTokensFresh()` neutered to no-op. The `/v1/me` probe was redundant (`OAuthRefreshPlugin` handles 401-driven refresh per-request) and harmful (consumed the first available rate-budget slot during punishment windows on a no-value call). Body kept for source-compat; KDoc explains why.

### 3. CLAUDE.md — worktree rules

Adds a "Working in a git worktree — MANDATORY rules" subsection under Build & Deploy after a cwd-resolution bug burned hours of debugging today. Five rules: cd discipline for gradle, APK-mtime verification, reading gradle warning paths, why DB-cached UI state isn't a deploy signal, and Edit-tool path discipline.

## Test plan

- [x] `./gradlew :app:testDebugUnitTest` — all tests pass
- [x] `./gradlew :app:installDebug` — clean build from worktree, APK mtime fresh
- [x] AM artwork populates on hosted XSPF tracks (SiriusXMU verified earlier)
- [x] Gate persistence verified end-to-end: 429 fired → cooldown written to `parachord_kmp_prefs.xml` with key `spotify_rate_limit_cooldown_ms` containing the correct epoch-ms timestamp (`now + 3600s`)
- [x] Only ONE Spotify call leaks through per cooldown window — confirms `ensureTokensFresh` no-op is deployed (old code: probe + first search = 2 calls; new code: 1 call)
- [ ] Spotify badges return after Spotify-side cooldown lapses — pending (Spotify currently still in punishment mode; cooldown runs to 12:56:25 today)

## Notes

- Spotify-side punishment is outside our control — they keep refreshing the 3600s on every contact attempt. The persistence fix prevents *us* from making it worse via cold-restart probes; it doesn't shorten Spotify's cool-down.
- The AM artwork pipeline was verified working in a previous session; today's session introduced the TrackEntity-path backfill (point 1, last bullet of point 1) and the persistence work (point 2 entirely).

🤖 Generated with [Claude Code](https://claude.com/claude-code)