### PR TITLE
Protocol play handlers — Phase 1: Foundation (#119)

### DIFF
--- a/app/src/main/java/com/parachord/android/deeplink/DeepLinkViewModel.kt
+++ b/app/src/main/java/com/parachord/android/deeplink/DeepLinkViewModel.kt
@@ -294,6 +294,14 @@ class DeepLinkViewModel constructor(
                 }
 
                 is DeepLinkAction.Unknown -> Log.w(TAG, "Unknown deep link: ${action.uri}")
+
+                // ── Phase 1 (#119) foundation types — wired in Phase 2 (#120) / Phase 3 (#121) ──
+                is DeepLinkAction.PlayAlbum,
+                is DeepLinkAction.PlayPlaylist,
+                is DeepLinkAction.PlayRadio,
+                is DeepLinkAction.ListenAlong -> {
+                    Log.d(TAG, "Protocol play handler not yet wired (Phase 2 / 3): $action")
+                }
             }
         }
     }

--- a/app/src/main/java/com/parachord/android/playlist/XspfProtocolAdapter.kt
+++ b/app/src/main/java/com/parachord/android/playlist/XspfProtocolAdapter.kt
@@ -1,0 +1,40 @@
+package com.parachord.android.playlist
+
+import com.parachord.shared.deeplink.ParsedProtocolTracklist
+import com.parachord.shared.deeplink.ProtocolTrack
+
+/**
+ * Adapter that bridges the existing Android-side [XspfParser] (built on
+ * `android.util.Xml`) into the shared [com.parachord.shared.deeplink.parseProtocolTracklist]
+ * via the `parseXspfPlatform` lambda parameter.
+ *
+ * Lives here (in `app/playlist`) instead of in `shared` because Android's
+ * `XmlPullParser` is not available in commonMain. The shared parser
+ * dispatches by content prefix; for XSPF input it calls into this
+ * adapter (wired via Koin in `AndroidModule`) to get back a
+ * [ParsedProtocolTracklist].
+ *
+ * Mapping:
+ * - `XspfPlaylist.title` → [ParsedProtocolTracklist.title]
+ * - `XspfPlaylist.creator` → [ParsedProtocolTracklist.creator]
+ * - `TrackEntity.{title,artist,album}` → [ProtocolTrack.{title,artist,album}]
+ *
+ * The XSPF parser doesn't currently extract MBID / ISRC (they're not in
+ * the existing TrackEntity output), so [ProtocolTrack.mbid] /
+ * [ProtocolTrack.isrc] are always null on the XSPF path. Non-XSPF
+ * formats (JSPF / generic JSON) still surface them via shared parser.
+ */
+fun parseXspfForProtocol(xspfContent: String): ParsedProtocolTracklist {
+    val parsed = XspfParser.parse(xspfContent)
+    return ParsedProtocolTracklist(
+        title = parsed.title,
+        creator = parsed.creator,
+        tracks = parsed.tracks.map {
+            ProtocolTrack(
+                artist = it.artist,
+                title = it.title,
+                album = it.album,
+            )
+        },
+    )
+}

--- a/shared/build.gradle.kts
+++ b/shared/build.gradle.kts
@@ -45,6 +45,8 @@ kotlin {
         commonTest.dependencies {
             implementation(kotlin("test"))
             implementation(libs.ktor.client.mock)
+            // For runTest in suspend-function tests (e.g. ProtocolInputResolverTest).
+            implementation(libs.kotlinx.coroutines.test)
         }
         androidMain.dependencies {
             implementation(libs.ktor.client.okhttp)

--- a/shared/src/commonMain/kotlin/com/parachord/shared/deeplink/Base64Json.kt
+++ b/shared/src/commonMain/kotlin/com/parachord/shared/deeplink/Base64Json.kt
@@ -1,0 +1,54 @@
+package com.parachord.shared.deeplink
+
+import kotlin.io.encoding.Base64
+import kotlin.io.encoding.ExperimentalEncodingApi
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonElement
+
+/**
+ * Shared `Json` configured for protocol payload parsing.
+ *
+ * - `ignoreUnknownKeys = true` — desktop emits forward-compatible payloads
+ *   that may add fields older Android builds don't know about; never fail
+ *   parsing on unrecognized keys.
+ * - `isLenient = false` — strict on the structural shape; we want a clean
+ *   error rather than a silent misinterpretation.
+ */
+internal val ProtocolJson: Json = Json {
+    ignoreUnknownKeys = true
+    isLenient = false
+}
+
+/**
+ * Decode a UTF-8 base64-encoded JSON payload into a [JsonElement].
+ *
+ * **The naive `String(Base64.decode(payload))` mangles UTF-8** — em
+ * dashes (`U+2014`), curly quotes (`U+2019`), Cyrillic, CJK, etc. all
+ * lose the multi-byte sequence when the platform default charset is not
+ * UTF-8 (Kotlin/Native and some JVMs default to platform-locale).
+ * Always go through [ByteArray.decodeToString], which is contractually
+ * UTF-8 on every Kotlin platform.
+ *
+ * Used by Phase 2's `play/playlist` and Phase 3's `play/radio` /
+ * `listen-along` commands to ingest the `tracks=` and `pool=` query
+ * parameters.
+ *
+ * Throws [IllegalArgumentException] on:
+ * - Invalid base64 payloads (delegated from [Base64.decode]).
+ * - Decoded bytes that aren't valid UTF-8.
+ * - Decoded text that isn't a parseable JSON value.
+ */
+@OptIn(ExperimentalEncodingApi::class)
+fun decodeBase64Utf8Json(payload: String): JsonElement {
+    val bytes = try {
+        Base64.decode(payload)
+    } catch (e: IllegalArgumentException) {
+        throw IllegalArgumentException("Invalid base64 payload", e)
+    }
+    val text = bytes.decodeToString()
+    return try {
+        ProtocolJson.parseToJsonElement(text)
+    } catch (e: Exception) {
+        throw IllegalArgumentException("Decoded payload is not valid JSON", e)
+    }
+}

--- a/shared/src/commonMain/kotlin/com/parachord/shared/deeplink/DeepLinkAction.kt
+++ b/shared/src/commonMain/kotlin/com/parachord/shared/deeplink/DeepLinkAction.kt
@@ -13,6 +13,43 @@ sealed class DeepLinkAction {
     data class Shuffle(val enabled: Boolean) : DeepLinkAction()
     data class Volume(val level: Int) : DeepLinkAction()
 
+    // ── Protocol play handlers (#119 / #120 / #121) ──
+    /** `parachord://play/album` — start playback of one resolved album. */
+    data class PlayAlbum(val input: ProtocolPlayInput) : DeepLinkAction()
+
+    /**
+     * `parachord://play/playlist` — start playback of a hosted or inline
+     * playlist. Optional [title] / [creator] are display hints only;
+     * [shuffle] toggles shuffle on the new context.
+     */
+    data class PlayPlaylist(
+        val input: ProtocolPlayInput,
+        val title: String? = null,
+        val creator: String? = null,
+        val shuffle: Boolean = false,
+    ) : DeepLinkAction()
+
+    /**
+     * `parachord://play/radio` — start a radio context. [refillUrl] is the
+     * URL the radio engine polls for fresh tracks (Mode A). [input]
+     * supplies the initial pool / seed; [mode] selects Mode B (artist seed)
+     * or Mode C (pool-based) for non-URL modes.
+     */
+    data class PlayRadio(
+        val mode: RadioMode,
+        val input: ProtocolPlayInput? = null,
+        val refillUrl: String? = null,
+        val name: String? = null,
+        val shuffle: Boolean = false,
+    ) : DeepLinkAction()
+
+    /**
+     * `parachord://listen-along` — mirror another user's now-playing.
+     * [service] is the scrobbler id (`listenbrainz` / `lastfm`); [user] is
+     * the platform username. Wired in Phase 3 (#121).
+     */
+    data class ListenAlong(val service: String, val user: String) : DeepLinkAction()
+
     // ── Navigation ──
     data object NavigateHome : DeepLinkAction()
     data class NavigateArtist(val name: String, val tab: String? = null) : DeepLinkAction()

--- a/shared/src/commonMain/kotlin/com/parachord/shared/deeplink/ProtocolInputResolver.kt
+++ b/shared/src/commonMain/kotlin/com/parachord/shared/deeplink/ProtocolInputResolver.kt
@@ -1,0 +1,110 @@
+package com.parachord.shared.deeplink
+
+/**
+ * Result of resolving a [ProtocolPlayInput] into something playable.
+ *
+ * - [displayName] — what to show in the now-playing card / toast (album
+ *   title for `play/album`, playlist title for `play/playlist`, station
+ *   name for `play/radio`).
+ * - [tracks] — non-empty list ready for queue insertion. Each track is
+ *   the on-the-wire `ProtocolTrack` shape; queue-build code is responsible
+ *   for stamping `id` / `sources` / `_playbackContext` per the per-track
+ *   tagging discipline (foundation item 8).
+ * - [albumArt] — optional cover URL surfaced from the resolved metadata.
+ */
+data class ResolvedProtocolPlay(
+    val displayName: String,
+    val tracks: List<ProtocolTrack>,
+    val albumArt: String? = null,
+)
+
+/**
+ * Per-command gating for [resolveProtocolPlayInput].
+ *
+ * Different verbs accept different subsets of identifier types:
+ *
+ * | Verb                          | mbid | provider | url | tracks | art+title |
+ * |-------------------------------|------|----------|-----|--------|-----------|
+ * | `play/album`                  |  ✓   |    ✓     |  ✗  |   ✗    |     ✗     |
+ * | `play/playlist`               |  ✗   |    ✓     |  ✓  |   ✓    |     ✗     |
+ * | `play/radio` (Mode B)         |  ✗   |    ✗     |  ✗  |   ✗    |     ✓     |
+ * | `play/radio` (Mode C)         |  ✗   |    ✗     |  ✗  |   ✓    |     ✗     |
+ *
+ * Disallowed inputs silently fall through to the next priority slot
+ * (rather than throwing) — an album MBID passed to `play/playlist`
+ * just isn't tried; if no other field works the resolver returns null
+ * and the caller surfaces "couldn't resolve" UX.
+ */
+data class ProtocolResolveOptions(
+    val allowMbid: Boolean = true,
+    val allowProviderId: Boolean = true,
+    val allowUrl: Boolean = true,
+    val allowTracks: Boolean = true,
+    val allowArtistTitleAlbum: Boolean = true,
+)
+
+/**
+ * Platform / dependency injection seam for the actual lookups.
+ *
+ * Phase 1 (this commit) defines the interface. Phase 2 wires concrete
+ * implementations against `MetadataService`, `SpotifyApi`,
+ * `AppleMusicLibraryClient`, and an HTTP client (for url-fetched
+ * tracklists). Wired through Koin in `AndroidModule`.
+ *
+ * Each method returns null when its identifier type can't be resolved;
+ * [resolveProtocolPlayInput] then falls through to the next priority
+ * slot. Throw only on hard errors (network 5xx, malformed payloads,
+ * SSRF guard rejection — see [validatePublicHttpsUrl]).
+ */
+interface ProtocolInputResolver {
+    suspend fun resolveByMbid(mbid: String): ResolvedProtocolPlay?
+    suspend fun resolveBySpotify(spotifyIdOrUri: String): ResolvedProtocolPlay?
+    suspend fun resolveByAppleMusic(appleMusicId: String): ResolvedProtocolPlay?
+    suspend fun resolveByUrl(url: String): ResolvedProtocolPlay?
+    suspend fun resolveByArtistTitle(artist: String, title: String?, album: String? = null): ResolvedProtocolPlay?
+}
+
+/**
+ * Walk a [ProtocolPlayInput] in priority order and return the first
+ * successful resolution.
+ *
+ * Priority (from desktop `protocol-schema.md` §3):
+ * `mbid → spotify → applemusic → url → tracks → artist+title`
+ *
+ * Each step is gated by the corresponding [ProtocolResolveOptions] flag;
+ * disallowed steps are skipped silently. Inline tracks (`input.tracks`)
+ * bypass [ProtocolInputResolver] entirely — they're already resolved
+ * and just need wrapping in a [ResolvedProtocolPlay] result.
+ *
+ * Returns null when the input has no identifiers the command can use
+ * AND no inline tracks. Caller surfaces "wrong input" / "couldn't
+ * resolve" toast.
+ */
+suspend fun resolveProtocolPlayInput(
+    input: ProtocolPlayInput,
+    opts: ProtocolResolveOptions,
+    resolver: ProtocolInputResolver,
+): ResolvedProtocolPlay? {
+    if (opts.allowMbid && input.mbid != null && isValidMbid(input.mbid.lowercase())) {
+        resolver.resolveByMbid(input.mbid.lowercase())?.let { return it }
+    }
+    if (opts.allowProviderId && !input.spotify.isNullOrBlank()) {
+        resolver.resolveBySpotify(input.spotify)?.let { return it }
+    }
+    if (opts.allowProviderId && !input.applemusic.isNullOrBlank()) {
+        resolver.resolveByAppleMusic(input.applemusic)?.let { return it }
+    }
+    if (opts.allowUrl && !input.url.isNullOrBlank()) {
+        resolver.resolveByUrl(input.url)?.let { return it }
+    }
+    if (opts.allowTracks && !input.tracks.isNullOrEmpty()) {
+        return ResolvedProtocolPlay(
+            displayName = input.title ?: "Untitled",
+            tracks = input.tracks,
+        )
+    }
+    if (opts.allowArtistTitleAlbum && !input.artist.isNullOrBlank()) {
+        resolver.resolveByArtistTitle(input.artist, input.title, /* album = */ null)?.let { return it }
+    }
+    return null
+}

--- a/shared/src/commonMain/kotlin/com/parachord/shared/deeplink/ProtocolPlayModels.kt
+++ b/shared/src/commonMain/kotlin/com/parachord/shared/deeplink/ProtocolPlayModels.kt
@@ -1,0 +1,91 @@
+package com.parachord.shared.deeplink
+
+/**
+ * Multi-source identifier bag for `parachord://play/...` commands.
+ *
+ * Mirrors desktop's `protocol-schema.md` — every play command accepts an
+ * input that may carry one or more of the following identifiers:
+ *
+ * - [mbid] — MusicBrainz UUID (recording / release / artist depending on
+ *   the verb). 36-char canonical form.
+ * - [spotify] — Spotify URI (`spotify:track:…`) or web URL.
+ * - [applemusic] — Apple Music ID (numeric for tracks/albums).
+ * - [url] — generic playlist URL (XSPF/JSPF/M3U/JSON tracklist hosted
+ *   anywhere — fetched + parsed via [ProtocolTracklistParser]).
+ * - [tracks] — inline tracklist (UTF-8 base64-encoded JSON in the wire
+ *   format; decoded into [ProtocolTrack] before this struct is built).
+ * - [artist] / [title] — last-resort textual identifier; only used by
+ *   commands that document acceptance of artist+title (e.g. radio Mode B).
+ *
+ * The resolver in `ProtocolInputResolver` walks these in priority order
+ * (`mbid → spotify → applemusic → url → tracks → artist+title`) and gates
+ * which fields are accepted per command via a small options struct.
+ *
+ * Album-only inputs (e.g. an album MBID passed to `play/playlist`) silently
+ * fall through for non-album commands; the resolver returns `null` and the
+ * caller surfaces a "wrong input" toast.
+ */
+data class ProtocolPlayInput(
+    val mbid: String? = null,
+    val spotify: String? = null,
+    val applemusic: String? = null,
+    val url: String? = null,
+    val tracks: List<ProtocolTrack>? = null,
+    val artist: String? = null,
+    val title: String? = null,
+)
+
+/**
+ * One track in an inline / parsed tracklist (XSPF / JSPF / generic JSON).
+ *
+ * The minimal viable shape on every track is `(artist, title)`. Optional
+ * MBIDs and ISRCs lift resolution quality (skip catalog search; route
+ * directly via the resolver pipeline). Album hints help disambiguate
+ * cover-of cases.
+ *
+ * Per-track `id`, `sources`, and `_playbackContext` tagging happens at
+ * queue-build time, NOT at parse time — this struct is the on-the-wire
+ * shape, not the runtime queue shape.
+ */
+data class ProtocolTrack(
+    val artist: String,
+    val title: String,
+    val album: String? = null,
+    val mbid: String? = null,
+    val isrc: String? = null,
+)
+
+/**
+ * Radio mode for `parachord://play/radio`.
+ *
+ * Mirrors desktop's three-mode model:
+ * - Mode A (URL-fed) — handled via `PlayRadio.refillUrl` + initial
+ *   `tracks` payload; no enum variant needed because the radio engine
+ *   just polls the URL on each refill.
+ * - [ArtistSeed] — Mode B. Server / client builds the queue from one
+ *   seed artist (and optional song hint); refills are computed from
+ *   the same seed.
+ * - [PoolBased] — Mode C. Initial pool of tracks supplied inline
+ *   (or via [ProtocolPlayInput.tracks]); subsequent refills draw from
+ *   that pool. No external seed.
+ */
+sealed class RadioMode {
+    /** Mode B — single seed artist (and optional song title hint). */
+    data class ArtistSeed(val artist: String, val title: String? = null) : RadioMode()
+
+    /** Mode C — initial pool fully supplied by the caller; no external seed. */
+    data object PoolBased : RadioMode()
+}
+
+/**
+ * Strict regex for MusicBrainz IDs in `urn:` / catalog-URL-style
+ * identifiers and bare-UUID payloads.
+ *
+ * Matches the canonical 8-4-4-4-12 lowercase hex form. Mirrors desktop's
+ * regex exactly; do NOT loosen to accept uppercase or strip dashes here
+ * — the resolver normalizes input before matching.
+ */
+val MBID_REGEX: Regex = Regex("^[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}$")
+
+/** True if [s] is a 36-char canonical lowercase MBID. */
+fun isValidMbid(s: String?): Boolean = s != null && MBID_REGEX.matches(s)

--- a/shared/src/commonMain/kotlin/com/parachord/shared/deeplink/ProtocolPlayTeardown.kt
+++ b/shared/src/commonMain/kotlin/com/parachord/shared/deeplink/ProtocolPlayTeardown.kt
@@ -1,0 +1,38 @@
+package com.parachord.shared.deeplink
+
+/**
+ * State teardown contract for protocol-driven playback transitions.
+ *
+ * Every `parachord://play/...` command that *replaces* the current
+ * context (album / playlist / radio) must call
+ * [prepareForNewPlayback] **before** building and submitting the new
+ * queue. Otherwise the cleanup that `PlaybackController.handlePlay`
+ * runs internally executes AFTER the new context is set, undoing the
+ * caller's work.
+ *
+ * **Order matters** (per desktop CLAUDE.md § "Android Parity Requirements"):
+ *
+ * 1. **Exit spinoff** (`PlaybackController.exitSpinoff()`).
+ *    Spinoff queues are derived state; if we leave them attached, the
+ *    new context inherits the old spinoff parent and refill behavior.
+ * 2. **Exit listen-along** (`MainViewModel.stopListenAlong()`).
+ *    The listen-along ticker keeps mirroring the followed user's track
+ *    changes; if we don't stop it before queue replacement, the next
+ *    poll tick reverts our newly-set track to whatever the followed
+ *    user is on.
+ * 3. **Clear the queue** (`QueueManager.clearQueue()`).
+ *    Wipes the prior context's tracks so the new ones aren't appended.
+ *
+ * Concrete implementation lives in `app/.../deeplink/AndroidProtocolPlayTeardown.kt`
+ * (wired via Koin); we only define the contract here so future iOS work
+ * has something to implement against.
+ */
+interface ProtocolPlayTeardown {
+    /**
+     * Run all three teardown steps **in order** (spinoff → listen-along
+     * → queue clear). Idempotent: safe to call when no spinoff,
+     * listen-along, or queue is active. Suspending so callers can wait
+     * for the queue clear to settle before submitting new tracks.
+     */
+    suspend fun prepareForNewPlayback()
+}

--- a/shared/src/commonMain/kotlin/com/parachord/shared/deeplink/ProtocolTracklistParser.kt
+++ b/shared/src/commonMain/kotlin/com/parachord/shared/deeplink/ProtocolTracklistParser.kt
@@ -1,0 +1,205 @@
+package com.parachord.shared.deeplink
+
+import kotlinx.serialization.json.JsonArray
+import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.contentOrNull
+import kotlinx.serialization.json.jsonArray
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+
+/**
+ * Inline tracks cap (per protocol-schema.md). 500 is desktop's value;
+ * exceeding it throws — caller surfaces "playlist too large" toast.
+ */
+const val MAX_INLINE_TRACKS: Int = 500
+
+/**
+ * Parsed shape returned by [parseProtocolTracklist].
+ *
+ * - [title] / [creator] are display hints; never required by the resolver.
+ * - [tracks] is non-empty (we throw if zero parseable tracks were found).
+ */
+data class ParsedProtocolTracklist(
+    val title: String?,
+    val creator: String?,
+    val tracks: List<ProtocolTrack>,
+)
+
+/**
+ * Looser 36-char hex+dash regex used for JSPF identifier MBID extraction.
+ *
+ * Mirrors desktop exactly. Looser than [MBID_REGEX] (which enforces the
+ * 8-4-4-4-12 canonical form) because some JSPF producers emit MBIDs in
+ * non-canonical UUID formats. We accept "looks like a UUID" here and let
+ * [isValidMbid] gate at the resolver if strict canonical form is needed.
+ */
+internal val JSPF_MBID_REGEX: Regex = Regex("^[a-f0-9-]{36}$", RegexOption.IGNORE_CASE)
+
+/**
+ * Auto-detects XSPF (XML) / JSPF (JSON, LB-style) / generic JSON
+ * tracklists and parses to [ParsedProtocolTracklist].
+ *
+ * Format detection (mirrors desktop):
+ * - Starts with `<` → XSPF — delegates to [parseXspfPlatform] (the
+ *   existing platform-specific XML parser; Android uses `XmlPullParser`,
+ *   iOS would use `NSXMLParser`).
+ * - Starts with `{` or `[` → JSON. Inspect for `playlist.track` (JSPF)
+ *   vs. `tracks` array (generic JSON).
+ *
+ * @param parseXspfPlatform lambda the platform module supplies to do
+ *   the actual XML parse. Wired through Koin in `AndroidModule.kt`.
+ *   Returns the playlist's tracks plus the playlist title/creator
+ *   (matching desktop's parser's return shape).
+ *
+ * @throws IllegalArgumentException on unrecognized format, empty
+ *   tracklist, or > [MAX_INLINE_TRACKS] tracks.
+ */
+fun parseProtocolTracklist(
+    content: String,
+    parseXspfPlatform: (String) -> ParsedProtocolTracklist,
+): ParsedProtocolTracklist {
+    val trimmed = content.trimStart()
+    val parsed = when {
+        trimmed.startsWith("<") -> parseXspfPlatform(content)
+        trimmed.startsWith("{") || trimmed.startsWith("[") -> parseJson(trimmed)
+        else -> throw IllegalArgumentException(
+            "Unrecognized tracklist format (expected XSPF / JSPF / JSON, got: ${trimmed.take(40)})"
+        )
+    }
+    if (parsed.tracks.isEmpty()) {
+        throw IllegalArgumentException("Tracklist contains no tracks")
+    }
+    if (parsed.tracks.size > MAX_INLINE_TRACKS) {
+        throw IllegalArgumentException("Tracklist exceeds $MAX_INLINE_TRACKS tracks")
+    }
+    return parsed
+}
+
+// ── JSON / JSPF parsing ───────────────────────────────────────────────
+
+private fun parseJson(content: String): ParsedProtocolTracklist {
+    val root: JsonElement = ProtocolJson.parseToJsonElement(content)
+
+    // LB lb-radio wrapper: unwrap parsed.payload?.jspf || parsed before
+    // looking for `playlist.track` (per desktop CLAUDE.md).
+    val unwrapped = (root as? JsonObject)
+        ?.get("payload")?.asJsonObjectOrNull()
+        ?.get("jspf")?.asJsonObjectOrNull()
+        ?: root
+
+    if (unwrapped is JsonObject) {
+        // JSPF form: { playlist: { title?, creator?, track: [...] } }
+        val playlist = unwrapped["playlist"]?.asJsonObjectOrNull()
+        if (playlist != null && playlist["track"] is JsonArray) {
+            return parseJspf(playlist)
+        }
+        // Generic JSON form: { title?, tracks: [{artist, title, album?, mbid?, isrc?}] }
+        val tracksArr = unwrapped["tracks"]?.asJsonArrayOrNull()
+        if (tracksArr != null) {
+            return ParsedProtocolTracklist(
+                title = unwrapped["title"]?.asStringOrNull(),
+                creator = unwrapped["creator"]?.asStringOrNull(),
+                tracks = tracksArr.mapNotNull { it.toGenericProtocolTrack() },
+            )
+        }
+    }
+    if (unwrapped is JsonArray) {
+        // Bare array form: [{artist, title, ...}, ...]
+        return ParsedProtocolTracklist(
+            title = null,
+            creator = null,
+            tracks = unwrapped.mapNotNull { it.toGenericProtocolTrack() },
+        )
+    }
+
+    throw IllegalArgumentException("JSON tracklist has no recognized shape (expected `playlist.track` (JSPF), `tracks` array, or bare array)")
+}
+
+private fun parseJspf(playlist: JsonObject): ParsedProtocolTracklist {
+    val title = playlist["title"]?.asStringOrNull()
+    val creator = playlist["creator"]?.asStringOrNull()
+    val tracks = playlist["track"]!!.jsonArray.mapNotNull { it.toJspfProtocolTrack() }
+    return ParsedProtocolTracklist(title, creator, tracks)
+}
+
+// ── Per-track decoders ────────────────────────────────────────────────
+
+private fun JsonElement.toGenericProtocolTrack(): ProtocolTrack? {
+    val obj = this as? JsonObject ?: return null
+    val artist = obj["artist"]?.asStringOrNull() ?: return null
+    val title = obj["title"]?.asStringOrNull() ?: return null
+    return ProtocolTrack(
+        artist = artist,
+        title = title,
+        album = obj["album"]?.asStringOrNull(),
+        mbid = obj["mbid"]?.asStringOrNull()?.takeIf { isValidMbid(it.lowercase()) },
+        isrc = obj["isrc"]?.asStringOrNull(),
+    )
+}
+
+private fun JsonElement.toJspfProtocolTrack(): ProtocolTrack? {
+    val obj = this as? JsonObject ?: return null
+
+    // Title: required.
+    val title = obj["title"]?.asStringOrNull() ?: return null
+
+    // Creator can be a string or an array (some producers emit arrays);
+    // join arrays with ", " per desktop.
+    val creator: String = when (val c = obj["creator"]) {
+        is JsonPrimitive -> c.contentOrNull
+        is JsonArray -> c.mapNotNull { it.asStringOrNull() }.joinToString(", ").ifEmpty { null }
+        else -> null
+    } ?: return null
+
+    val album = obj["album"]?.asStringOrNull()
+
+    // MBID: identifier may be a string or an array of strings. Look for
+    // either bare 36-char UUIDs or `musicbrainz.org/(recording|track)/<uuid>`.
+    val mbidCandidates: List<String> = when (val ident = obj["identifier"]) {
+        is JsonPrimitive -> listOfNotNull(ident.contentOrNull)
+        is JsonArray -> ident.mapNotNull { it.asStringOrNull() }
+        else -> emptyList()
+    }
+    val mbid = mbidCandidates.firstNotNullOfOrNull { extractMbid(it) }
+
+    // ISRC: some JSPFs put it under `extension.isrc` or top-level `isrc`.
+    val isrc = obj["isrc"]?.asStringOrNull()
+        ?: obj["extension"]?.asJsonObjectOrNull()?.get("isrc")?.asStringOrNull()
+
+    return ProtocolTrack(
+        artist = creator,
+        title = title,
+        album = album,
+        mbid = mbid,
+        isrc = isrc,
+    )
+}
+
+/**
+ * Extract a 36-char UUID-shaped MBID from a JSPF identifier.
+ *
+ * Accepts:
+ * - Bare UUID: `c70a2d8f-c1b7-4f10-9d10-95158a08b528`
+ * - URL forms: `https://musicbrainz.org/recording/<uuid>`,
+ *              `https://musicbrainz.org/track/<uuid>`
+ *
+ * Returns the lowercase UUID if matched, else null.
+ */
+private fun extractMbid(identifier: String): String? {
+    val trimmed = identifier.trim()
+    if (JSPF_MBID_REGEX.matches(trimmed)) return trimmed.lowercase()
+    val mbUrl = Regex(
+        "musicbrainz\\.org/(?:recording|track)/([a-f0-9-]{36})",
+        RegexOption.IGNORE_CASE,
+    )
+    return mbUrl.find(trimmed)?.groupValues?.get(1)?.lowercase()
+}
+
+// ── Tiny JsonElement helpers ──────────────────────────────────────────
+
+private fun JsonElement.asJsonObjectOrNull(): JsonObject? = this as? JsonObject
+private fun JsonElement.asJsonArrayOrNull(): JsonArray? = this as? JsonArray
+private fun JsonElement.asStringOrNull(): String? =
+    (this as? JsonPrimitive)?.contentOrNull

--- a/shared/src/commonMain/kotlin/com/parachord/shared/deeplink/PublicHttpsUrl.kt
+++ b/shared/src/commonMain/kotlin/com/parachord/shared/deeplink/PublicHttpsUrl.kt
@@ -1,0 +1,192 @@
+package com.parachord.shared.deeplink
+
+/**
+ * SSRF guard for protocol-fetched URLs (Phase 2 `play/playlist?url=`,
+ * Phase 3 `play/radio?refillUrl=`, etc.).
+ *
+ * Mirrors desktop's `isPublicHttpUrl` exactly. Rejects:
+ *
+ * - **Non-HTTPS schemes** — only `https://` is allowed. (XSPF / JSPF /
+ *   JSON tracklists must be served over TLS; we do not fetch `http://`
+ *   even when the host is otherwise public.)
+ * - **Loopback / private / link-local IPv4** — `0.0.0.0/8`, `10/8`,
+ *   `127/8`, `169.254/16` (link-local + AWS metadata `169.254.169.254`),
+ *   `172.16/12`, `192.168/16`.
+ * - **CGNAT** — `100.64.0.0/10` (covers Tailscale + ISP CGNAT).
+ *   *(Missing in `XspfHashing.validateXspfUrl`; covered here.)*
+ * - **Loopback / private / link-local IPv6** — `::1`, `fc00::/7`
+ *   (unique-local), `fe80::/10` (link-local).
+ * - **IPv4-mapped IPv6** — `::ffff:0:0/96`. An attacker can otherwise
+ *   reach `127.0.0.1` via `[::ffff:127.0.0.1]`.
+ *   *(Missing in `XspfHashing.validateXspfUrl`; covered here.)*
+ * - **Localhost name forms** — `localhost`, `localhost.`, `*.local`,
+ *   `*.local.` (mDNS).
+ * - **Decimal-int / octal IPv4 forms** — `http://2130706433/`,
+ *   `http://0177.0.0.1/`. We reject any host that isn't either a
+ *   resolvable DNS name or a canonical dotted-quad / `[bracketed]` IPv6.
+ *
+ * **What this does NOT defend against** (matches desktop's caveat):
+ * - **DNS rebinding.** A resolvable hostname that returns a public IP
+ *   on lookup but a private IP on subsequent fetch (or post-redirect)
+ *   slips through. The defense is socket-level post-resolution checking,
+ *   which neither Ktor nor OkHttp expose portably across KMP. Document
+ *   this; revisit if/when the threat becomes relevant.
+ * - **3xx redirects to private addresses.** Callers must use
+ *   `redirect: manual` (or `followRedirects(false)` on OkHttp) and
+ *   re-validate the `Location` header through this function.
+ *
+ * @throws IllegalArgumentException with a user-readable message on
+ *   any rejection. Caller is expected to convert this to a toast or
+ *   silent fallback per command's UX policy.
+ */
+fun validatePublicHttpsUrl(url: String) {
+    val parsed = parseSimpleUrl(url)
+        ?: throw IllegalArgumentException("Invalid URL: $url")
+
+    if (parsed.scheme != "https") {
+        throw IllegalArgumentException("URL must use https:// (got ${parsed.scheme})")
+    }
+    val rawHost = parsed.host
+    if (rawHost.isBlank()) {
+        throw IllegalArgumentException("URL is missing a host")
+    }
+
+    // Strip optional trailing dot (`example.com.`) before classification —
+    // it changes the textual host but is functionally identical for resolution.
+    val host = rawHost.lowercase().trimEnd('.')
+    if (isLocalNameForm(host)) {
+        throw IllegalArgumentException("URL targets a local hostname: $rawHost")
+    }
+    if (isPrivateIpv4(host)) {
+        throw IllegalArgumentException("URL targets a private / loopback IPv4 address: $rawHost")
+    }
+    if (isPrivateIpv6(rawHost)) {
+        throw IllegalArgumentException("URL targets a private / loopback IPv6 address: $rawHost")
+    }
+}
+
+// ── Internal helpers ──────────────────────────────────────────────────
+
+/** Minimal `scheme://host[:port]/path` extractor. KMP-clean (no OkHttp). */
+internal data class SimpleUrl(val scheme: String, val host: String)
+
+internal fun parseSimpleUrl(url: String): SimpleUrl? {
+    val schemeEnd = url.indexOf("://")
+    if (schemeEnd <= 0) return null
+    val scheme = url.substring(0, schemeEnd).lowercase()
+    val rest = url.substring(schemeEnd + 3)
+    if (rest.isEmpty()) return null
+
+    // Authority ends at the first `/`, `?`, or `#`.
+    val authorityEnd = rest.indexOfFirst { it == '/' || it == '?' || it == '#' }
+        .let { if (it < 0) rest.length else it }
+    val authority = rest.substring(0, authorityEnd)
+    if (authority.isEmpty()) return null
+
+    // Strip optional userinfo (`user:pass@host`).
+    val hostStart = authority.indexOf('@').let { if (it < 0) 0 else it + 1 }
+    val hostAndPort = authority.substring(hostStart)
+
+    // IPv6 literal: `[::1]:port` — bracketed.
+    val host = if (hostAndPort.startsWith("[")) {
+        val close = hostAndPort.indexOf(']')
+        if (close < 0) return null
+        hostAndPort.substring(0, close + 1)  // keep brackets for downstream
+    } else {
+        hostAndPort.substringBefore(':')
+    }
+    if (host.isEmpty()) return null
+    return SimpleUrl(scheme, host)
+}
+
+internal fun isLocalNameForm(host: String): Boolean {
+    if (host == "localhost") return true
+    if (host == "ip6-localhost" || host == "ip6-loopback") return true
+    if (host.endsWith(".local")) return true
+    return false
+}
+
+/**
+ * True if [host] is a canonical dotted-quad IPv4 in a private / reserved
+ * range. Returns true for any *malformed* dotted-quad to fail closed
+ * (e.g. `999.999.999.999`, `0177.0.0.1`).
+ *
+ * Decimal-integer hosts (`http://2130706433/` → 127.0.0.1) and
+ * non-canonical octal forms (`http://0177.0.0.1/`) are NOT canonical
+ * IPv4 in this regex sense, but they're also not legal DNS names — most
+ * DNS resolvers reject leading digits or non-letter chars in segments,
+ * so they fail the implicit "must be resolvable" gate. We don't try to
+ * canonicalize them here; we just refuse anything that looks like an
+ * IP-but-not-quite. Specifically, a host of all-digits (`2130706433`)
+ * is rejected as malformed quad.
+ */
+internal fun isPrivateIpv4(host: String): Boolean {
+    // All-digits "host" — single-integer IPv4 form (e.g. 2130706433).
+    if (host.all { it.isDigit() }) return true
+
+    val parts = host.split('.')
+    if (parts.size != 4) return false
+    val octets = IntArray(4)
+    for (i in 0..3) {
+        val p = parts[i]
+        // Reject leading-zero non-canonical forms (`0177` octal would map
+        // to 127 if we honored it; we just reject leading-zero non-empty).
+        if (p.isEmpty()) return true
+        if (p.length > 1 && p[0] == '0') return true
+        val n = p.toIntOrNull() ?: return true
+        if (n < 0 || n > 255) return true
+        octets[i] = n
+    }
+    val (a, b, _, _) = octets
+    return a == 0 ||
+        a == 10 ||
+        a == 127 ||
+        (a == 100 && b in 64..127) ||      // 100.64.0.0/10 — CGNAT
+        (a == 169 && b == 254) ||
+        (a == 172 && b in 16..31) ||
+        (a == 192 && b == 168)
+}
+
+/**
+ * True if [host] is a private / loopback / link-local IPv6 (or
+ * IPv4-mapped IPv6 covering an IPv4 private range).
+ *
+ * Accepts both bracketed (`[::1]`) and bare (`::1`) forms — RFC 3986
+ * URI syntax requires brackets in URL authority position, but callers
+ * sometimes pass unbracketed.
+ */
+internal fun isPrivateIpv6(host: String): Boolean {
+    val stripped = host.removePrefix("[").removeSuffix("]").lowercase()
+    if (!stripped.contains(':')) return false  // not IPv6 at all
+    if (stripped == "::1") return true
+    if (stripped.startsWith("fe80:") || stripped == "fe80::" || stripped.startsWith("fe8")) {
+        // fe80::/10 — link-local. Match fe80, fe81–febf prefix.
+        val firstWord = stripped.substringBefore(':')
+        val n = firstWord.toIntOrNull(16) ?: return false
+        if (n in 0xfe80..0xfebf) return true
+    }
+    if (stripped.startsWith("fc") || stripped.startsWith("fd")) {
+        // fc00::/7 — unique-local.
+        val firstWord = stripped.substringBefore(':')
+        val n = firstWord.toIntOrNull(16) ?: return false
+        if (n in 0xfc00..0xfdff) return true
+    }
+    // IPv4-mapped IPv6: ::ffff:a.b.c.d (recommended) or ::ffff:HHHH:HHHH.
+    if (stripped.startsWith("::ffff:") || stripped.startsWith("0:0:0:0:0:ffff:")) {
+        val v4Part = stripped.substringAfterLast(':').takeIf { it.contains('.') }
+        if (v4Part != null && isPrivateIpv4(v4Part)) return true
+        // Hex form: ::ffff:7f00:0001 → 127.0.0.1. Convert.
+        val tail = stripped.removePrefix("::ffff:").removePrefix("0:0:0:0:0:ffff:")
+        val words = tail.split(':')
+        if (words.size == 2) {
+            val hi = words[0].toIntOrNull(16) ?: return false
+            val lo = words[1].toIntOrNull(16) ?: return false
+            val a = (hi ushr 8) and 0xff
+            val b = hi and 0xff
+            val c = (lo ushr 8) and 0xff
+            val d = lo and 0xff
+            return isPrivateIpv4("$a.$b.$c.$d")
+        }
+    }
+    return false
+}

--- a/shared/src/commonTest/kotlin/com/parachord/shared/deeplink/Base64JsonTest.kt
+++ b/shared/src/commonTest/kotlin/com/parachord/shared/deeplink/Base64JsonTest.kt
@@ -1,0 +1,87 @@
+package com.parachord.shared.deeplink
+
+import kotlin.io.encoding.Base64
+import kotlin.io.encoding.ExperimentalEncodingApi
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertTrue
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.contentOrNull
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+
+@OptIn(ExperimentalEncodingApi::class)
+class Base64JsonTest {
+
+    @Test
+    fun roundTrip_basicAscii() {
+        val payload = """{"title":"Hello","tracks":[]}"""
+        val encoded = Base64.encode(payload.encodeToByteArray())
+        val decoded = decodeBase64Utf8Json(encoded) as JsonObject
+        assertEquals("Hello", decoded["title"]!!.jsonPrimitive.contentOrNull)
+    }
+
+    @Test
+    fun roundTrip_emDash() {
+        // U+2014 — three bytes in UTF-8 (E2 80 94). Any decoder using
+        // platform-default charset on Latin-1 systems mangles this.
+        val payload = """{"title":"Side A — Side B"}"""
+        val encoded = Base64.encode(payload.encodeToByteArray())
+        val decoded = decodeBase64Utf8Json(encoded) as JsonObject
+        assertEquals("Side A — Side B", decoded["title"]!!.jsonPrimitive.contentOrNull)
+    }
+
+    @Test
+    fun roundTrip_curlyApostrophe() {
+        // U+2019 — common in titles ("Don't" → "Don't"). E2 80 99.
+        val payload = """{"title":"Don’t Stop"}"""
+        val encoded = Base64.encode(payload.encodeToByteArray())
+        val decoded = decodeBase64Utf8Json(encoded) as JsonObject
+        assertEquals("Don’t Stop", decoded["title"]!!.jsonPrimitive.contentOrNull)
+    }
+
+    @Test
+    fun roundTrip_cyrillic() {
+        val payload = """{"artist":"Кино","title":"Пачка сигарет"}"""
+        val encoded = Base64.encode(payload.encodeToByteArray())
+        val decoded = decodeBase64Utf8Json(encoded) as JsonObject
+        assertEquals("Кино", decoded["artist"]!!.jsonPrimitive.contentOrNull)
+        assertEquals("Пачка сигарет", decoded["title"]!!.jsonPrimitive.contentOrNull)
+    }
+
+    @Test
+    fun roundTrip_cjk() {
+        // 4-byte UTF-8 sequences for Han characters.
+        val payload = """{"artist":"中島美嘉","title":"雪の華"}"""
+        val encoded = Base64.encode(payload.encodeToByteArray())
+        val decoded = decodeBase64Utf8Json(encoded) as JsonObject
+        assertEquals("中島美嘉", decoded["artist"]!!.jsonPrimitive.contentOrNull)
+        assertEquals("雪の華", decoded["title"]!!.jsonPrimitive.contentOrNull)
+    }
+
+    @Test
+    fun roundTrip_emoji() {
+        // Astral plane: U+1F3B5 musical note (4 bytes UTF-8).
+        val payload = """{"title":"🎵 Hot Tracks"}"""
+        val encoded = Base64.encode(payload.encodeToByteArray())
+        val decoded = decodeBase64Utf8Json(encoded) as JsonObject
+        assertEquals("🎵 Hot Tracks", decoded["title"]!!.jsonPrimitive.contentOrNull)
+    }
+
+    @Test
+    fun rejectsInvalidBase64() {
+        assertFailsWith<IllegalArgumentException> {
+            decodeBase64Utf8Json("!!!not valid base64!!!")
+        }
+    }
+
+    @Test
+    fun rejectsInvalidJson() {
+        val notJson = Base64.encode("this is not json".encodeToByteArray())
+        assertFailsWith<IllegalArgumentException> {
+            decodeBase64Utf8Json(notJson)
+        }
+    }
+}

--- a/shared/src/commonTest/kotlin/com/parachord/shared/deeplink/MbidRegexTest.kt
+++ b/shared/src/commonTest/kotlin/com/parachord/shared/deeplink/MbidRegexTest.kt
@@ -1,0 +1,51 @@
+package com.parachord.shared.deeplink
+
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class MbidRegexTest {
+    private val canonical = "c70a2d8f-c1b7-4f10-9d10-95158a08b528"
+
+    @Test
+    fun acceptsCanonicalLowercaseUuid() {
+        assertTrue(isValidMbid(canonical))
+    }
+
+    @Test
+    fun rejectsUppercase() {
+        // Strict regex is lowercase-only. Callers pre-normalize via .lowercase()
+        // before invoking the resolver, so uppercase here is a real bug.
+        assertFalse(isValidMbid(canonical.uppercase()))
+    }
+
+    @Test
+    fun rejectsMissingDashes() {
+        assertFalse(isValidMbid(canonical.replace("-", "")))
+    }
+
+    @Test
+    fun rejectsTooShort() {
+        assertFalse(isValidMbid(canonical.dropLast(1)))
+    }
+
+    @Test
+    fun rejectsTooLong() {
+        assertFalse(isValidMbid(canonical + "0"))
+    }
+
+    @Test
+    fun rejectsNonHexChars() {
+        assertFalse(isValidMbid("z70a2d8f-c1b7-4f10-9d10-95158a08b528"))
+    }
+
+    @Test
+    fun rejectsNull() {
+        assertFalse(isValidMbid(null))
+    }
+
+    @Test
+    fun rejectsEmpty() {
+        assertFalse(isValidMbid(""))
+    }
+}

--- a/shared/src/commonTest/kotlin/com/parachord/shared/deeplink/ProtocolInputResolverTest.kt
+++ b/shared/src/commonTest/kotlin/com/parachord/shared/deeplink/ProtocolInputResolverTest.kt
@@ -1,0 +1,151 @@
+package com.parachord.shared.deeplink
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+import kotlinx.coroutines.test.runTest
+
+/**
+ * Recording resolver — captures which methods get called in which order
+ * and returns scripted results.
+ */
+private class RecordingResolver(
+    var mbidResult: ResolvedProtocolPlay? = null,
+    var spotifyResult: ResolvedProtocolPlay? = null,
+    var appleMusicResult: ResolvedProtocolPlay? = null,
+    var urlResult: ResolvedProtocolPlay? = null,
+    var artistTitleResult: ResolvedProtocolPlay? = null,
+) : ProtocolInputResolver {
+    val calls = mutableListOf<String>()
+    override suspend fun resolveByMbid(mbid: String): ResolvedProtocolPlay? { calls += "mbid($mbid)"; return mbidResult }
+    override suspend fun resolveBySpotify(spotifyIdOrUri: String): ResolvedProtocolPlay? { calls += "spotify($spotifyIdOrUri)"; return spotifyResult }
+    override suspend fun resolveByAppleMusic(appleMusicId: String): ResolvedProtocolPlay? { calls += "applemusic($appleMusicId)"; return appleMusicResult }
+    override suspend fun resolveByUrl(url: String): ResolvedProtocolPlay? { calls += "url($url)"; return urlResult }
+    override suspend fun resolveByArtistTitle(artist: String, title: String?, album: String?): ResolvedProtocolPlay? { calls += "artistTitle($artist,$title)"; return artistTitleResult }
+}
+
+class ProtocolInputResolverTest {
+
+    private val ok = ResolvedProtocolPlay("ok", listOf(ProtocolTrack("A", "T")))
+    private val canonical = "c70a2d8f-c1b7-4f10-9d10-95158a08b528"
+
+    @Test
+    fun mbidWinsWhenAllAllowed() = runTest {
+        val r = RecordingResolver(mbidResult = ok, spotifyResult = ok, appleMusicResult = ok)
+        val input = ProtocolPlayInput(mbid = canonical, spotify = "spotify:album:abc", applemusic = "12345")
+        val out = resolveProtocolPlayInput(input, ProtocolResolveOptions(), r)
+        assertEquals(ok, out)
+        assertEquals(listOf("mbid($canonical)"), r.calls)
+    }
+
+    @Test
+    fun spotifyWinsAfterMbidFallthrough() = runTest {
+        val r = RecordingResolver(mbidResult = null, spotifyResult = ok, appleMusicResult = ok)
+        val input = ProtocolPlayInput(mbid = canonical, spotify = "spotify:album:abc", applemusic = "12345")
+        val out = resolveProtocolPlayInput(input, ProtocolResolveOptions(), r)
+        assertEquals(ok, out)
+        assertEquals(listOf("mbid($canonical)", "spotify(spotify:album:abc)"), r.calls)
+    }
+
+    @Test
+    fun appleMusicWinsAfterMbidAndSpotifyFallthrough() = runTest {
+        val r = RecordingResolver(appleMusicResult = ok)
+        val input = ProtocolPlayInput(mbid = canonical, spotify = "spotify:album:abc", applemusic = "12345")
+        val out = resolveProtocolPlayInput(input, ProtocolResolveOptions(), r)
+        assertEquals(ok, out)
+        assertEquals(listOf("mbid($canonical)", "spotify(spotify:album:abc)", "applemusic(12345)"), r.calls)
+    }
+
+    @Test
+    fun urlWinsBeforeTracksAndArtistTitle() = runTest {
+        val r = RecordingResolver(urlResult = ok)
+        val input = ProtocolPlayInput(
+            url = "https://example.com/x.xspf",
+            tracks = listOf(ProtocolTrack("A", "T")),
+            artist = "A",
+            title = "T",
+        )
+        val out = resolveProtocolPlayInput(input, ProtocolResolveOptions(), r)
+        assertEquals(ok, out)
+        assertEquals(listOf("url(https://example.com/x.xspf)"), r.calls)
+    }
+
+    @Test
+    fun inlineTracksWrappedDirectlyWithoutResolverCall() = runTest {
+        val r = RecordingResolver()
+        val tracks = listOf(ProtocolTrack("A", "T1"), ProtocolTrack("B", "T2"))
+        val input = ProtocolPlayInput(tracks = tracks, title = "Inline Mix")
+        val out = resolveProtocolPlayInput(input, ProtocolResolveOptions(), r)
+        assertEquals("Inline Mix", out!!.displayName)
+        assertEquals(2, out.tracks.size)
+        assertTrue(r.calls.isEmpty())  // resolver never called for inline tracks
+    }
+
+    @Test
+    fun artistTitleLastResort() = runTest {
+        val r = RecordingResolver(artistTitleResult = ok)
+        val input = ProtocolPlayInput(artist = "Witch Post", title = "Twin Fawn")
+        val out = resolveProtocolPlayInput(input, ProtocolResolveOptions(), r)
+        assertEquals(ok, out)
+        assertEquals(listOf("artistTitle(Witch Post,Twin Fawn)"), r.calls)
+    }
+
+    @Test
+    fun returnsNullWhenNothingResolves() = runTest {
+        val r = RecordingResolver()  // every method returns null
+        val input = ProtocolPlayInput(mbid = canonical, spotify = "x", applemusic = "y", artist = "A", title = "T")
+        val out = resolveProtocolPlayInput(input, ProtocolResolveOptions(), r)
+        assertNull(out)
+        // All slots tried (proves we walked the full priority chain).
+        assertEquals(4, r.calls.size)
+    }
+
+    // ── Per-command gating ──
+
+    @Test
+    fun gatedMbidIsSkippedSilently() = runTest {
+        // play/playlist disallows mbid; should fall through to spotify.
+        val r = RecordingResolver(spotifyResult = ok)
+        val input = ProtocolPlayInput(mbid = canonical, spotify = "spotify:playlist:xyz")
+        val opts = ProtocolResolveOptions(allowMbid = false)
+        val out = resolveProtocolPlayInput(input, opts, r)
+        assertEquals(ok, out)
+        assertEquals(listOf("spotify(spotify:playlist:xyz)"), r.calls)
+        assertFalse(r.calls.any { it.startsWith("mbid") })
+    }
+
+    @Test
+    fun gatedProviderIdSkipsBothSpotifyAndAppleMusic() = runTest {
+        // play/radio (Mode B) disallows providers but allows artist+title.
+        val r = RecordingResolver(artistTitleResult = ok)
+        val input = ProtocolPlayInput(spotify = "x", applemusic = "y", artist = "A", title = "T")
+        val opts = ProtocolResolveOptions(
+            allowMbid = false, allowProviderId = false, allowUrl = false, allowTracks = false,
+        )
+        val out = resolveProtocolPlayInput(input, opts, r)
+        assertEquals(ok, out)
+        assertEquals(listOf("artistTitle(A,T)"), r.calls)
+    }
+
+    @Test
+    fun rejectsMalformedMbidSilently() = runTest {
+        // MBID field present but doesn't pass strict validation — fall through.
+        val r = RecordingResolver(spotifyResult = ok)
+        val input = ProtocolPlayInput(mbid = "NOT-A-VALID-MBID", spotify = "spotify:album:abc")
+        val out = resolveProtocolPlayInput(input, ProtocolResolveOptions(), r)
+        assertEquals(ok, out)
+        assertFalse(r.calls.any { it.startsWith("mbid") })
+    }
+
+    @Test
+    fun acceptsUppercaseMbidViaLowercasedNormalization() = runTest {
+        val r = RecordingResolver(mbidResult = ok)
+        val input = ProtocolPlayInput(mbid = canonical.uppercase())
+        val out = resolveProtocolPlayInput(input, ProtocolResolveOptions(), r)
+        assertEquals(ok, out)
+        // Normalized to lowercase before passing to resolver.
+        assertEquals(listOf("mbid($canonical)"), r.calls)
+    }
+}

--- a/shared/src/commonTest/kotlin/com/parachord/shared/deeplink/ProtocolTracklistParserTest.kt
+++ b/shared/src/commonTest/kotlin/com/parachord/shared/deeplink/ProtocolTracklistParserTest.kt
@@ -1,0 +1,201 @@
+package com.parachord.shared.deeplink
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertNull
+
+class ProtocolTracklistParserTest {
+
+    /** Stub platform XSPF parser — returns whatever the test sets. */
+    private fun fakeXspf(result: ParsedProtocolTracklist): (String) -> ParsedProtocolTracklist =
+        { result }
+
+    /** Fail-loudly stub for tests that should never hit XSPF. */
+    private val noXspf: (String) -> ParsedProtocolTracklist = {
+        throw AssertionError("XSPF parser should not have been invoked")
+    }
+
+    // ── Format dispatch ──
+
+    @Test
+    fun dispatchesXmlPrefixToXspfLambda() {
+        val expected = ParsedProtocolTracklist(
+            title = "From Lambda",
+            creator = null,
+            tracks = listOf(ProtocolTrack("A", "T")),
+        )
+        val out = parseProtocolTracklist("<?xml version=\"1.0\"?><playlist/>", fakeXspf(expected))
+        assertEquals("From Lambda", out.title)
+    }
+
+    @Test
+    fun dispatchesXmlBareTagToXspfLambda() {
+        val expected = ParsedProtocolTracklist(null, null, listOf(ProtocolTrack("A", "T")))
+        val out = parseProtocolTracklist("<playlist/>", fakeXspf(expected))
+        assertEquals(1, out.tracks.size)
+    }
+
+    @Test
+    fun rejectsUnrecognizedFormat() {
+        assertFailsWith<IllegalArgumentException> {
+            parseProtocolTracklist("M3U raw text", noXspf)
+        }
+    }
+
+    // ── Generic JSON ──
+
+    @Test
+    fun parsesGenericJsonWithTopLevelTracks() {
+        val payload = """
+            {"title":"Mix",
+             "tracks":[
+               {"artist":"Witch Post","title":"Twin Fawn"},
+               {"artist":"Wintersleep","title":"Wishing Moon","album":"New Inheritors"}
+             ]}
+        """.trimIndent()
+        val out = parseProtocolTracklist(payload, noXspf)
+        assertEquals("Mix", out.title)
+        assertEquals(2, out.tracks.size)
+        assertEquals("Witch Post", out.tracks[0].artist)
+        assertEquals("Wishing Moon", out.tracks[1].title)
+        assertEquals("New Inheritors", out.tracks[1].album)
+    }
+
+    @Test
+    fun parsesGenericJsonBareArray() {
+        val payload = """[{"artist":"A","title":"T1"},{"artist":"B","title":"T2"}]"""
+        val out = parseProtocolTracklist(payload, noXspf)
+        assertNull(out.title)
+        assertEquals(2, out.tracks.size)
+    }
+
+    @Test
+    fun skipsGenericJsonTracksMissingArtist() {
+        val payload = """{"tracks":[{"artist":"OK","title":"OK"},{"title":"Missing artist"}]}"""
+        val out = parseProtocolTracklist(payload, noXspf)
+        assertEquals(1, out.tracks.size)
+        assertEquals("OK", out.tracks[0].artist)
+    }
+
+    // ── JSPF ──
+
+    @Test
+    fun parsesStandardJspf() {
+        val payload = """
+            {"playlist":{
+                "title":"My Mix",
+                "creator":"jesse",
+                "track":[
+                    {"title":"Twin Fawn","creator":"Witch Post","album":"Witch Post"},
+                    {"title":"Wishing Moon","creator":"Wintersleep"}
+                ]
+            }}
+        """.trimIndent()
+        val out = parseProtocolTracklist(payload, noXspf)
+        assertEquals("My Mix", out.title)
+        assertEquals("jesse", out.creator)
+        assertEquals(2, out.tracks.size)
+        assertEquals("Witch Post", out.tracks[0].artist)
+        assertEquals("Twin Fawn", out.tracks[0].title)
+        assertEquals("Witch Post", out.tracks[0].album)
+    }
+
+    @Test
+    fun unwrapsLbRadioWrapper() {
+        // ListenBrainz lb-radio API returns { payload: { jspf: { playlist: ... } } }
+        val payload = """
+            {"payload":{"jspf":{"playlist":{
+                "title":"LB Radio: Witch Post",
+                "track":[{"title":"Twin Fawn","creator":"Witch Post"}]
+            }}}}
+        """.trimIndent()
+        val out = parseProtocolTracklist(payload, noXspf)
+        assertEquals("LB Radio: Witch Post", out.title)
+        assertEquals(1, out.tracks.size)
+    }
+
+    @Test
+    fun joinsCreatorArrayWithComma() {
+        val payload = """
+            {"playlist":{"track":[{
+                "title":"Collab",
+                "creator":["Artist A","Artist B"]
+            }]}}
+        """.trimIndent()
+        val out = parseProtocolTracklist(payload, noXspf)
+        assertEquals("Artist A, Artist B", out.tracks[0].artist)
+    }
+
+    @Test
+    fun extractsMbidFromBareIdentifier() {
+        val mbid = "c70a2d8f-c1b7-4f10-9d10-95158a08b528"
+        val payload = """
+            {"playlist":{"track":[{
+                "title":"T","creator":"A",
+                "identifier":"$mbid"
+            }]}}
+        """.trimIndent()
+        val out = parseProtocolTracklist(payload, noXspf)
+        assertEquals(mbid, out.tracks[0].mbid)
+    }
+
+    @Test
+    fun extractsMbidFromMusicbrainzUrlIdentifier() {
+        val mbid = "c70a2d8f-c1b7-4f10-9d10-95158a08b528"
+        val payload = """
+            {"playlist":{"track":[{
+                "title":"T","creator":"A",
+                "identifier":"https://musicbrainz.org/recording/$mbid"
+            }]}}
+        """.trimIndent()
+        val out = parseProtocolTracklist(payload, noXspf)
+        assertEquals(mbid, out.tracks[0].mbid)
+    }
+
+    @Test
+    fun extractsMbidFromIdentifierArray() {
+        val mbid = "c70a2d8f-c1b7-4f10-9d10-95158a08b528"
+        val payload = """
+            {"playlist":{"track":[{
+                "title":"T","creator":"A",
+                "identifier":["spotify:track:foo","https://musicbrainz.org/recording/$mbid"]
+            }]}}
+        """.trimIndent()
+        val out = parseProtocolTracklist(payload, noXspf)
+        assertEquals(mbid, out.tracks[0].mbid)
+    }
+
+    @Test
+    fun extractsIsrcFromExtension() {
+        val payload = """
+            {"playlist":{"track":[{
+                "title":"T","creator":"A",
+                "extension":{"isrc":"USRC17607839"}
+            }]}}
+        """.trimIndent()
+        val out = parseProtocolTracklist(payload, noXspf)
+        assertEquals("USRC17607839", out.tracks[0].isrc)
+    }
+
+    // ── Limits ──
+
+    @Test
+    fun rejectsEmptyTracklist() {
+        val payload = """{"tracks":[]}"""
+        assertFailsWith<IllegalArgumentException> {
+            parseProtocolTracklist(payload, noXspf)
+        }
+    }
+
+    @Test
+    fun rejectsOversizeTracklist() {
+        val tracks = (1..MAX_INLINE_TRACKS + 1).joinToString(",") {
+            """{"artist":"A$it","title":"T$it"}"""
+        }
+        val payload = """{"tracks":[$tracks]}"""
+        assertFailsWith<IllegalArgumentException> {
+            parseProtocolTracklist(payload, noXspf)
+        }
+    }
+}

--- a/shared/src/commonTest/kotlin/com/parachord/shared/deeplink/PublicHttpsUrlTest.kt
+++ b/shared/src/commonTest/kotlin/com/parachord/shared/deeplink/PublicHttpsUrlTest.kt
@@ -1,0 +1,192 @@
+package com.parachord.shared.deeplink
+
+import kotlin.test.Test
+import kotlin.test.assertFailsWith
+
+class PublicHttpsUrlTest {
+
+    // ── Acceptance: real public URLs ──
+
+    @Test
+    fun accepts_publicHttpsHost() {
+        validatePublicHttpsUrl("https://example.com/playlist.xspf")
+    }
+
+    @Test
+    fun accepts_publicIpv4() {
+        validatePublicHttpsUrl("https://1.2.3.4/x")
+    }
+
+    @Test
+    fun accepts_172_15_x() {
+        // 172.15 is just below the 172.16-31 private block.
+        validatePublicHttpsUrl("https://172.15.0.1/x")
+    }
+
+    @Test
+    fun accepts_172_32_x() {
+        // 172.32 is just above the 172.16-31 private block.
+        validatePublicHttpsUrl("https://172.32.0.1/x")
+    }
+
+    @Test
+    fun accepts_publicCgnatBoundary_100_63() {
+        // 100.63.x.x is just below the 100.64-127 CGNAT block.
+        validatePublicHttpsUrl("https://100.63.255.255/x")
+    }
+
+    @Test
+    fun accepts_publicCgnatBoundary_100_128() {
+        // 100.128.x.x is just above the 100.64-127 CGNAT block.
+        validatePublicHttpsUrl("https://100.128.0.0/x")
+    }
+
+    @Test
+    fun accepts_urlWithUserinfo() {
+        validatePublicHttpsUrl("https://user:pass@example.com/x")
+    }
+
+    @Test
+    fun accepts_urlWithPortAndQuery() {
+        validatePublicHttpsUrl("https://example.com:8443/x?foo=bar")
+    }
+
+    // ── Rejection: scheme ──
+
+    @Test
+    fun rejects_httpScheme() {
+        assertFailsWith<IllegalArgumentException> {
+            validatePublicHttpsUrl("http://example.com/x")
+        }
+    }
+
+    @Test
+    fun rejects_fileScheme() {
+        assertFailsWith<IllegalArgumentException> {
+            validatePublicHttpsUrl("file:///etc/passwd")
+        }
+    }
+
+    // ── Rejection: localhost / private IPv4 ──
+
+    @Test
+    fun rejects_localhost() {
+        assertFailsWith<IllegalArgumentException> { validatePublicHttpsUrl("https://localhost/x") }
+    }
+
+    @Test
+    fun rejects_localhostTrailingDot() {
+        assertFailsWith<IllegalArgumentException> { validatePublicHttpsUrl("https://localhost./x") }
+    }
+
+    @Test
+    fun rejects_dotLocal() {
+        assertFailsWith<IllegalArgumentException> { validatePublicHttpsUrl("https://evil.local/x") }
+    }
+
+    @Test
+    fun rejects_dotLocalTrailingDot() {
+        assertFailsWith<IllegalArgumentException> { validatePublicHttpsUrl("https://evil.local./x") }
+    }
+
+    @Test
+    fun rejects_127_0_0_1() {
+        assertFailsWith<IllegalArgumentException> { validatePublicHttpsUrl("https://127.0.0.1/x") }
+    }
+
+    @Test
+    fun rejects_10_x() {
+        assertFailsWith<IllegalArgumentException> { validatePublicHttpsUrl("https://10.0.0.1/x") }
+    }
+
+    @Test
+    fun rejects_192_168_x() {
+        assertFailsWith<IllegalArgumentException> { validatePublicHttpsUrl("https://192.168.1.1/x") }
+    }
+
+    @Test
+    fun rejects_172_16_x() {
+        assertFailsWith<IllegalArgumentException> { validatePublicHttpsUrl("https://172.16.0.1/x") }
+    }
+
+    @Test
+    fun rejects_172_31_x() {
+        assertFailsWith<IllegalArgumentException> { validatePublicHttpsUrl("https://172.31.255.255/x") }
+    }
+
+    @Test
+    fun rejects_169_254_x() {
+        // Link-local — covers AWS metadata 169.254.169.254.
+        assertFailsWith<IllegalArgumentException> { validatePublicHttpsUrl("https://169.254.169.254/latest") }
+    }
+
+    @Test
+    fun rejects_0_0_0_0() {
+        assertFailsWith<IllegalArgumentException> { validatePublicHttpsUrl("https://0.0.0.0/x") }
+    }
+
+    // ── Rejection: CGNAT ──
+
+    @Test
+    fun rejects_cgnat_100_64() {
+        assertFailsWith<IllegalArgumentException> { validatePublicHttpsUrl("https://100.64.1.1/x") }
+    }
+
+    @Test
+    fun rejects_cgnat_100_127() {
+        assertFailsWith<IllegalArgumentException> { validatePublicHttpsUrl("https://100.127.255.255/x") }
+    }
+
+    // ── Rejection: IPv6 ──
+
+    @Test
+    fun rejects_ipv6_loopback() {
+        assertFailsWith<IllegalArgumentException> { validatePublicHttpsUrl("https://[::1]/x") }
+    }
+
+    @Test
+    fun rejects_ipv6_uniqueLocal_fc() {
+        assertFailsWith<IllegalArgumentException> { validatePublicHttpsUrl("https://[fc00::1]/x") }
+    }
+
+    @Test
+    fun rejects_ipv6_uniqueLocal_fd() {
+        assertFailsWith<IllegalArgumentException> { validatePublicHttpsUrl("https://[fdff::1]/x") }
+    }
+
+    @Test
+    fun rejects_ipv6_linkLocal_fe80() {
+        assertFailsWith<IllegalArgumentException> { validatePublicHttpsUrl("https://[fe80::1]/x") }
+    }
+
+    @Test
+    fun rejects_ipv4MappedIpv6_dottedForm() {
+        // ::ffff:127.0.0.1 — text-format IPv4-mapped reaching loopback.
+        assertFailsWith<IllegalArgumentException> { validatePublicHttpsUrl("https://[::ffff:127.0.0.1]/x") }
+    }
+
+    @Test
+    fun rejects_ipv4MappedIpv6_hexForm() {
+        // ::ffff:7f00:1 — same address, hex words form.
+        assertFailsWith<IllegalArgumentException> { validatePublicHttpsUrl("https://[::ffff:7f00:1]/x") }
+    }
+
+    // ── Rejection: malformed / non-canonical IPv4 forms ──
+
+    @Test
+    fun rejects_singleIntegerIpv4() {
+        // 2130706433 = 127.0.0.1 in decimal-int form.
+        assertFailsWith<IllegalArgumentException> { validatePublicHttpsUrl("https://2130706433/x") }
+    }
+
+    @Test
+    fun rejects_octalIpv4() {
+        // 0177 = 127. We refuse leading-zero octets to fail closed.
+        assertFailsWith<IllegalArgumentException> { validatePublicHttpsUrl("https://0177.0.0.1/x") }
+    }
+
+    @Test
+    fun rejects_emptyHost() {
+        assertFailsWith<IllegalArgumentException> { validatePublicHttpsUrl("https:///path") }
+    }
+}


### PR DESCRIPTION
## Summary

Phase 1 of 3 for the `parachord://` protocol play surface. Foundation only — additive infrastructure, **zero behavior change**, no callers wired. Phases 2 (#120) and 3 (#121) layer commands on top.

All new code lives in `shared/commonMain/` (KMP-clean — no JVM-only APIs).

### What's new

| File | Role |
|---|---|
| `shared/.../deeplink/ProtocolPlayModels.kt` | `ProtocolPlayInput`, `ProtocolTrack`, `RadioMode` (`ArtistSeed` / `PoolBased`), `MBID_REGEX` + `isValidMbid` |
| `shared/.../deeplink/DeepLinkAction.kt` (modified) | New variants: `PlayAlbum`, `PlayPlaylist`, `PlayRadio`, `ListenAlong` |
| `shared/.../deeplink/Base64Json.kt` | `decodeBase64Utf8Json` — fixes UTF-8 mangling on Native / non-UTF-8-default JVMs (per desktop `87b1be4`) |
| `shared/.../deeplink/PublicHttpsUrl.kt` | `validatePublicHttpsUrl` — closes SSRF gaps in existing `XspfHashing.validateXspfUrl` (CGNAT 100.64/10, IPv4-mapped IPv6, decimal-int / leading-zero IPs, trailing-dot variants) |
| `shared/.../deeplink/ProtocolTracklistParser.kt` | Auto-detects XSPF / JSPF / generic JSON; XSPF dispatches to platform lambda (Android wires `XspfProtocolAdapter`) |
| `shared/.../deeplink/ProtocolInputResolver.kt` | `ProtocolInputResolver` interface + `resolveProtocolPlayInput` priority walker (mbid → spotify → applemusic → url → tracks → artist+title) |
| `shared/.../deeplink/ProtocolPlayTeardown.kt` | Interface documenting the spinoff → listen-along → queue-clear teardown order |

### Tests

74 new tests, 0 failures:

- `MbidRegexTest` (8) — strict canonical-form gate
- `Base64JsonTest` (8) — em dash, U+2019, Cyrillic, CJK, emoji round-trips
- `PublicHttpsUrlTest` (32) — full SSRF coverage including new CGNAT and IPv4-mapped IPv6 boundaries
- `ProtocolTracklistParserTest` (15) — XSPF lambda dispatch, JSPF + LB lb-radio wrapper, MBID extraction, creator-as-array, isrc fallback, limits
- `ProtocolInputResolverTest` (11) — full priority walk + per-command gating + MBID normalization

Pre-existing `MusicBrainzClientTest` failures (7) are unrelated — present on `main` before this branch.

### Out of scope (Phases 2 / 3)

- Wiring `PlayAlbum` / `PlayPlaylist` / `PlayRadio` / `ListenAlong` in `DeepLinkViewModel.executeAction` — Phase 2 (#120)
- Concrete `ProtocolInputResolver` implementations (against `MetadataService`, `SpotifyApi`, `AppleMusicLibraryClient`, Ktor client) — Phase 2
- `AndroidProtocolPlayTeardown` concrete impl — Phase 2
- `play/radio` refill loop — Phase 3 (#121)
- `listen-along` ticker + transient friend — Phase 3

The four new sealed-class variants needed an exhaustive-`when` stub in `DeepLinkViewModel.executeAction`; added a no-op branch with a "Phase 2 / 3 will wire" log.

### Effort

~1 day, 7 commits, ~1100 LOC (most of it KDoc + tests). One sub-item per commit so review can proceed file-by-file:

```
deeplink: add ProtocolPlayInput/Track/RadioMode + 4 new DeepLinkAction types (#119 [1/N])
deeplink: UTF-8 base64 → JSON helper for protocol payloads             (#119 [2/N])
deeplink: shared SSRF guard for protocol-fetched URLs                  (#119 [3/N])
deeplink: ProtocolTracklistParser (XSPF / JSPF / generic JSON)         (#119 [4/N])
deeplink: ProtocolInputResolver interface + priority-walk function     (#119 [5/N])
deeplink: ProtocolPlayTeardown contract                                (#119 [6/N])
deeplink: shared unit tests for #119 foundation                        (#119 [7/N])
```

Closes #119

## Test plan

- [x] `./gradlew :shared:compileDebugKotlinAndroid` green
- [x] `./gradlew :app:assembleDebug` green (after exhaustive-`when` stub)
- [x] `./gradlew :shared:testDebugUnitTest --tests 'com.parachord.shared.deeplink.*'` — 74/74 passing
- [ ] Smoke: existing `parachord://` deep links (artist/album/play) still work — no behavior change expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)