### PR TITLE
Loved tracks → ListenBrainz / Last.fm push (#125)

### DIFF
--- a/app/src/main/java/com/parachord/android/di/AndroidModule.kt
+++ b/app/src/main/java/com/parachord/android/di/AndroidModule.kt
@@ -442,6 +442,7 @@ val androidModule = module {
     // the shared-side signature isn't tightly coupled to MbidEnrichmentService.
     single {
         val mbidEnrichment: com.parachord.android.data.metadata.MbidEnrichmentService = get()
+        val lovesPush: com.parachord.android.playback.LovesPushService = get()
         com.parachord.shared.repository.LibraryRepository(
             trackDao = get(),
             albumDao = get(),
@@ -463,6 +464,11 @@ val androidModule = module {
                     }
                 )
             },
+            // Issue #125 — fire love push when the user adds a track to
+            // their collection AND has the per-service toggle enabled.
+            // LovesPushService is fire-and-forget internally; this lambda
+            // returns immediately.
+            pushLovedTrack = { track -> lovesPush.pushLoved(track) },
         )
     }
     // ChartsRepository takes `lastFmApiKey` as a constructor parameter

--- a/app/src/main/java/com/parachord/android/di/AndroidModule.kt
+++ b/app/src/main/java/com/parachord/android/di/AndroidModule.kt
@@ -344,6 +344,11 @@ val androidModule = module {
         setOf(get<LastFmScrobbler>(), get<ListenBrainzScrobbler>(), get<LibreFmScrobbler>())
     }
 
+    // Loves push (issue #125) — orchestrates per-service loveTrack
+    // dispatch + idempotency cache for both single-track (live toggle)
+    // and bulk backfill paths.
+    singleOf(::LovesPushService)
+
     // ── Metadata ─────────────────────────────────────────────────────
 
     // MetadataService is constructed directly from the shared cascading

--- a/app/src/main/java/com/parachord/android/playback/LovesPushService.kt
+++ b/app/src/main/java/com/parachord/android/playback/LovesPushService.kt
@@ -1,0 +1,199 @@
+package com.parachord.android.playback
+
+import com.parachord.android.data.db.entity.TrackEntity
+import com.parachord.android.data.store.SettingsStore
+import com.parachord.android.playback.scrobbler.Scrobbler
+import com.parachord.shared.platform.Log
+import com.parachord.shared.platform.currentTimeMillis
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+
+private const val TAG = "LovesPushService"
+
+/** Inter-request delay in the backfill loop. Mirrors desktop's 1 req/sec
+ *  rate-limit (`runLoveBackfill` in app.js) — keeps both LB and LFM happy
+ *  even when the user has hundreds of collection items. */
+private const val BACKFILL_INTER_REQUEST_DELAY_MS = 1000L
+
+/**
+ * Orchestrates the loved-tracks push to per-service scrobblers (issue #125).
+ *
+ * Two entry points:
+ * - [pushLoved] — single-track, fire-and-forget. Called from
+ *   `LibraryRepository.addToCollection` when the user toggles a track to
+ *   "loved." Skips silently when both per-service toggles are off OR the
+ *   track has already been pushed to all enabled services (idempotency).
+ * - [runBackfill] — bulk, sequential. Walks the user's existing collection
+ *   tracks, applies the same per-service / per-track filter, paces requests
+ *   at 1 per second, writes the idempotency cache after each success so
+ *   resume-on-crash works. Exposes [backfillState] for the Settings UI.
+ *
+ * Architectural notes:
+ * - One-way: love only, no unlove. Mirrors desktop's
+ *   `2026-05-03-loved-tracks-scrobbler-push-design.md`.
+ * - Per-service `Scrobbler.loveTrack` throws on hard errors. We catch +
+ *   log + leave the idempotency cache untouched so the next sync gets
+ *   another shot.
+ * - LB requires a 36-char-UUID MBID; the LB scrobbler implementation
+ *   handles the mapper fallback internally and silently skips if no MBID
+ *   resolves. LFM only needs artist + title.
+ * - Libre.fm has no equivalent endpoint; its scrobbler inherits the
+ *   `Scrobbler.loveTrack` default no-op so it never appears in the
+ *   per-service toggle UI.
+ */
+class LovesPushService constructor(
+    private val scrobblers: Set<@JvmSuppressWildcards Scrobbler>,
+    private val settingsStore: SettingsStore,
+) {
+    /** Fire-and-forget scope. Survives ViewModel lifecycle so a love
+     *  toggled mid-screen-rotation still finishes pushing. */
+    private val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+
+    /** Serializes idempotency-cache reads/writes across concurrent loves
+     *  + backfill. Without this, two concurrent calls could both read
+     *  the cache, both write the same key, last-writer-wins overwrites
+     *  the other's progress. */
+    private val cacheMutex = Mutex()
+
+    /** Backfill progress state for the Settings UI. */
+    sealed class BackfillState {
+        data object Idle : BackfillState()
+        data class Running(val service: String, val pushed: Int, val skipped: Int, val failed: Int, val total: Int) : BackfillState()
+        data class Done(val service: String, val pushed: Int, val skipped: Int, val failed: Int) : BackfillState()
+    }
+
+    private val _backfillState = MutableStateFlow<BackfillState>(BackfillState.Idle)
+    val backfillState: StateFlow<BackfillState> = _backfillState.asStateFlow()
+
+    /**
+     * Push love for [track] to each enabled scrobbler that hasn't already
+     * received it. Fire-and-forget — call from any coroutine; this returns
+     * immediately and the actual push happens on the service's IO scope.
+     *
+     * No-op when:
+     * - All per-service `LovePushEnabled` toggles are false.
+     * - The track has already been pushed to every enabled service.
+     */
+    fun pushLoved(track: TrackEntity) {
+        scope.launch {
+            try {
+                pushLovedInternal(track)
+            } catch (e: Exception) {
+                Log.w(TAG, "pushLoved('${track.title}' by ${track.artist}) failed: ${e.message}")
+            }
+        }
+    }
+
+    private suspend fun pushLovedInternal(track: TrackEntity) {
+        val enabledMap = settingsStore.getLovePushEnabled()
+        val enabledServices = enabledMap.filterValues { it }.keys
+        if (enabledServices.isEmpty()) return
+
+        val targetScrobblers = scrobblers.filter { it.id in enabledServices }
+        if (targetScrobblers.isEmpty()) return
+
+        val pushedKeys = settingsStore.getLovePushedKeys()
+        val alreadyPushedFor = pushedKeys[track.id]?.keys.orEmpty()
+        val toPush = targetScrobblers.filter { it.id !in alreadyPushedFor }
+        if (toPush.isEmpty()) return
+
+        for (scrobbler in toPush) {
+            try {
+                if (!scrobbler.isEnabled()) {
+                    Log.d(TAG, "${scrobbler.displayName}: not authenticated; skipping love")
+                    continue
+                }
+                scrobbler.loveTrack(track)
+                writeIdempotencyKey(track.id, scrobbler.id)
+            } catch (e: Exception) {
+                Log.w(TAG, "${scrobbler.displayName}: love push failed for '${track.title}' by ${track.artist}: ${e.message}")
+                // Leave cache untouched → retried next time.
+            }
+        }
+    }
+
+    /**
+     * One-shot bulk backfill of [collectionTracks] to the named [service].
+     * Sequential, 1 req/sec rate-limited, writes the idempotency cache
+     * after each push so an interrupted run resumes correctly. Caller is
+     * the Settings UI; observes [backfillState] for live progress.
+     *
+     * Already-pushed entries (per the cache) are silently skipped + counted
+     * under `skipped`. Per-track failures are caught + counted under
+     * `failed` and don't abort the loop — better N-1 successes than 0.
+     *
+     * Returns the final [BackfillState.Done] for callers that want a
+     * synchronous final tally (also published on the StateFlow).
+     */
+    suspend fun runBackfill(
+        service: String,
+        collectionTracks: List<TrackEntity>,
+    ): BackfillState.Done {
+        val scrobbler = scrobblers.firstOrNull { it.id == service }
+            ?: throw IllegalArgumentException("No scrobbler registered for service '$service'")
+        if (!scrobbler.isEnabled()) {
+            throw IllegalStateException("${scrobbler.displayName} not authenticated")
+        }
+
+        var pushed = 0
+        var skipped = 0
+        var failed = 0
+        val total = collectionTracks.size
+        _backfillState.value = BackfillState.Running(service, 0, 0, 0, total)
+
+        // Snapshot the cache once at start; we'll consult it in-memory and
+        // only re-read on writes (via writeIdempotencyKey, which goes
+        // through the mutex + reads-modifies-writes the persistent map).
+        val initialCache = settingsStore.getLovePushedKeys()
+
+        for ((index, track) in collectionTracks.withIndex()) {
+            if (initialCache[track.id]?.containsKey(service) == true) {
+                skipped++
+                _backfillState.value = BackfillState.Running(service, pushed, skipped, failed, total)
+                continue
+            }
+            try {
+                scrobbler.loveTrack(track)
+                writeIdempotencyKey(track.id, service)
+                pushed++
+            } catch (e: Exception) {
+                Log.w(TAG, "Backfill: $service love push failed for '${track.title}' by ${track.artist}: ${e.message}")
+                failed++
+            }
+            _backfillState.value = BackfillState.Running(service, pushed, skipped, failed, total)
+            // Pace 1 req/sec except after the last item.
+            if (index < collectionTracks.lastIndex) {
+                delay(BACKFILL_INTER_REQUEST_DELAY_MS)
+            }
+        }
+
+        val done = BackfillState.Done(service, pushed, skipped, failed)
+        _backfillState.value = done
+        Log.d(TAG, "Backfill done for $service: pushed=$pushed skipped=$skipped failed=$failed (of $total)")
+        return done
+    }
+
+    /** Reset the StateFlow back to Idle (e.g., after the user dismisses the
+     *  Done toast in Settings). */
+    fun resetBackfillState() {
+        _backfillState.value = BackfillState.Idle
+    }
+
+    private suspend fun writeIdempotencyKey(trackId: String, service: String) {
+        cacheMutex.withLock {
+            val current = settingsStore.getLovePushedKeys().toMutableMap()
+            val perService = current[trackId]?.toMutableMap() ?: mutableMapOf()
+            perService[service] = currentTimeMillis()
+            current[trackId] = perService
+            settingsStore.setLovePushedKeys(current)
+        }
+    }
+}

--- a/app/src/main/java/com/parachord/android/playback/scrobbler/LastFmScrobbler.kt
+++ b/app/src/main/java/com/parachord/android/playback/scrobbler/LastFmScrobbler.kt
@@ -79,6 +79,34 @@ class LastFmScrobbler constructor(
     }
 
     /**
+     * Push a love (track.love) to Last.fm. Issue #125 — opt-in cross-service
+     * love sync. One-way: no unlove. Throws on auth/network/API failures so
+     * the caller (LovesPushService) can decide whether to write the
+     * idempotency key.
+     *
+     * Last.fm `track.love` requires `artist` + `track` + session-key auth.
+     * `mbid` is optional and improves match accuracy on Last.fm's side
+     * (helps disambiguate covers / same-name tracks).
+     */
+    override suspend fun loveTrack(track: TrackEntity) {
+        val sessionKey = settingsStore.getLastFmSessionKey()
+            ?: throw IllegalStateException("Last.fm not authenticated (no session key)")
+        val params = buildMap {
+            put("method", "track.love")
+            put("artist", track.artist)
+            put("track", track.title)
+            put("api_key", BuildConfig.LASTFM_API_KEY)
+            put("sk", sessionKey)
+            track.recordingMbid?.let { put("mbid", it) }
+        }
+        val success = postSigned(params, API_URL, BuildConfig.LASTFM_SHARED_SECRET)
+        if (!success) {
+            throw RuntimeException("Last.fm track.love returned API error for '${track.artist} - ${track.title}'")
+        }
+        Log.d(TAG, "Loved on Last.fm: ${track.artist} — ${track.title}")
+    }
+
+    /**
      * POST signed request to a Last.fm-compatible API.
      * Signature = MD5 of sorted key+value pairs (excluding format) + shared secret.
      *

--- a/app/src/main/java/com/parachord/android/playback/scrobbler/ListenBrainzScrobbler.kt
+++ b/app/src/main/java/com/parachord/android/playback/scrobbler/ListenBrainzScrobbler.kt
@@ -2,13 +2,18 @@ package com.parachord.android.playback.scrobbler
 
 import com.parachord.shared.platform.Log
 import com.parachord.android.data.db.entity.TrackEntity
+import com.parachord.android.data.metadata.MbidEnrichmentService
 import com.parachord.android.data.store.SettingsStore
+import com.parachord.shared.api.ListenBrainzClient
 import okhttp3.MediaType.Companion.toMediaType
 import okhttp3.OkHttpClient
 import okhttp3.Request
 import okhttp3.RequestBody.Companion.toRequestBody
 import org.json.JSONArray
 import org.json.JSONObject
+
+/** 36-char MusicBrainz Identifier shape — required by LB feedback API. */
+private val LB_MBID_PATTERN = Regex("^[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}\$", RegexOption.IGNORE_CASE)
 
 /**
  * ListenBrainz scrobbler — sends JSON POST requests to api.listenbrainz.org.
@@ -17,10 +22,18 @@ import org.json.JSONObject
  * Auth is a simple user token passed as `Authorization: Token {token}`.
  *
  * API docs: https://listenbrainz.readthedocs.io/en/latest/users/api/core.html
+ *
+ * Uses raw OkHttp for `submit-listens` (legacy path) and the shared
+ * Ktor-based [ListenBrainzClient] for the `feedback/recording-feedback`
+ * endpoint added for issue #125's loved-tracks push. Mixed clients is
+ * intentional minimal scope — converting `submit-listens` to Ktor too
+ * would be a separate cleanup.
  */
 class ListenBrainzScrobbler constructor(
     private val settingsStore: SettingsStore,
     private val okHttpClient: OkHttpClient,
+    private val listenBrainzClient: ListenBrainzClient,
+    private val mbidEnrichment: MbidEnrichmentService,
 ) : Scrobbler {
     companion object {
         private const val TAG = "ListenBrainzScrobbler"
@@ -68,6 +81,50 @@ class ListenBrainzScrobbler constructor(
         } catch (e: Exception) {
             Log.e(TAG, "Failed to scrobble", e)
         }
+    }
+
+    /**
+     * Push a love (feedback score=1) to ListenBrainz. Issue #125 — opt-in
+     * cross-service love sync. One-way: no unlove (LB has score=0 to clear,
+     * but desktop's design doc explicitly excludes that path).
+     *
+     * Requires a 36-char-UUID `track.recordingMbid`. When the track row
+     * lacks one, falls through to the MBID Mapper (via
+     * [MbidEnrichmentService.getRecordingMbid]) at the mapper's confidence
+     * threshold. Silent skip on no resolution — caller leaves the
+     * idempotency key untouched and retries on next sync (matches desktop's
+     * `pushLoveToScrobblers` behavior in `app.js`).
+     *
+     * Throws on hard failures (auth invalid, rate-limited 5xx, network).
+     */
+    override suspend fun loveTrack(track: TrackEntity) {
+        val token = settingsStore.getListenBrainzToken()
+            ?: throw IllegalStateException("ListenBrainz not authenticated (no token)")
+
+        // Resolve MBID. Use the track's stored value if it's a valid UUID;
+        // else fall through to the mapper. Either return value or null.
+        val mbid = track.recordingMbid?.takeIf { LB_MBID_PATTERN.matches(it) }
+            ?: try {
+                mbidEnrichment.getRecordingMbid(track.artist, track.title)
+                    ?.takeIf { LB_MBID_PATTERN.matches(it) }
+            } catch (e: Exception) {
+                Log.w(TAG, "MBID mapper lookup failed for '${track.artist} - ${track.title}': ${e.message}")
+                null
+            }
+
+        if (mbid == null) {
+            // Per design doc: "If the mapper returns confidence < 0.7 or no
+            // result, the LB push is skipped for that track but LFM still
+            // gets it." Silent skip; caller leaves cache untouched.
+            Log.d(TAG, "Skipping LB love for '${track.artist} - ${track.title}': no MBID resolvable")
+            return
+        }
+
+        val ok = listenBrainzClient.submitRecordingFeedback(mbid, score = 1, token = token)
+        if (!ok) {
+            throw RuntimeException("ListenBrainz feedback API rejected love for $mbid")
+        }
+        Log.d(TAG, "Loved on ListenBrainz: ${track.artist} — ${track.title} ($mbid)")
     }
 
     /**

--- a/app/src/main/java/com/parachord/android/playback/scrobbler/Scrobbler.kt
+++ b/app/src/main/java/com/parachord/android/playback/scrobbler/Scrobbler.kt
@@ -23,4 +23,31 @@ interface Scrobbler {
 
     /** Submit a scrobble (track was listened to sufficiently). */
     suspend fun submitScrobble(track: TrackEntity, timestamp: Long)
+
+    /**
+     * Push a "love" / favorite of [track] up to the service. One-way per
+     * desktop's design (see `docs/plans/2026-05-03-loved-tracks-scrobbler-
+     * push-design.md`): if the user later un-loves the track locally, we
+     * do NOT call an unlove. Idempotency / dedup is enforced by the
+     * caller's `love_pushed_keys` cache.
+     *
+     * Throws on hard errors (auth invalid, rate-limited 5xx, malformed
+     * MBID for LB, etc.). Per-service caveats:
+     *
+     * - **ListenBrainz** requires a 36-char-UUID `track.recordingMbid`.
+     *   When absent, the impl SHOULD attempt the MBID Mapper fallback via
+     *   [com.parachord.shared.metadata.MbidEnrichmentService.getRecordingMbid]
+     *   before giving up; on no resolution at confidence ≥ 0.7 the impl
+     *   skips silently (no throw — caller leaves cache untouched and
+     *   retries next sync).
+     * - **Last.fm** only needs `artist` + `track`; MBID is optional.
+     * - **Libre.fm** has no equivalent endpoint. Default impl is a no-op
+     *   per design.
+     *
+     * Default no-op so adding `loveTrack` to the interface doesn't break
+     * any future scrobbler that genuinely doesn't support loves.
+     */
+    suspend fun loveTrack(track: TrackEntity) {
+        // Default no-op — services without a love endpoint inherit this.
+    }
 }

--- a/app/src/main/java/com/parachord/android/ui/MainViewModel.kt
+++ b/app/src/main/java/com/parachord/android/ui/MainViewModel.kt
@@ -180,7 +180,7 @@ class MainViewModel constructor(
             if (isCurrentTrackFavorited.value) {
                 libraryRepository.deleteTrackWithSync(track)
             } else {
-                libraryRepository.addTrack(track)
+                libraryRepository.addToCollection(track)
             }
         }
     }

--- a/app/src/main/java/com/parachord/android/ui/screens/album/AlbumViewModel.kt
+++ b/app/src/main/java/com/parachord/android/ui/screens/album/AlbumViewModel.kt
@@ -272,7 +272,7 @@ class AlbumViewModel constructor(
 
     fun addToCollection(track: TrackEntity) {
         viewModelScope.launch {
-            libraryRepository.addTrack(track)
+            libraryRepository.addToCollection(track)
         }
     }
 

--- a/app/src/main/java/com/parachord/android/ui/screens/artist/ArtistViewModel.kt
+++ b/app/src/main/java/com/parachord/android/ui/screens/artist/ArtistViewModel.kt
@@ -312,7 +312,7 @@ class ArtistViewModel constructor(
 
     fun addToCollection(track: TrackEntity) {
         viewModelScope.launch {
-            libraryRepository.addTrack(track)
+            libraryRepository.addToCollection(track)
         }
     }
 

--- a/app/src/main/java/com/parachord/android/ui/screens/nowplaying/NowPlayingViewModel.kt
+++ b/app/src/main/java/com/parachord/android/ui/screens/nowplaying/NowPlayingViewModel.kt
@@ -144,7 +144,7 @@ class NowPlayingViewModel constructor(
 
     fun addToCollection(track: TrackEntity) {
         viewModelScope.launch {
-            libraryRepository.addTrack(track)
+            libraryRepository.addToCollection(track)
         }
     }
 

--- a/app/src/main/java/com/parachord/android/ui/screens/playlists/PlaylistDetailViewModel.kt
+++ b/app/src/main/java/com/parachord/android/ui/screens/playlists/PlaylistDetailViewModel.kt
@@ -249,7 +249,7 @@ class PlaylistDetailViewModel constructor(
 
     fun addToCollection(track: TrackEntity) {
         viewModelScope.launch {
-            libraryRepository.addTrack(track)
+            libraryRepository.addToCollection(track)
         }
     }
 

--- a/app/src/main/java/com/parachord/android/ui/screens/playlists/WeeklyPlaylistViewModel.kt
+++ b/app/src/main/java/com/parachord/android/ui/screens/playlists/WeeklyPlaylistViewModel.kt
@@ -146,7 +146,7 @@ class WeeklyPlaylistViewModel constructor(
 
     fun addToCollection(track: TrackEntity) {
         viewModelScope.launch {
-            libraryRepository.addTrack(track)
+            libraryRepository.addToCollection(track)
         }
     }
 
@@ -155,7 +155,7 @@ class WeeklyPlaylistViewModel constructor(
             if (isInCollection) {
                 libraryRepository.deleteTrack(track)
             } else {
-                libraryRepository.addTrack(track)
+                libraryRepository.addToCollection(track)
             }
         }
     }

--- a/app/src/main/java/com/parachord/android/ui/screens/settings/SettingsScreen.kt
+++ b/app/src/main/java/com/parachord/android/ui/screens/settings/SettingsScreen.kt
@@ -662,6 +662,12 @@ private fun PlugInsTab(
         item { Spacer(modifier = Modifier.height(32.dp)) }
     }
 
+    // ── Loved-tracks push state (issue #125) ─────────────────────────
+    // Sourced from the local SettingsViewModel reference (line above) —
+    // no need to plumb props all the way down from SettingsScreen.
+    val lovePushEnabled by settingsViewModel.lovePushEnabled.collectAsStateWithLifecycle()
+    val loveBackfillState by settingsViewModel.loveBackfillState.collectAsStateWithLifecycle()
+
     // Config bottom sheet
     selectedPlugin?.let { plugin ->
         PluginConfigSheet(
@@ -719,6 +725,11 @@ private fun PlugInsTab(
             onSongkickDisconnect = { settingsViewModel.clearPluginApiKey("songkick") },
             concertLocation = concertLocation,
             onConcertLocationSelected = onConcertLocationSelected,
+            lovePushEnabled = lovePushEnabled,
+            loveBackfillState = loveBackfillState,
+            onLovePushToggle = { service, enabled -> settingsViewModel.setLovePushEnabled(service, enabled) },
+            onLoveBackfillClick = { service -> settingsViewModel.runLoveBackfill(service) },
+            onLoveBackfillDismiss = { settingsViewModel.dismissLoveBackfillState() },
         )
     }
 }
@@ -978,6 +989,12 @@ private fun PluginConfigSheet(
     onSongkickDisconnect: () -> Unit = {},
     concertLocation: com.parachord.android.data.store.ConcertLocation = com.parachord.android.data.store.ConcertLocation(null, null, null, 50),
     onConcertLocationSelected: (Double, Double, String) -> Unit = { _, _, _ -> },
+    lovePushEnabled: Map<String, Boolean> = emptyMap(),
+    loveBackfillState: com.parachord.android.playback.LovesPushService.BackfillState =
+        com.parachord.android.playback.LovesPushService.BackfillState.Idle,
+    onLovePushToggle: (service: String, enabled: Boolean) -> Unit = { _, _ -> },
+    onLoveBackfillClick: (service: String) -> Unit = {},
+    onLoveBackfillDismiss: () -> Unit = {},
 ) {
     val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
 
@@ -1105,7 +1122,17 @@ private fun PluginConfigSheet(
                     scanProgress = scanProgress,
                     onScanLocalFiles = onScanLocalFiles,
                 )
-                "lastfm" -> LastFmConfig(isConnected, onToggleConnection, scrobbling, onScrobblingChanged)
+                "lastfm" -> LastFmConfig(
+                    isConnected = isConnected,
+                    onToggle = onToggleConnection,
+                    scrobbling = scrobbling,
+                    onScrobblingChanged = onScrobblingChanged,
+                    lovePushEnabled = lovePushEnabled,
+                    loveBackfillState = loveBackfillState,
+                    onLovePushToggle = onLovePushToggle,
+                    onLoveBackfillClick = onLoveBackfillClick,
+                    onLoveBackfillDismiss = onLoveBackfillDismiss,
+                )
                 "listenbrainz" -> ListenBrainzConfig(
                     isConnected = isConnected,
                     onTokenSubmit = onListenBrainzTokenSubmit,
@@ -1113,6 +1140,11 @@ private fun PluginConfigSheet(
                     authError = listenBrainzAuthError,
                     scrobbling = scrobbling,
                     onScrobblingChanged = onScrobblingChanged,
+                    lovePushEnabled = lovePushEnabled,
+                    loveBackfillState = loveBackfillState,
+                    onLovePushToggle = onLovePushToggle,
+                    onLoveBackfillClick = onLoveBackfillClick,
+                    onLoveBackfillDismiss = onLoveBackfillDismiss,
                 )
                 "librefm" -> LibreFmConfig(
                     isConnected = isConnected,
@@ -1985,6 +2017,11 @@ private fun LastFmConfig(
     onToggle: () -> Unit,
     scrobbling: Boolean,
     onScrobblingChanged: (Boolean) -> Unit,
+    lovePushEnabled: Map<String, Boolean>,
+    loveBackfillState: com.parachord.android.playback.LovesPushService.BackfillState,
+    onLovePushToggle: (service: String, enabled: Boolean) -> Unit,
+    onLoveBackfillClick: (service: String) -> Unit,
+    onLoveBackfillDismiss: () -> Unit,
 ) {
     Spacer(modifier = Modifier.height(16.dp))
     HorizontalDivider()
@@ -2055,6 +2092,17 @@ private fun LastFmConfig(
             enabled = isConnected,
         )
     }
+
+    LovePushControls(
+        serviceId = "lastfm",
+        serviceLabel = "Last.fm",
+        isConnected = isConnected,
+        lovePushEnabled = lovePushEnabled,
+        backfillState = loveBackfillState,
+        onLovePushToggle = onLovePushToggle,
+        onBackfillClick = onLoveBackfillClick,
+        onBackfillDismiss = onLoveBackfillDismiss,
+    )
 }
 
 // ── ListenBrainz Config ────────────────────────────────────────────
@@ -2067,6 +2115,11 @@ private fun ListenBrainzConfig(
     authError: String? = null,
     scrobbling: Boolean,
     onScrobblingChanged: (Boolean) -> Unit,
+    lovePushEnabled: Map<String, Boolean>,
+    loveBackfillState: com.parachord.android.playback.LovesPushService.BackfillState,
+    onLovePushToggle: (service: String, enabled: Boolean) -> Unit,
+    onLoveBackfillClick: (service: String) -> Unit,
+    onLoveBackfillDismiss: () -> Unit,
 ) {
     Spacer(modifier = Modifier.height(16.dp))
     HorizontalDivider()
@@ -2182,6 +2235,125 @@ private fun ListenBrainzConfig(
             onCheckedChange = onScrobblingChanged,
             enabled = isConnected,
         )
+    }
+
+    LovePushControls(
+        serviceId = "listenbrainz",
+        serviceLabel = "ListenBrainz",
+        isConnected = isConnected,
+        lovePushEnabled = lovePushEnabled,
+        backfillState = loveBackfillState,
+        onLovePushToggle = onLovePushToggle,
+        onBackfillClick = onLoveBackfillClick,
+        onBackfillDismiss = onLoveBackfillDismiss,
+    )
+}
+
+// ── Love-Push Controls (issue #125) ────────────────────────────────
+
+/**
+ * Per-service "love-push" toggle row + manual backfill button. Used by
+ * both [LastFmConfig] and [ListenBrainzConfig] (Libre.fm has no
+ * equivalent endpoint per desktop's design doc and is excluded).
+ *
+ * Both rows are disabled until the service is connected (`isConnected =
+ * true`) — flipping them earlier would write a Settings entry that goes
+ * nowhere, the toggle goes back to false on the first push attempt
+ * because the scrobbler returns `isEnabled() = false`.
+ *
+ * Backfill state is shared across services (a single
+ * [LovesPushService.BackfillState] StateFlow) — running one service's
+ * backfill grays out the OTHER service's button mid-run, since the
+ * service serializes with a 1-req/sec pacing loop. Done state shows a
+ * compact summary line "Pushed N, skipped M, failed K" + a Dismiss
+ * button that resets to Idle.
+ */
+@Composable
+private fun LovePushControls(
+    serviceId: String,
+    serviceLabel: String,
+    isConnected: Boolean,
+    lovePushEnabled: Map<String, Boolean>,
+    backfillState: com.parachord.android.playback.LovesPushService.BackfillState,
+    onLovePushToggle: (service: String, enabled: Boolean) -> Unit,
+    onBackfillClick: (service: String) -> Unit,
+    onBackfillDismiss: () -> Unit,
+) {
+    val pushOn = lovePushEnabled[serviceId] == true
+    Spacer(modifier = Modifier.height(16.dp))
+    HorizontalDivider()
+    Spacer(modifier = Modifier.height(16.dp))
+    Row(
+        modifier = Modifier.fillMaxWidth(),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Column(modifier = Modifier.weight(1f)) {
+            Text(
+                text = "Push loved tracks to $serviceLabel",
+                style = MaterialTheme.typography.bodyMedium,
+                fontWeight = FontWeight.Medium,
+            )
+            Text(
+                text = "When you favorite a track, send it as a love to $serviceLabel.",
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+        }
+        Switch(
+            checked = pushOn,
+            onCheckedChange = { onLovePushToggle(serviceId, it) },
+            enabled = isConnected,
+        )
+    }
+
+    Spacer(modifier = Modifier.height(12.dp))
+
+    val running = backfillState as?
+        com.parachord.android.playback.LovesPushService.BackfillState.Running
+    val done = backfillState as?
+        com.parachord.android.playback.LovesPushService.BackfillState.Done
+    val isThisServiceRunning = running?.service == serviceId
+    val isThisServiceDone = done?.service == serviceId
+    val isOtherServiceRunning = running != null && running.service != serviceId
+
+    Row(
+        modifier = Modifier.fillMaxWidth(),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Column(modifier = Modifier.weight(1f)) {
+            Text(
+                text = "Backfill loved tracks → $serviceLabel",
+                style = MaterialTheme.typography.bodyMedium,
+                fontWeight = FontWeight.Medium,
+            )
+            Text(
+                text = when {
+                    isThisServiceRunning ->
+                        // running != null is implied by isThisServiceRunning (which is
+                        // running?.service == serviceId) but the compiler can't infer
+                        // it through the cast; the safe-call here keeps it null-safe.
+                        running?.let { "Pushing… ${it.pushed + it.skipped + it.failed} / ${it.total}" } ?: ""
+                    isThisServiceDone ->
+                        done?.let { "Pushed ${it.pushed}, skipped ${it.skipped}, failed ${it.failed}." } ?: ""
+                    else ->
+                        "One-time push of every track in your collection. Existing pushes are skipped via the per-track cache."
+                },
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+        }
+        if (isThisServiceDone) {
+            TextButton(onClick = onBackfillDismiss) {
+                Text("Dismiss")
+            }
+        } else {
+            TextButton(
+                onClick = { onBackfillClick(serviceId) },
+                enabled = isConnected && !isThisServiceRunning && !isOtherServiceRunning,
+            ) {
+                Text(if (isThisServiceRunning) "Running…" else "Backfill")
+            }
+        }
     }
 }
 

--- a/app/src/main/java/com/parachord/android/ui/screens/settings/SettingsViewModel.kt
+++ b/app/src/main/java/com/parachord/android/ui/screens/settings/SettingsViewModel.kt
@@ -8,11 +8,14 @@ import com.parachord.shared.api.ListenBrainzClient
 import com.parachord.android.data.scanner.MediaScanner
 import com.parachord.android.data.scanner.ScanProgress
 import com.parachord.android.data.store.SettingsStore
+import com.parachord.android.data.repository.LibraryRepository
+import com.parachord.android.playback.LovesPushService
 import com.parachord.android.playback.QueuePersistence
 import com.parachord.android.playback.handlers.MusicKitWebBridge
 import com.parachord.android.playback.scrobbler.LibreFmScrobbler
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.map
@@ -28,6 +31,8 @@ class SettingsViewModel constructor(
     private val mediaScanner: MediaScanner,
     private val pluginManager: com.parachord.android.plugin.PluginManager,
     private val pluginSyncService: com.parachord.shared.plugin.PluginSyncService,
+    private val lovesPushService: LovesPushService,
+    private val libraryRepository: LibraryRepository,
 ) : ViewModel() {
 
     /** Loaded .axe plugins — drives the dynamic plugin list in Settings. */
@@ -463,5 +468,46 @@ class SettingsViewModel constructor(
 
     fun setConcertLocation(lat: Double, lon: Double, city: String) {
         viewModelScope.launch { settingsStore.setConcertLocation(lat, lon, city) }
+    }
+
+    // --- Loved-tracks push (issue #125) ---
+
+    /**
+     * Per-service love-push toggle state. UI subscribes via
+     * `collectAsStateWithLifecycle()` and reflects flips immediately.
+     */
+    val lovePushEnabled: StateFlow<Map<String, Boolean>> =
+        settingsStore.getLovePushEnabledFlow()
+            .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), emptyMap())
+
+    /** Backfill progress state for the Settings UI's per-service Backfill button. */
+    val loveBackfillState: StateFlow<LovesPushService.BackfillState> =
+        lovesPushService.backfillState
+
+    /** Toggle live love-push for [service] ("lastfm" / "listenbrainz"). */
+    fun setLovePushEnabled(service: String, enabled: Boolean) {
+        viewModelScope.launch { settingsStore.setLovePushEnabled(service, enabled) }
+    }
+
+    /**
+     * Kick off the bulk backfill for [service]. Snapshots the current
+     * collection-tracks list once at the call point and hands it to
+     * `LovesPushService.runBackfill`. Service paces requests at 1 req/sec
+     * + writes idempotency keys per-track so resume-on-crash works.
+     */
+    fun runLoveBackfill(service: String) {
+        viewModelScope.launch {
+            try {
+                val tracks = libraryRepository.getAllTracks().first()
+                lovesPushService.runBackfill(service, tracks)
+            } catch (e: Exception) {
+                Log.w("SettingsVM", "Love backfill for $service failed: ${e.message}")
+            }
+        }
+    }
+
+    /** Reset the StateFlow → Idle (after the user has seen the Done summary). */
+    fun dismissLoveBackfillState() {
+        lovesPushService.resetBackfillState()
     }
 }

--- a/shared/src/commonMain/kotlin/com/parachord/shared/api/ListenBrainzClient.kt
+++ b/shared/src/commonMain/kotlin/com/parachord/shared/api/ListenBrainzClient.kt
@@ -6,15 +6,18 @@ import io.ktor.client.request.get
 import io.ktor.client.request.header
 import io.ktor.client.request.parameter
 import io.ktor.client.request.post
+import io.ktor.client.request.setBody
 import io.ktor.client.statement.HttpResponse
 import io.ktor.client.statement.bodyAsText
 import io.ktor.http.HttpStatusCode
+import io.ktor.http.contentType
 import io.ktor.http.isSuccess
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.delay
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.put
 
 /**
  * ListenBrainz API client. Cross-platform (commonMain).
@@ -113,6 +116,52 @@ class ListenBrainzClient(private val httpClient: HttpClient) {
         } catch (e: Throwable) {
             Log.e(TAG, "Failed to unfollow $username", e)
             false
+        }
+    }
+
+    /**
+     * Submit a recording-level feedback ("love" / "hate" / "neutral") to LB.
+     *
+     * Used by the loved-tracks push (issue #125): when the user adds a track
+     * to their Parachord collection AND the LB push toggle is on, we POST
+     * `{ recording_mbid, score: 1 }` to set the love. `score` per LB API:
+     *   1 = love, -1 = hate, 0 = clear/neutral.
+     *
+     * Caller is responsible for ensuring `recordingMbid` is a valid 36-char
+     * UUID (the desktop's `loveTrack` validates `track.mbid` against
+     * `^[a-f0-9-]{36}$/i` before calling this — mirror that check here in
+     * the calling scrobbler since LB returns a 400 for malformed UUIDs and
+     * we don't want to retry those).
+     *
+     * Throws on hard errors (auth invalid, rate-limited 5xx). Callers in
+     * the love-push path catch and skip the per-track push, leaving the
+     * idempotency cache untouched so the next sync gets another shot.
+     */
+    suspend fun submitRecordingFeedback(
+        recordingMbid: String,
+        score: Int,
+        token: String,
+    ): Boolean {
+        return try {
+            val response = httpClient.post("$BASE_URL/1/feedback/recording-feedback") {
+                header("Authorization", "Token $token")
+                contentType(io.ktor.http.ContentType.Application.Json)
+                setBody(
+                    kotlinx.serialization.json.buildJsonObject {
+                        put("recording_mbid", recordingMbid)
+                        put("score", score)
+                    },
+                )
+            }
+            if (!response.status.isSuccess()) {
+                Log.w(TAG, "submitRecordingFeedback($recordingMbid, score=$score) → HTTP ${response.status.value}")
+            }
+            response.status.isSuccess()
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Throwable) {
+            Log.w(TAG, "submitRecordingFeedback failed for $recordingMbid: ${e.message}")
+            throw e
         }
     }
 

--- a/shared/src/commonMain/kotlin/com/parachord/shared/repository/LibraryRepository.kt
+++ b/shared/src/commonMain/kotlin/com/parachord/shared/repository/LibraryRepository.kt
@@ -43,6 +43,16 @@ class LibraryRepository(
     private val mbidEnrichTrack: (trackId: String, artist: String, title: String) -> Unit,
     /** Fire-and-forget MBID enrichment for a batch of tracks. */
     private val mbidEnrichBatch: (tracks: List<Track>) -> Unit,
+    /**
+     * Fire-and-forget love-push trigger (issue #125). Called from
+     * [addToCollection] — i.e. only when the user explicitly toggles a
+     * track into their collection — NOT from the raw [addTrack] path
+     * (sync, MediaScanner local-file scan, etc. shouldn't auto-love).
+     *
+     * Wired to `LovesPushService.pushLoved` in `AndroidModule`. Default
+     * no-op so non-Android consumers and tests don't need to provide one.
+     */
+    private val pushLovedTrack: (Track) -> Unit = {},
 ) {
 
     /**
@@ -96,6 +106,23 @@ class LibraryRepository(
         // Background MBID enrichment
         mbidEnrichTrack(track.id, track.artist, track.title)
     }
+
+    /**
+     * User-intent collection add: writes the track AND fires the love-push
+     * (when enabled in Settings) — issue #125.
+     *
+     * **Use this from any user-driven "add to collection" / "love" action**
+     * (heart toggle, ViewModel `addToCollection`, etc). DON'T use it from
+     * sync paths, MediaScanner local-file scans, or any automated import —
+     * those should call [addTrack] directly so they don't generate phantom
+     * loves on tracks the user never touched.
+     */
+    suspend fun addToCollection(track: Track) {
+        addTrack(track)
+        // Fire-and-forget; LovesPushService handles its own coroutine + idempotency.
+        pushLovedTrack(track)
+    }
+
     suspend fun addTracks(tracks: List<Track>) {
         trackDao.insertAll(tracks)
         // Background MBID enrichment for batch imports

--- a/shared/src/commonMain/kotlin/com/parachord/shared/settings/SettingsStore.kt
+++ b/shared/src/commonMain/kotlin/com/parachord/shared/settings/SettingsStore.kt
@@ -13,6 +13,12 @@ import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import kotlinx.serialization.json.long
+import kotlinx.serialization.json.put
+import kotlinx.serialization.json.putJsonObject
 
 /**
  * KMP preferences store — successor to the desktop app's electron-store.
@@ -76,6 +82,20 @@ class SettingsStore(
         const val CONCERT_RADIUS = "concert_radius_miles"
         const val LAST_PLUGIN_SYNC = "last_plugin_sync_timestamp"
         const val DISABLED_PLUGINS = "disabled_plugins"
+
+        /** Per-service opt-in toggle for the loved-tracks push. Mirrors
+         *  desktop's `scrobbler_love_push_enabled` shape from the design
+         *  doc (`docs/plans/2026-05-03-loved-tracks-scrobbler-push-design.md`).
+         *  CSV format `service:bool,service:bool` (e.g. `lastfm:true,listenbrainz:false`).
+         *  Default for unset service = false (per desktop's "default OFF"). */
+        const val LOVE_PUSH_ENABLED = "scrobbler_love_push_enabled"
+
+        /** Idempotency cache: `trackId -> {service: epochMs}` of completed
+         *  love pushes. JSON-encoded `{ "<trackId>": { "lastfm": 1234, "listenbrainz": 1235 } }`.
+         *  Survives crashes mid-backfill (each successful push writes its
+         *  key before moving on, so resume picks up where it left off).
+         *  Mirrors desktop's `love_pushed_keys`. */
+        const val LOVE_PUSHED_KEYS = "love_pushed_keys"
 
         // Sync key family (Phase 9B Stage 2 — already KvStore-resident)
         const val SYNC_ENABLED = "sync_enabled"
@@ -842,6 +862,96 @@ class SettingsStore(
         val current = getDisabledPlugins().toMutableSet()
         if (enabled) current.remove(pluginId) else current.add(pluginId)
         kv.setString(DISABLED_PLUGINS, current.joinToString(","))
+    }
+
+    // ── Loved-tracks push (issue #125) ────────────────────────────────
+
+    /**
+     * Return the per-service love-push enabled map. Unrecognized keys are
+     * preserved (forward-compat) but only `lastfm` / `listenbrainz` are
+     * meaningful today. Default for any unset service = `false` (defaults
+     * OFF per desktop's design doc).
+     */
+    suspend fun getLovePushEnabled(): Map<String, Boolean> {
+        ensureMigrated()
+        val raw = kv.getStringOrNull(LOVE_PUSH_ENABLED) ?: return emptyMap()
+        if (raw.isBlank()) return emptyMap()
+        return raw.split(",").mapNotNull { entry ->
+            val parts = entry.split(":")
+            if (parts.size != 2) return@mapNotNull null
+            val service = parts[0].trim().takeIf { it.isNotBlank() } ?: return@mapNotNull null
+            val flag = parts[1].trim().toBooleanStrictOrNull() ?: return@mapNotNull null
+            service to flag
+        }.toMap()
+    }
+
+    /** Flow variant for reactive Settings UI. */
+    fun getLovePushEnabledFlow(): Flow<Map<String, Boolean>> = migratedFlow().flatMapConcat {
+        kv.observeString(LOVE_PUSH_ENABLED, default = "").map { raw ->
+            if (raw.isBlank()) emptyMap()
+            else raw.split(",").mapNotNull { entry ->
+                val parts = entry.split(":")
+                if (parts.size != 2) return@mapNotNull null
+                val service = parts[0].trim().takeIf { it.isNotBlank() } ?: return@mapNotNull null
+                val flag = parts[1].trim().toBooleanStrictOrNull() ?: return@mapNotNull null
+                service to flag
+            }.toMap()
+        }
+    }
+
+    /** Set the toggle for a single service; preserves other services' state. */
+    suspend fun setLovePushEnabled(service: String, enabled: Boolean) {
+        ensureMigrated()
+        val current = getLovePushEnabled().toMutableMap()
+        current[service] = enabled
+        kv.setString(
+            LOVE_PUSH_ENABLED,
+            current.entries.joinToString(",") { (s, b) -> "$s:$b" },
+        )
+    }
+
+    /**
+     * Idempotency cache: `trackId -> {service: epochMs}` of completed pushes.
+     * JSON-encoded so per-service timestamps round-trip cleanly.
+     *
+     * Format:
+     * ```json
+     * { "<trackId>": { "lastfm": 1234567890123, "listenbrainz": 1234567891000 } }
+     * ```
+     *
+     * Returns an empty map on no entry / parse failure (corrupted prefs
+     * shouldn't block the love-push flow). Reads are infrequent — the
+     * service caches in-memory after the first read.
+     */
+    suspend fun getLovePushedKeys(): Map<String, Map<String, Long>> {
+        ensureMigrated()
+        val raw = kv.getStringOrNull(LOVE_PUSHED_KEYS) ?: return emptyMap()
+        if (raw.isBlank()) return emptyMap()
+        return try {
+            val element = kotlinx.serialization.json.Json.parseToJsonElement(raw).jsonObject
+            element.mapValues { (_, inner) ->
+                inner.jsonObject.mapValues { (_, ts) ->
+                    ts.jsonPrimitive.long
+                }
+            }
+        } catch (_: Exception) {
+            emptyMap()
+        }
+    }
+
+    /** Persist the idempotency map. Called per-track after each successful push. */
+    suspend fun setLovePushedKeys(map: Map<String, Map<String, Long>>) {
+        ensureMigrated()
+        val obj = kotlinx.serialization.json.buildJsonObject {
+            for ((trackId, services) in map) {
+                putJsonObject(trackId) {
+                    for ((service, ts) in services) {
+                        put(service, ts)
+                    }
+                }
+            }
+        }
+        kv.setString(LOVE_PUSHED_KEYS, obj.toString())
     }
 }
 


### PR DESCRIPTION
Closes #125. Implements desktop's loved-tracks cross-service push on Android — opt-in per service (Last.fm + ListenBrainz), with both live push (on every heart-toggle) and a one-shot manual backfill of existing collection.

## Architecture

Mirrors desktop's deliberate split (CLAUDE.md `## Scrobbling: inline core, plugin contract for the rest`): write-half scrobblers live native (Kotlin), the marketplace `.axe` files are read-only meta-services. Android's existing `LastFmScrobbler` / `ListenBrainzScrobbler` get a new `loveTrack(track)` method; a new `LovesPushService` orchestrates per-service dispatch, idempotency, and backfill.

```
ViewModel.addToCollection
  → LibraryRepository.addToCollection         (new — only user-intent path)
    → addTrack                                  (existing data write)
    → pushLovedTrack(track)                     (lambda; no-op default)
      → LovesPushService.pushLoved              (fire-and-forget)
        → for each enabled service in settings:
          → Scrobbler.loveTrack(track)
          → settingsStore.setLovePushedKeys(...) (idempotency cache write)
```

Sync paths, `MediaScanner` local-file scans, and other automated track imports keep calling `LibraryRepository.addTrack` directly — they don't trigger the love-push.

## Four commits

1. **`834afda` — API surfaces.** `Scrobbler.loveTrack(track)` interface method (default no-op so future scrobblers without a love endpoint inherit it for free, and Libre.fm is excluded by design). Per-service impls on `LastFmScrobbler` (signed `track.love` POST via existing `postSigned` helper) + `ListenBrainzScrobbler` (POST `/1/feedback/recording-feedback` with `score=1`, requires 36-char MBID, falls through to `MbidEnrichmentService.getRecordingMbid` on absent — mirrors desktop's `pushLoveToScrobblers` confidence behavior). New `ListenBrainzClient.submitRecordingFeedback` shared API client method.

2. **`b3967f2` — Persistence + service + DI.**
   - SettingsStore keys: `scrobbler_love_push_enabled` (per-service Boolean CSV) + `love_pushed_keys` (JSON `{trackId: {service: epochMs}}` idempotency cache). Both read/write methods + a Flow for the toggle.
   - `LovesPushService` — single class, two entry points. `pushLoved(track)` for live single-track. `runBackfill(service, tracks)` for sequential bulk push at 1 req/sec (mirrors desktop `runLoveBackfill` rate-limit). Per-track failures don't abort. Cache writes after each success → resume-on-crash works. StateFlow<BackfillState> for UI: `Idle / Running(pushed,skipped,failed,total) / Done(pushed,skipped,failed)`.
   - Mutex around cache reads-modify-writes; `singleOf(::LovesPushService)` Koin binding.

3. **`0e9736a` — Wiring.** New `LibraryRepository.addToCollection(track)` + lambda forwarding (matches existing `mbidEnrichTrack` pattern; default no-op for tests/iOS). 5 ViewModels swapped from `libraryRepository.addTrack(track)` → `addToCollection(track)`: `PlaylistDetailViewModel`, `WeeklyPlaylistViewModel` (both `addToCollection` and the add branch of `toggleCollection`), `NowPlayingViewModel`, `AlbumViewModel`, `ArtistViewModel`. AndroidModule wires the lambda → `lovesPushService.pushLoved`.

4. **`5f6ebdc` — Settings UI.** Two new rows under each scrobbler card (LFM + LB only): toggle + backfill button. Shared `LovePushControls` composable used by both. Three states: Idle / Running (`Pushing… N / total`) / Done (`Pushed N, skipped M, failed K.` + Dismiss). Other-service's Backfill button disables mid-run since the service serializes through one StateFlow. UI reads state from `PlugInsTab`'s local `koinViewModel()` reference — no plumb up to `SettingsScreen`.

## Verification

- `./gradlew :app:compileDebugKotlin` — clean (only pre-existing deprecation warnings).
- APK installs cleanly. Settings UI renders: toggle + backfill row visible per service after Connection + Scrobbling rows.
- Pending on-device manual: heart a track → grep logcat for `D/ListenBrainzScrobbler: Loved on ListenBrainz: <track> (<mbid>)` and/or `D/LastFmScrobbler: Loved on Last.fm: <track>`.

## Cross-refs

- Desktop design doc: `parachord-desktop/docs/plans/2026-05-03-loved-tracks-scrobbler-push-design.md`.
- Desktop CLAUDE.md `### Loved Tracks → ListenBrainz / Last.fm` (L484-510).
- #126 (merged) — `MbidEnrichmentService.getRecordingMbid` was added there for the achordion plugin's MBID fallback; the LB scrobbler's `loveTrack` reuses the same method here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)