### PR TITLE
Fix: MusicBrainzClient query params silently dropped (#133)

### DIFF
--- a/shared/src/commonMain/kotlin/com/parachord/shared/api/MusicBrainzClient.kt
+++ b/shared/src/commonMain/kotlin/com/parachord/shared/api/MusicBrainzClient.kt
@@ -65,13 +65,27 @@ class MusicBrainzClient(private val httpClient: HttpClient) {
         it.status.value == 429 || it.status.value == 503
     }
 
-    private suspend inline fun <reified T> guardedGet(url: String, crossinline build: io.ktor.client.request.HttpRequestBuilder.() -> Unit): T =
+    /**
+     * Run a `GET $url` through the rate-limit gate, applying [block] to the
+     * Ktor request builder before sending.
+     *
+     * **Do NOT rename [block] back to `build`** — `HttpRequestBuilder` has a
+     * member function `build(): HttpRequestData` that would silently shadow
+     * the lambda parameter, causing every `parameter("…", …)` call passed
+     * by callers to be discarded. The bug shipped from `f41d5bc` (the
+     * Retrofit→Ktor cutover) until issue #133, surviving because `fmt=json`
+     * (set inline below) was the only param MB actually requires for
+     * happy-path queries to return *something* — search endpoints returned
+     * empty result sets and `inc=` calls returned defaults, but UI paths
+     * fell back to other providers cleanly enough that nobody noticed.
+     */
+    private suspend inline fun <reified T> guardedGet(url: String, crossinline block: io.ktor.client.request.HttpRequestBuilder.() -> Unit): T =
         gate.withPermit(
             isRateLimited = isMbRateLimited,
             exceptionFactory = { MusicBrainzRateLimitedException(it) },
         ) {
             val response: HttpResponse = httpClient.get(url) {
-                build()
+                block()
                 parameter("fmt", "json")
             }
             gate.handleResponse(

--- a/shared/src/commonTest/kotlin/com/parachord/shared/api/MusicBrainzClientTest.kt
+++ b/shared/src/commonTest/kotlin/com/parachord/shared/api/MusicBrainzClientTest.kt
@@ -8,8 +8,10 @@ import com.parachord.shared.config.AppConfig
 import io.ktor.client.HttpClient
 import io.ktor.client.engine.mock.MockEngine
 import io.ktor.client.engine.mock.respond
+import io.ktor.client.request.HttpRequestData
 import io.ktor.http.HttpHeaders
 import io.ktor.http.HttpStatusCode
+import io.ktor.http.decodeURLQueryComponent
 import io.ktor.http.headersOf
 import kotlinx.coroutines.runBlocking
 import kotlinx.serialization.json.Json
@@ -49,6 +51,28 @@ class MusicBrainzClientTest {
         return MusicBrainzClient(httpClient)
     }
 
+    /**
+     * Read a query parameter from a captured Ktor [HttpRequestData].
+     *
+     * Workaround for Ktor 3.1.1 (#133): query params added via the
+     * `parameter("k", v)` extension on `HttpRequestBuilder` end up in the
+     * eventual request URL but are NOT visible via `request.url.parameters[k]`
+     * inside a `MockEngine` lambda — that map returns `null`. The encoded
+     * URL string DOES contain them, so we parse out of the query string
+     * directly. Returns null when [name] isn't present.
+     */
+    private fun queryParam(request: HttpRequestData, name: String): String? {
+        val query = request.url.toString().substringAfter('?', missingDelimiterValue = "")
+        if (query.isEmpty()) return null
+        return query.split('&')
+            .firstNotNullOfOrNull { kv ->
+                val eq = kv.indexOf('=')
+                if (eq < 0) return@firstNotNullOfOrNull null
+                val k = kv.substring(0, eq).decodeURLQueryComponent()
+                if (k != name) null else kv.substring(eq + 1).decodeURLQueryComponent(plusIsSpace = true)
+            }
+    }
+
     @Test
     fun searchRecordings_buildsCorrectRequest_andDeserializesResponse() = runBlocking {
         val mock = MockEngine { request ->
@@ -56,9 +80,9 @@ class MusicBrainzClientTest {
                 "https://musicbrainz.org/ws/2/recording/",
                 request.url.toString().substringBefore("?"),
             )
-            assertEquals("turnstile", request.url.parameters["query"])
-            assertEquals("20", request.url.parameters["limit"])
-            assertEquals("json", request.url.parameters["fmt"])
+            assertEquals("turnstile", queryParam(request, "query"))
+            assertEquals("20", queryParam(request, "limit"))
+            assertEquals("json", queryParam(request, "fmt"))
             respond(
                 content = """
                     {
@@ -98,9 +122,9 @@ class MusicBrainzClientTest {
                 "https://musicbrainz.org/ws/2/release/",
                 request.url.toString().substringBefore("?"),
             )
-            assertEquals("glow on", request.url.parameters["query"])
-            assertEquals("10", request.url.parameters["limit"])
-            assertEquals("json", request.url.parameters["fmt"])
+            assertEquals("glow on", queryParam(request, "query"))
+            assertEquals("10", queryParam(request, "limit"))
+            assertEquals("json", queryParam(request, "fmt"))
             respond(
                 content = """
                     {
@@ -140,9 +164,9 @@ class MusicBrainzClientTest {
                 "https://musicbrainz.org/ws/2/artist/",
                 request.url.toString().substringBefore("?"),
             )
-            assertEquals("turnstile", request.url.parameters["query"])
-            assertEquals("5", request.url.parameters["limit"])
-            assertEquals("json", request.url.parameters["fmt"])
+            assertEquals("turnstile", queryParam(request, "query"))
+            assertEquals("5", queryParam(request, "limit"))
+            assertEquals("json", queryParam(request, "fmt"))
             respond(
                 content = """
                     {
@@ -180,8 +204,8 @@ class MusicBrainzClientTest {
                 "https://musicbrainz.org/ws/2/release/rel-1",
                 request.url.toString().substringBefore("?"),
             )
-            assertEquals("recordings+artist-credits", request.url.parameters["inc"])
-            assertEquals("json", request.url.parameters["fmt"])
+            assertEquals("recordings+artist-credits", queryParam(request, "inc"))
+            assertEquals("json", queryParam(request, "fmt"))
             respond(
                 content = """
                     {
@@ -232,10 +256,10 @@ class MusicBrainzClientTest {
                 "https://musicbrainz.org/ws/2/release-group",
                 request.url.toString().substringBefore("?"),
             )
-            assertEquals("art-1", request.url.parameters["artist"])
-            assertEquals("100", request.url.parameters["limit"])
-            assertEquals("0", request.url.parameters["offset"])
-            assertEquals("json", request.url.parameters["fmt"])
+            assertEquals("art-1", queryParam(request, "artist"))
+            assertEquals("100", queryParam(request, "limit"))
+            assertEquals("0", queryParam(request, "offset"))
+            assertEquals("json", queryParam(request, "fmt"))
             respond(
                 content = """
                     {
@@ -286,8 +310,8 @@ class MusicBrainzClientTest {
                 "https://musicbrainz.org/ws/2/artist/art-1",
                 request.url.toString().substringBefore("?"),
             )
-            assertEquals("url-rels", request.url.parameters["inc"])
-            assertEquals("json", request.url.parameters["fmt"])
+            assertEquals("url-rels", queryParam(request, "inc"))
+            assertEquals("json", queryParam(request, "fmt"))
             respond(
                 content = """
                     {
@@ -322,7 +346,7 @@ class MusicBrainzClientTest {
         // Validates non-default `inc` value flows through to the query string.
         var capturedInc: String? = null
         val mock = MockEngine { request ->
-            capturedInc = request.url.parameters["inc"]
+            capturedInc = queryParam(request, "inc")
             respond(
                 content = """{"id":"rel-1","title":"x","media":[]}""",
                 status = HttpStatusCode.OK,


### PR DESCRIPTION
**Production bug, not just a test failure.** The 7 failing `MusicBrainzClientTest` cases were the only thing surfacing it.

## Root cause

`MusicBrainzClient.guardedGet` named its lambda parameter `build`, which silently shadowed `HttpRequestBuilder.build()` (a member function). Result: every \`parameter("query", q)\` / \`parameter("limit", n)\` / \`parameter("inc", x)\` call passed in by callers was discarded.

```kotlin
private suspend inline fun <reified T> guardedGet(
    url: String,
    crossinline build: HttpRequestBuilder.() -> Unit,  // ← shadowed
): T = gate.withPermit(...) {
    val response = httpClient.get(url) {
        build()                       // ← calls HttpRequestBuilder.build(), NOT the lambda
        parameter("fmt", "json")
    }
    ...
}
```

Verified by adding a debug print in MockEngine — the URL actually sent for \`searchRecordings("turnstile", 20)\` was just:

```
https://musicbrainz.org/ws/2/recording/?fmt=json
```

No \`query=\`, no \`limit=\`. Bug shipped in `f41d5bc` (Retrofit→Ktor cutover).

## Why nobody noticed

MB returned **defaults** instead of erroring:
- Search endpoints with no `query=` → empty result sets, metadata cascade fell through to Last.fm / Spotify
- `inc=` missing from `getRelease` / `getArtist` → MB returned the entity without recording details / URL relations; consumers reading `.media` / `.relations` got empty lists and silently degraded
- MBID enrichment (the heaviest consumer) calls `mapper.listenbrainz.org` — different endpoint, unaffected

## Fix

1. **Production:** rename the lambda parameter `build` → `block` in `MusicBrainzClient.guardedGet`. One-line change. Long KDoc explaining the shadowing trap so a future refactor doesn't reintroduce.
2. **Tests:** Ktor 3.1.1's MockEngine also doesn't surface dynamically-added query params via `request.url.parameters[…]` (returns null). Added a `queryParam(request, name)` helper that parses from `request.url.toString()`'s query segment. Replaces 18 broken assertions across the 7 tests.

## Verification

`./gradlew :shared:testDebugUnitTest` → **110 tests, 0 failures** (was 103/110 before).

Closes #133

## Test plan
- [x] `./gradlew :shared:testDebugUnitTest --tests "com.parachord.shared.api.MusicBrainzClientTest"` — 7/7 green
- [x] `./gradlew :shared:testDebugUnitTest` — 110/110 green
- [ ] Manual on-device sanity: search a track / artist / release that hits MB and confirm metadata now flows through (cascading providers were masking the bug previously)

🤖 Generated with [Claude Code](https://claude.com/claude-code)