### PR TITLE
Wire achordion plugin: window.scrobbleManager + window.resolveMbidForLove (#126)

### DIFF
--- a/app/src/main/assets/js/bootstrap.html
+++ b/app/src/main/assets/js/bootstrap.html
@@ -93,6 +93,135 @@
         set: function(key, value) { NativeBridge.storageSet('plugin._global.' + key, value); },
     };
 
+    // ── Client identifier ────────────────────────────────────────────
+    // Set BEFORE plugin init runs so plugins can read it for client-
+    // distinguishing telemetry headers. See parachord-plugins#3 — the
+    // achordion plugin is being updated to send `X-Parachord-Client:
+    // <window.__parachordClient>` on every fetch so Achordion's server
+    // can split metrics across desktop / android / future-ios.
+    window.__parachordClient = 'android';
+
+    // ── ScrobbleManager registry ─────────────────────────────────────
+    // Public, stable contract documented in desktop CLAUDE.md
+    // `## Scrobbling: inline core, plugin contract for the rest`
+    // (L712-754). Plugins call `registerPlugin({id, isEnabled,
+    // updateNowPlaying, scrobble})` to opt in to playback-telemetry
+    // dispatch. The achordion plugin is the canonical consumer; future
+    // additive write-targets (Maloja, custom analytics) use the same
+    // surface.
+    //
+    // Native dispatch path: `ScrobbleManager.kt` builds a desktop-
+    // shaped track JSON and calls
+    // `__scrobbleManagerDispatch('updateNowPlaying' | 'scrobble', json)`
+    // which iterates registered plugins, awaits `isEnabled()`, then
+    // calls the corresponding hook. Errors per-plugin are logged via
+    // `console.warn` and do not break the loop.
+    //
+    // Inherited filter from desktop scrobbleManager
+    // (scrobbler-loader.js:75): tracks with `duration < 30s` are
+    // excluded from BOTH hooks. Mirror that here so a 25s ambient
+    // interlude with a verified Spotify ID won't fire either hook,
+    // matching cross-platform behavior parity.
+    window.scrobbleManager = {
+        _plugins: [],
+        registerPlugin: function(plugin) {
+            if (!plugin || !plugin.id) {
+                console.warn('[scrobbleManager] registerPlugin rejected: missing id');
+                return;
+            }
+            // Replace any existing registration with the same id (re-register
+            // semantics on plugin reload).
+            window.scrobbleManager._plugins =
+                window.scrobbleManager._plugins.filter(function(p) { return p.id !== plugin.id; });
+            window.scrobbleManager._plugins.push(plugin);
+            console.log('[scrobbleManager] registered plugin:', plugin.id);
+        },
+        unregisterPlugin: function(id) {
+            var before = window.scrobbleManager._plugins.length;
+            window.scrobbleManager._plugins =
+                window.scrobbleManager._plugins.filter(function(p) { return p.id !== id; });
+            if (window.scrobbleManager._plugins.length < before) {
+                console.log('[scrobbleManager] unregistered plugin:', id);
+            }
+        },
+    };
+
+    /**
+     * Native → JS dispatch entry point. Called from
+     * `ScrobbleManager.kt`'s `dispatchNowPlaying` / `dispatchScrobble`
+     * via `JsBridge.evaluate(...)`. `eventName` is `"updateNowPlaying"`
+     * or `"scrobble"`. `trackJson` is a desktop-shaped track object
+     * with `id`, `title`, `artist`, `album`, `duration`, `mbid`,
+     * `_activeResolver`, and a `sources` map (resolverId → source with
+     * confidence + per-resolver IDs).
+     *
+     * Returns a Promise — fire-and-forget from the native side. Don't
+     * rely on the return value being readable from Kotlin (see
+     * CLAUDE.md Common Mistake #27 — async IIFE returns Promise object,
+     * not the resolved value). The WebView runs the loop independently.
+     */
+    window.__scrobbleManagerDispatch = async function(eventName, trackJson) {
+        try {
+            var track = JSON.parse(trackJson);
+            // <30s duration filter inherited from desktop scrobbleManager
+            // (scrobbler-loader.js:75). Match cross-platform behavior.
+            if (track.duration && track.duration < 30) return false;
+            for (var i = 0; i < window.scrobbleManager._plugins.length; i++) {
+                var plugin = window.scrobbleManager._plugins[i];
+                try {
+                    var enabled = true;
+                    if (typeof plugin.isEnabled === 'function') {
+                        enabled = await plugin.isEnabled();
+                    }
+                    if (!enabled) continue;
+                    if (typeof plugin[eventName] === 'function') {
+                        await plugin[eventName](track);
+                    }
+                } catch (e) {
+                    console.warn(
+                        '[scrobbleManager] plugin', plugin.id, eventName,
+                        'threw:', (e && e.message) ? e.message : e,
+                    );
+                }
+            }
+            return true;
+        } catch (e) {
+            console.warn('[scrobbleManager] dispatch failed:', (e && e.message) ? e.message : e);
+            return false;
+        }
+    };
+
+    // ── MBID resolver shim ────────────────────────────────────────────
+    // `window.resolveMbidForLove(track)` returns Promise<string|null>.
+    // Used by the achordion plugin's `resolveMbid(track)` fallback when
+    // `track.mbid` is absent. The Kotlin side calls
+    // `MbidEnrichmentService.getRecordingMbid` with the track's artist +
+    // title and returns a 36-char MBID at the mapper's confidence
+    // threshold, or null.
+    //
+    // Pattern mirrors the existing `__fetchCallbacks` async harness:
+    // JS registers a callback id, native dispatches to a coroutine,
+    // calls back via `evaluateJavascript` on the main thread.
+    window.__resolveMbidCallbacks = {};
+    var __resolveMbidIdCounter = 0;
+
+    window.resolveMbidForLove = function(track) {
+        return new Promise(function(resolve, reject) {
+            var callbackId = 'mbid_' + (++__resolveMbidIdCounter);
+            window.__resolveMbidCallbacks[callbackId] = function(mbidOrNull) {
+                delete window.__resolveMbidCallbacks[callbackId];
+                resolve(mbidOrNull || null);
+            };
+            try {
+                var trackJson = JSON.stringify(track || {});
+                NativeBridge.resolveMbidForLove(callbackId, trackJson);
+            } catch (e) {
+                delete window.__resolveMbidCallbacks[callbackId];
+                reject(e);
+            }
+        });
+    };
+
     console.log('Parachord JS runtime: polyfills loaded');
 </script>
 

--- a/app/src/main/java/com/parachord/android/bridge/JsBridge.kt
+++ b/app/src/main/java/com/parachord/android/bridge/JsBridge.kt
@@ -7,6 +7,7 @@ import android.webkit.WebView
 import android.webkit.WebViewClient
 import androidx.datastore.core.DataStore
 import androidx.datastore.preferences.core.Preferences
+import com.parachord.android.data.metadata.MbidEnrichmentService
 import com.parachord.shared.plugin.JsRuntime
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CoroutineScope
@@ -34,6 +35,7 @@ class JsBridge constructor(
     private val context: Context,
     private val httpClient: OkHttpClient,
     private val dataStore: DataStore<Preferences>,
+    private val mbidEnrichment: MbidEnrichmentService,
 ) : JsRuntime {
 
     private val scope = CoroutineScope(SupervisorJob() + Dispatchers.Main)
@@ -54,7 +56,7 @@ class JsBridge constructor(
         if (webView != null) return@withContext
 
         val pageLoaded = CompletableDeferred<Unit>()
-        val nativeBridge = NativeBridge(httpClient, scope, dataStore)
+        val nativeBridge = NativeBridge(httpClient, scope, dataStore, mbidEnrichment)
 
         val wv = WebView(context).apply {
             settings.javaScriptEnabled = true

--- a/app/src/main/java/com/parachord/android/bridge/NativeBridge.kt
+++ b/app/src/main/java/com/parachord/android/bridge/NativeBridge.kt
@@ -6,10 +6,15 @@ import androidx.datastore.core.DataStore
 import androidx.datastore.preferences.core.Preferences
 import androidx.datastore.preferences.core.edit
 import androidx.datastore.preferences.core.stringPreferencesKey
+import com.parachord.android.data.metadata.MbidEnrichmentService
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.contentOrNull
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
 import okhttp3.MediaType.Companion.toMediaType
 import okhttp3.OkHttpClient
 import okhttp3.Request
@@ -17,19 +22,30 @@ import okhttp3.RequestBody.Companion.toRequestBody
 
 private const val TAG = "NativeBridge"
 
+/** 36-char MusicBrainz Identifier (8-4-4-4-12 hex with dashes). Plugins
+ *  validate `track.mbid` against this same shape; we mirror the regex
+ *  here so [NativeBridge.resolveMbidForLove] can short-circuit when JS
+ *  already has a valid MBID. */
+private val MBID_PATTERN = Regex("^[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}\$", RegexOption.IGNORE_CASE)
+
 /**
  * Native module bindings exposed to JavaScript via @JavascriptInterface.
  *
- * Provides fetch, storage, and logging to the JS runtime so .axe resolver
- * plugins and AI providers can call back into native code.
+ * Provides fetch, storage, logging, and MBID resolution to the JS
+ * runtime so .axe resolver plugins, AI providers, and the achordion
+ * playback-telemetry plugin can call back into native code.
  *
  * These methods are called synchronously from the WebView thread —
  * they must return without suspending (hence [runBlocking] for storage reads).
+ * Long-running calls (HTTP fetches, MBID lookups) use callback patterns
+ * keyed by a JS-generated id, with the result delivered back via
+ * `WebView.evaluateJavascript` on the main thread.
  */
 class NativeBridge(
     private val httpClient: OkHttpClient,
     private val scope: CoroutineScope,
     private val dataStore: DataStore<Preferences>,
+    private val mbidEnrichment: MbidEnrichmentService,
 ) {
     /** WebView reference for async fetch callbacks. Set by JsBridge after creation. */
     var webView: android.webkit.WebView? = null
@@ -157,6 +173,61 @@ class NativeBridge(
             kotlinx.coroutines.withContext(kotlinx.coroutines.Dispatchers.Main) {
                 webView?.evaluateJavascript(
                     "window.__fetchCallbacks && window.__fetchCallbacks['$callbackId'] && window.__fetchCallbacks['$callbackId']('$escapedEnvelope')",
+                    null,
+                )
+            }
+        }
+    }
+
+    // ── MBID Resolver (for window.resolveMbidForLove) ─────────────────
+
+    /**
+     * Async MBID lookup. JS calls this with a `callbackId` (registered
+     * in `window.__resolveMbidCallbacks`) and a `trackJson` containing
+     * at minimum `{ title, artist, mbid? }`. We dispatch to a coroutine
+     * that:
+     *
+     * 1. If `track.mbid` is already a 36-char UUID, returns it directly.
+     * 2. Otherwise, calls [MbidEnrichmentService.getRecordingMbid] which
+     *    hits the disk cache first, then ListenBrainz's MBID Mapper at
+     *    its confidence threshold.
+     * 3. JS-callbacks the result (or null) on the main thread via
+     *    `window.__resolveMbidCallbacks[callbackId](mbid)`.
+     *
+     * Used by the achordion plugin's `resolveMbid(track)` fallback when
+     * `track.mbid` isn't present. Without this surface, the plugin
+     * silently skips submission for any track lacking an upstream MBID.
+     *
+     * Pattern mirrors [fetchAsync] — the same callback-id-keyed harness.
+     */
+    @JavascriptInterface
+    fun resolveMbidForLove(callbackId: String, trackJson: String) {
+        scope.launch {
+            val mbid = try {
+                val parsed = Json.parseToJsonElement(trackJson).jsonObject
+                val existingMbid = parsed["mbid"]?.jsonPrimitive?.contentOrNull
+                if (existingMbid != null && MBID_PATTERN.matches(existingMbid)) {
+                    existingMbid
+                } else {
+                    val title = parsed["title"]?.jsonPrimitive?.contentOrNull?.takeIf { it.isNotBlank() }
+                    val artist = parsed["artist"]?.jsonPrimitive?.contentOrNull?.takeIf { it.isNotBlank() }
+                    if (title != null && artist != null) {
+                        mbidEnrichment.getRecordingMbid(artist, title)
+                    } else {
+                        null
+                    }
+                }
+            } catch (e: Exception) {
+                Log.w(TAG, "resolveMbidForLove($callbackId) failed: ${e.message}")
+                null
+            }
+
+            // Deliver result back to JS on the main thread. Pass either the
+            // MBID string or `null` (literal — JS treats it as a null arg).
+            val payload = if (mbid != null) "'${mbid.replace("'", "\\'")}'" else "null"
+            kotlinx.coroutines.withContext(kotlinx.coroutines.Dispatchers.Main) {
+                webView?.evaluateJavascript(
+                    "window.__resolveMbidCallbacks && window.__resolveMbidCallbacks['$callbackId'] && window.__resolveMbidCallbacks['$callbackId']($payload)",
                     null,
                 )
             }

--- a/app/src/main/java/com/parachord/android/playback/ScrobbleManager.kt
+++ b/app/src/main/java/com/parachord/android/playback/ScrobbleManager.kt
@@ -1,10 +1,13 @@
 package com.parachord.android.playback
 
 import com.parachord.shared.platform.Log
+import com.parachord.android.bridge.JsBridge
 import com.parachord.android.data.db.dao.TrackDao
 import com.parachord.android.data.metadata.MbidEnrichmentService
 import com.parachord.android.data.store.SettingsStore
 import com.parachord.android.playback.scrobbler.Scrobbler
+import com.parachord.android.resolver.ResolvedSource
+import com.parachord.android.resolver.TrackResolverCache
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
@@ -12,17 +15,35 @@ import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.launch
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.put
+import kotlinx.serialization.json.putJsonObject
 
 /**
  * Dispatches scrobble events to all enabled scrobbler plugins.
  *
  * Mirrors the desktop app's scrobble-manager.js which loads and dispatches
- * to registered scrobbler plugins (Last.fm, ListenBrainz, Libre.fm).
+ * to registered scrobbler plugins (Last.fm, ListenBrainz, Libre.fm) AND
+ * to JS-registered playback-telemetry plugins (achordion etc.) via the
+ * `window.scrobbleManager.registerPlugin(...)` contract documented in
+ * desktop CLAUDE.md `## Scrobbling: inline core, plugin contract for the
+ * rest` (L712-754).
  *
  * Scrobbling rules (per Last.fm / ListenBrainz spec):
  * - Send "now playing" when a track starts
  * - Send "scrobble" after listening to max(30s, min(duration/2, 240s))
  * - Only scrobble once per track play
+ *
+ * Native + JS dispatch happen in parallel: native scrobblers (LB / LFM /
+ * Libre.fm) get the original `TrackEntity`; JS plugins get a desktop-
+ * shaped JSON object that includes the `sources` map (resolverId →
+ * `{confidence, spotifyId, appleMusicId, ...}`) so they can run their
+ * confidence-gated logic (achordion's tier-1 / tier-2 dispatch reads
+ * `track.sources[track._activeResolver].confidence`).
+ *
+ * Inherited <30s duration filter is enforced JS-side in
+ * `__scrobbleManagerDispatch` (see `assets/js/bootstrap.html`).
  */
 class ScrobbleManager constructor(
     private val settingsStore: SettingsStore,
@@ -30,6 +51,8 @@ class ScrobbleManager constructor(
     private val scrobblers: Set<@JvmSuppressWildcards Scrobbler>,
     private val trackDao: TrackDao,
     private val mbidEnrichment: MbidEnrichmentService,
+    private val jsBridge: JsBridge,
+    private val trackResolverCache: TrackResolverCache,
 ) {
     companion object {
         private const val TAG = "ScrobbleManager"
@@ -127,7 +150,7 @@ class ScrobbleManager constructor(
         }
     }
 
-    /** Dispatch "now playing" to all enabled scrobblers. */
+    /** Dispatch "now playing" to all enabled scrobblers and JS plugins. */
     private suspend fun dispatchNowPlaying(track: com.parachord.android.data.db.entity.TrackEntity) {
         nowPlayingSent = true
         // Re-read from Room — MBIDs may have been backfilled since playback started
@@ -143,9 +166,10 @@ class ScrobbleManager constructor(
                 }
             }
         }
+        dispatchToJsPlugins("updateNowPlaying", enrichedTrack)
     }
 
-    /** Dispatch scrobble to all enabled scrobblers. */
+    /** Dispatch scrobble to all enabled scrobblers and JS plugins. */
     private suspend fun dispatchScrobble(
         track: com.parachord.android.data.db.entity.TrackEntity,
         timestamp: Long,
@@ -164,5 +188,147 @@ class ScrobbleManager constructor(
                 }
             }
         }
+        dispatchToJsPlugins("scrobble", enrichedTrack)
+    }
+
+    /**
+     * Fire-and-forget dispatch into the JS-side `window.scrobbleManager`
+     * registry. Builds a desktop-shaped track JSON, then asks the WebView
+     * to iterate registered plugins and call the matching hook. Errors are
+     * logged via `console.warn` JS-side; any exceptions don't propagate
+     * back here. The <30s duration filter and per-plugin `isEnabled()` gate
+     * are both enforced JS-side in `__scrobbleManagerDispatch`.
+     */
+    private fun dispatchToJsPlugins(eventName: String, track: com.parachord.android.data.db.entity.TrackEntity) {
+        scope.launch {
+            try {
+                val trackJson = buildPluginTrackJson(track)
+                // Pass the JSON via base64 to dodge the JS string-escaping minefield
+                // (CLAUDE.md Common Mistake #26 — backticks + `$` break template
+                // strings; #33 — `if` statements aren't valid JS expressions for
+                // `evaluate()` wrapping). Decode at the JS boundary.
+                val base64 = android.util.Base64.encodeToString(
+                    trackJson.toString().toByteArray(Charsets.UTF_8),
+                    android.util.Base64.NO_WRAP,
+                )
+                val safeEvent = eventName.replace("'", "")
+                jsBridge.evaluate(
+                    "window.__scrobbleManagerDispatch && window.__scrobbleManagerDispatch('$safeEvent', atob('$base64'))",
+                )
+            } catch (e: Exception) {
+                Log.w(TAG, "dispatchToJsPlugins($eventName) failed: ${e.message}")
+            }
+        }
+    }
+
+    /**
+     * Build the desktop-shaped track JSON the achordion plugin (and any
+     * future JS-side scrobble-plugin) expects. Required fields:
+     *
+     * - `id`, `title`, `artist`, `album`, `duration` — basic shape
+     * - `mbid` — recording MBID, when known (the plugin's `resolveMbid()`
+     *   short-circuits on this; absent → falls back to
+     *   `window.resolveMbidForLove`)
+     * - `_activeResolver` — id of the resolver actually playing this track
+     *   (`spotify` / `applemusic` / `localfiles` / etc). Used by
+     *   `playedSourceConfidence(track)` to pick tier-1 vs tier-2.
+     * - `sources: { resolverId: { confidence, spotifyId?, appleMusicId?,
+     *   appleMusicUrl?, soundcloudUrl?, bandcampUrl?, url?, youtubeId? } }` —
+     *   the per-resolver source map. The plugin's `buildLinks(track)`
+     *   iterates this to construct the submit payload.
+     *
+     * Source data comes from [TrackResolverCache.getSources]. If the cache
+     * is empty for this track (e.g. user pressed play before background
+     * resolution finished), we fall back to a single-entry sources map
+     * built from the track's own resolver-side IDs (`spotifyId`,
+     * `appleMusicId`, etc.) at confidence `0.95` (matching how
+     * [com.parachord.android.resolver.ResolverManager.resolveWithHints]
+     * stamps direct-ID hints today; see #128 for the future bump to 1.0).
+     */
+    private fun buildPluginTrackJson(
+        track: com.parachord.android.data.db.entity.TrackEntity,
+    ): JsonObject {
+        val cachedSources = trackResolverCache.getSources(track.title, track.artist)
+        val sources: List<ResolvedSource> = cachedSources ?: buildFallbackSources(track)
+        return buildJsonObject {
+            put("id", track.id)
+            put("title", track.title)
+            put("artist", track.artist)
+            track.album?.let { put("album", it) }
+            // Track.duration is milliseconds; desktop / plugin contract is seconds
+            // (achordion AGENTS.md L323: "duration in seconds, not ms — protocol spec").
+            track.duration?.let { put("duration", it / 1000.0) }
+            track.recordingMbid?.let { put("mbid", it) }
+            track.resolver?.let { put("_activeResolver", it) }
+            putJsonObject("sources") {
+                for (source in sources) {
+                    putJsonObject(source.resolver) {
+                        source.confidence?.let { put("confidence", it) }
+                        if (source.noMatch) put("noMatch", true)
+                        source.spotifyId?.let { put("spotifyId", it) }
+                        source.spotifyUri?.let { put("spotifyUri", it) }
+                        source.appleMusicId?.let { put("appleMusicId", it) }
+                        source.soundcloudId?.let { put("soundcloudId", it) }
+                        source.soundcloudUrl?.let { put("soundcloudUrl", it) }
+                        // The plugin reads `appleMusicUrl` / `bandcampUrl` /
+                        // `url` / `youtubeId` for link construction. These
+                        // aren't on Android's [ResolvedSource] today (see
+                        // `ResolverModels.kt`); when adding new resolver
+                        // fields with publicly-shareable URLs, surface them
+                        // here so the achordion submit picks them up.
+                        put("url", source.url)
+                    }
+                }
+            }
+        }
+    }
+
+    /**
+     * Synthesize a `sources` map from the track's own per-resolver IDs
+     * when [TrackResolverCache] hasn't cached anything for this track.
+     * Confidence stamps `0.95` to match the direct-ID-hint pattern in
+     * [com.parachord.android.resolver.ResolverManager.resolveWithHints].
+     * Used as a fallback path so the JS plugin still gets useful source
+     * data even on a resolver-cache miss.
+     */
+    private fun buildFallbackSources(
+        track: com.parachord.android.data.db.entity.TrackEntity,
+    ): List<ResolvedSource> {
+        val out = mutableListOf<ResolvedSource>()
+        if (!track.spotifyId.isNullOrBlank() || !track.spotifyUri.isNullOrBlank()) {
+            out.add(
+                ResolvedSource(
+                    url = track.spotifyUri ?: "spotify:track:${track.spotifyId}",
+                    sourceType = "spotify",
+                    resolver = "spotify",
+                    spotifyId = track.spotifyId,
+                    spotifyUri = track.spotifyUri,
+                    confidence = 0.95,
+                ),
+            )
+        }
+        if (!track.appleMusicId.isNullOrBlank()) {
+            out.add(
+                ResolvedSource(
+                    url = "applemusic:song:${track.appleMusicId}",
+                    sourceType = "applemusic",
+                    resolver = "applemusic",
+                    appleMusicId = track.appleMusicId,
+                    confidence = 0.95,
+                ),
+            )
+        }
+        if (!track.soundcloudId.isNullOrBlank()) {
+            out.add(
+                ResolvedSource(
+                    url = "https://api.soundcloud.com/tracks/${track.soundcloudId}",
+                    sourceType = "soundcloud",
+                    resolver = "soundcloud",
+                    soundcloudId = track.soundcloudId,
+                    confidence = 0.95,
+                ),
+            )
+        }
+        return out
     }
 }

--- a/shared/src/commonMain/kotlin/com/parachord/shared/metadata/MbidEnrichmentService.kt
+++ b/shared/src/commonMain/kotlin/com/parachord/shared/metadata/MbidEnrichmentService.kt
@@ -130,6 +130,26 @@ class MbidEnrichmentService(
     }
 
     /**
+     * Look up a recording MBID from the cache or via the mapper.
+     * Returns null if not found at the mapper's confidence threshold.
+     * Does not persist to Room (no trackId context).
+     *
+     * Used by [com.parachord.android.bridge.NativeBridge.resolveMbidForLove]
+     * to back the JS bridge's `window.resolveMbidForLove(track)` Promise.
+     * The achordion plugin's `resolveMbid(track)` fallback calls this when
+     * `track.mbid` is absent. Same-shape mirror of [getArtistMbid].
+     */
+    suspend fun getRecordingMbid(artistName: String, recordingName: String): String? {
+        val key = cacheKey(artistName, recordingName)
+        val cached = getCachedEntry(key)
+        if (cached != null) return cached.recordingMbid
+
+        val result = mapperLookup(artistName, recordingName) ?: return null
+        putCache(key, result)
+        return result.recordingMbid
+    }
+
+    /**
      * Check if we have a cached artist MBID for any track by this artist.
      * Faster than a full mapper call — scans the disk cache for a match.
      */

--- a/shared/src/commonMain/kotlin/com/parachord/shared/plugin/PluginManager.kt
+++ b/shared/src/commonMain/kotlin/com/parachord/shared/plugin/PluginManager.kt
@@ -150,6 +150,35 @@ class PluginManager constructor(
             val hidden = pluginInfos.filter { it.capabilities["mobile"] == false }.map { it.id }
             Log.d(TAG, "Hidden ${hidden.size} plugins not supported on mobile: $hidden")
         }
+
+        // Invoke init() on plugins that need it. Per desktop CLAUDE.md
+        // `## Achordion Pre-resolution Plugin`, plugins with the
+        // `playbackTelemetry: true` capability self-register with
+        // `window.scrobbleManager` inside their `init()` function — without
+        // this call, they're loaded into the resolver-loader's registry but
+        // never run, so dispatch to JS plugins from `ScrobbleManager.kt`
+        // hits an empty plugin list. Mirrors desktop's capability-filtered
+        // initResolver() invocation in `initResolvers()` (the
+        // withGenerate/withChat/withConcerts pattern).
+        //
+        // Resolver-side native-first plugins (spotify, applemusic, etc.)
+        // intentionally don't init their .axe form — Android calls them via
+        // native Kotlin paths. AI plugin .axe init isn't needed either
+        // (native ChatGPT/Claude/Gemini providers handle the calls).
+        // PlaybackTelemetry plugins like achordion are the load-bearing
+        // case: they MUST init to register their hooks.
+        for (info in platformFiltered) {
+            if (info.capabilities["playbackTelemetry"] == true) {
+                try {
+                    jsRuntime.evaluate(
+                        "window.__resolverLoader && window.__resolverLoader.initResolver('${info.id}', {})",
+                    )
+                    Log.d(TAG, "Initialized playback-telemetry plugin: ${info.id}")
+                } catch (e: Exception) {
+                    Log.w(TAG, "Failed to init plugin '${info.id}': ${e.message}")
+                }
+            }
+        }
     }
 
     private data class PluginEntry(val id: String, val version: String, val axeJson: String)


### PR DESCRIPTION
Closes #126.

The achordion plugin (v1.0.7, type meta-service, capability `playbackTelemetry`) auto-syncs to every Android install via the marketplace, but loaded **inert** because the JS bridge didn't expose two surfaces the plugin requires:

- `window.scrobbleManager.{registerPlugin,unregisterPlugin}`
- `window.resolveMbidForLove(track)` — Promise<string|null>

…and `PluginManager` never called `initResolver()` on `playbackTelemetry` plugins, so the plugin's `init()` (where it self-registers with `window.scrobbleManager`) never fired.

This PR wires all three pieces. Plugin registers on every cold start and starts contributing MBID→streaming-URL submissions to Achordion's match cache from Android playback.

## What's in this PR

| File | Change |
|---|---|
| `shared/.../MbidEnrichmentService.kt` | New `getRecordingMbid(artist, title)` parallel to existing `getArtistMbid`. Backs the JS resolver. |
| `app/.../assets/js/bootstrap.html` | `window.scrobbleManager` registry + `__scrobbleManagerDispatch` + `window.resolveMbidForLove` async harness + `window.__parachordClient = "android"` (forward-compat with parachord-plugins#3). <30s duration filter enforced JS-side per desktop CLAUDE.md L765. |
| `app/.../bridge/NativeBridge.kt` | `resolveMbidForLove(callbackId, trackJson)` `@JavascriptInterface`. Short-circuits on a valid 36-char `track.mbid`; otherwise delegates to `MbidEnrichmentService`. Same callback-id-keyed harness as the existing `fetchAsync` polyfill. New `MbidEnrichmentService` constructor param. |
| `app/.../bridge/JsBridge.kt` | Threads `MbidEnrichmentService` through to `NativeBridge`. |
| `app/.../playback/ScrobbleManager.kt` | `dispatchToJsPlugins(eventName, track)` fires after the existing native-scrobbler dispatch loop. Builds a desktop-shaped track JSON (`id`, `title`, `artist`, `album`, `duration` in **seconds**, `mbid`, `_activeResolver`, `sources` map) from `TrackResolverCache`; falls back to a synthetic sources map when the cache is empty so the plugin still has data on resolver-cache misses. New `JsBridge` + `TrackResolverCache` constructor params. |
| `shared/.../plugin/PluginManager.kt` | Invokes `__resolverLoader.initResolver()` for plugins with `capabilities.playbackTelemetry == true` after `loadResolver` completes. Without this, the plugin is loaded into the resolver-loader's registry but never run. Mirrors desktop's capability-filtered `initResolver` pattern (CLAUDE.md L758). |

Koin DI auto-wires both new constructor params: `MbidEnrichmentService` and `TrackResolverCache` are already registered as singletons via existing bindings. No `AndroidModule.kt` changes needed.

## Verified on device

Cold launch, log-stream-to-file (FriendsRepository spam was rolling the ring buffer, hence the file capture). All three deployment-confirmation signals fired:

```
D/PluginManager: Initialized playback-telemetry plugin: achordion
D/NativeBridge: [scrobbleManager] registered plugin: achordion
D/NativeBridge: [achordion] registered with scrobbleManager (tier-1: now-playing for direct-ID;
                  tier-2: scrobble for fuzzy 0.95; submits all sources at >=0.95 confidence;
                  window.achordion.{submitNow,fetchEntityLink,fetchEmbedCode} exposed)
```

Three signals = three layers wired correctly:

1. Kotlin-side `initResolver()` invocation (#126's `PluginManager` change).
2. JS-side `window.scrobbleManager.registerPlugin` accepting the call (#126's `bootstrap.html` shim).
3. The plugin's own `init()` taking the success branch (`if (window.scrobbleManager && typeof window.scrobbleManager.registerPlugin === 'function')` is now true).

Tier-1 / tier-2 POSTs not yet observed because nothing was playing during the verification window. Will fire on first 0.95+ resolver-match track that passes the scrobble threshold (or never for tier-1 until #128 lands — see "Caveats" below).

## Caveats

**Tier-1 won't fire on Android until #128 lands.** Android's `ResolverManager.resolveWithHints()` stamps direct-ID hints at confidence `0.95`, but the plugin's tier-1 dispatch requires `>= 1.0`. Three-line fix tracked in #128 (out of scope here). Tier-2 (after scrobble threshold) fires normally for everything ≥0.95.

**Bearer token shared with desktop.** Achordion's server can't yet distinguish Android-originated submissions. parachord-plugins#3 adds an `X-Parachord-Client` header to the plugin's fetches; we already populate `window.__parachordClient = "android"` in this PR so when that plugin update lands, the header light up automatically with no further mobile work.

## Cross-refs

- Desktop CLAUDE.md `## Scrobbling: inline core, plugin contract for the rest` (L712-754) — the public, stable plugin contract this exposes.
- Desktop CLAUDE.md `## Achordion Pre-resolution Plugin` (L756+) — the consumer + tier-1/tier-2 dispatch design.
- #128 — direct-ID hint confidence stamp follow-up.
- parachord-plugins#3 — server-side client-header support.

🤖 Generated with [Claude Code](https://claude.com/claude-code)