### PR TITLE
Protocol play handlers — Phase 3: play/radio (Mode B + C) + listen-along (#121)

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -87,6 +87,7 @@
                 <data android:scheme="parachord" android:host="queue" />
                 <data android:scheme="parachord" android:host="shuffle" />
                 <data android:scheme="parachord" android:host="volume" />
+                <data android:scheme="parachord" android:host="listen-along" />
                 <!-- Navigation -->
                 <data android:scheme="parachord" android:host="home" />
                 <data android:scheme="parachord" android:host="artist" />

--- a/app/src/main/java/com/parachord/android/deeplink/AndroidProtocolInputResolver.kt
+++ b/app/src/main/java/com/parachord/android/deeplink/AndroidProtocolInputResolver.kt
@@ -2,6 +2,7 @@ package com.parachord.android.deeplink
 
 import com.parachord.android.playlist.parseXspfForProtocol
 import com.parachord.shared.api.AppleMusicClient
+import com.parachord.shared.api.MbReleaseDetail
 import com.parachord.shared.api.MusicBrainzClient
 import com.parachord.shared.api.SpotifyClient
 import com.parachord.shared.deeplink.ProtocolInputResolver
@@ -53,27 +54,53 @@ class AndroidProtocolInputResolver constructor(
     private val maxTracklistBytes: Int = 100 * 1024
 
     override suspend fun resolveByMbid(mbid: String): ResolvedProtocolPlay? {
-        return try {
-            val release = musicBrainzClient.getRelease(mbid, inc = "recordings+artist-credits")
-            val tracks = release.media.flatMap { medium ->
-                medium.tracks.map { track ->
-                    ProtocolTrack(
-                        artist = track.artistName ?: release.artistName.orEmpty(),
-                        title = track.title,
-                        album = release.title,
-                        mbid = track.id,
-                    )
-                }
-            }
-            if (tracks.isEmpty()) return null
-            ResolvedProtocolPlay(
-                displayName = release.title.orEmpty().ifEmpty { "Album" },
-                tracks = tracks,
-            )
+        // Try /release/{mbid} first (cheap, common path). If it 404s — typical
+        // for release-group MBIDs that Achordion + most music tools emit —
+        // fall back to /release?release-group={mbid} to find a canonical
+        // release within the release-group.
+        //
+        // expectSuccess=false on the shared HttpClient means a 404's error
+        // JSON `{"error":"Not Found"}` doesn't trip a status throw, but the
+        // body deserializer fires a SerializationException when the payload
+        // doesn't match MbReleaseDetail. The catch below handles both that
+        // and any genuinely malformed response. We additionally fall through
+        // when getRelease returns a usable object that has no media[] — that
+        // case is rare in practice but the release-group browse may carry a
+        // sibling edition with full tracks.
+        val releaseFromDirect: MbReleaseDetail? = try {
+            musicBrainzClient.getRelease(mbid, inc = "recordings+artist-credits")
+                .takeIf { it.media.isNotEmpty() }
         } catch (e: Exception) {
-            Log.w(TAG, "MBID resolve failed for $mbid: ${e.message}")
+            Log.d(TAG, "MBID $mbid not a release (${e.message?.take(80)}); trying release-group")
             null
         }
+        val releaseFromGroup: MbReleaseDetail? = if (releaseFromDirect != null) null else try {
+            musicBrainzClient.browseReleasesByReleaseGroup(
+                releaseGroupMbid = mbid,
+                inc = "recordings+artist-credits",
+                limit = 1,
+            ).releases.firstOrNull()
+        } catch (e: Exception) {
+            Log.w(TAG, "MBID $mbid release-group browse failed: ${e.message}")
+            null
+        }
+        val release: MbReleaseDetail = releaseFromDirect ?: releaseFromGroup ?: return null
+
+        val tracks = release.media.flatMap { medium ->
+            medium.tracks.map { track ->
+                ProtocolTrack(
+                    artist = track.artistName.ifEmpty { release.artistName },
+                    title = track.title,
+                    album = release.title,
+                    mbid = track.id,
+                )
+            }
+        }
+        if (tracks.isEmpty()) return null
+        return ResolvedProtocolPlay(
+            displayName = release.title.ifEmpty { "Album" },
+            tracks = tracks,
+        )
     }
 
     override suspend fun resolveBySpotify(spotifyIdOrUri: String): ResolvedProtocolPlay? {

--- a/app/src/main/java/com/parachord/android/deeplink/AndroidProtocolPlayTeardown.kt
+++ b/app/src/main/java/com/parachord/android/deeplink/AndroidProtocolPlayTeardown.kt
@@ -72,4 +72,29 @@ class AndroidProtocolPlayTeardown constructor(
             Log.w(TAG, "clearQueue failed: ${e.message}")
         }
     }
+
+    override suspend fun prepareForListenAlongHandover() {
+        // Step 1 — exit spinoff. Same rationale as [prepareForNewPlayback]:
+        // a leftover spinoff parent would shape the new friend's playback.
+        try {
+            playbackController.exitSpinoff()
+        } catch (e: Exception) {
+            Log.w(TAG, "exitSpinoff failed: ${e.message}")
+        }
+
+        // Step 2 (stop listen-along) is INTENTIONALLY OMITTED — see
+        // [ProtocolPlayTeardown.prepareForListenAlongHandover] KDoc.
+        // MainViewModel.startListenAlong handles its own swap.
+
+        // Step 3 — clear the queue. Without this, the previous context's
+        // tracks remain queued behind the listen-along ticker's first
+        // play, then surface as soon as the user is no longer in sync
+        // with the friend. Mirrors the desktop's listen-along entry
+        // path which also wipes the queue.
+        try {
+            playbackController.clearQueue()
+        } catch (e: Exception) {
+            Log.w(TAG, "clearQueue failed: ${e.message}")
+        }
+    }
 }

--- a/app/src/main/java/com/parachord/android/deeplink/DeepLinkHandler.kt
+++ b/app/src/main/java/com/parachord/android/deeplink/DeepLinkHandler.kt
@@ -275,25 +275,38 @@ class DeepLinkHandler constructor() {
      * Parse `parachord://play/radio?...` into [DeepLinkAction.PlayRadio].
      *
      * Mode selection (mirrors desktop `protocol-schema.md` §Radio):
-     * - `?refillUrl=` present → Mode A (URL-fed). [RadioMode.PoolBased] used as
-     *   placeholder for the sealed-class slot; the radio engine reads
-     *   `refillUrl` directly.
-     * - `?artist=` present (with optional `?title=`) → Mode B
-     *   ([RadioMode.ArtistSeed]).
-     * - `?tracks=` present → Mode C ([RadioMode.PoolBased]).
+     * - `?artist=` alone (no `?url=`/`?tracks=`) → Mode B ([RadioMode.ArtistSeed]).
+     * - `?url=` or `?tracks=` present → Mode C ([RadioMode.PoolBased]). `?url=`
+     *   is the initial pool URL; `?tracks=` is an inline base64 JSON pool.
+     * - `?refill=` (or legacy alias `?refillUrl=`) is the URL used for
+     *   subsequent refills only — NOT a valid initial pool source. Alone, it
+     *   yields [DeepLinkAction.Unknown].
      * - none of the above → [DeepLinkAction.Unknown].
+     *
+     * `?name=` (precedence: `name` > `title` > resolved name > "Radio") is the
+     * station display name; `PlayRadio.refillUrl` carries either `?refill=` or
+     * `?refillUrl=` for downstream refill fetches.
      */
     private fun parsePlayRadio(uri: Uri): DeepLinkAction {
         val input = parseProtocolPlayInput(uri)
-        val refillUrl = uri.clampedParam("refillUrl")
+        // ?refill= is the explicit refill URL for Mode C; ?refillUrl= kept as
+        // a legacy alias for back-compat with anything generated against the
+        // Phase 2 build.
+        val refillUrl = uri.clampedParam("refill") ?: uri.clampedParam("refillUrl")
         val name = uri.clampedParam("name")
         val shuffle = uri.clampedParam("shuffle") == "1"
         val artist = uri.clampedParam("artist")
         val title = uri.clampedParam("title")
+
+        val hasUrl = !input?.url.isNullOrBlank()
+        val hasTracks = input?.tracks?.isNotEmpty() == true
+        val hasArtist = !artist.isNullOrBlank()
+
         val mode: RadioMode = when {
-            refillUrl != null -> RadioMode.PoolBased
-            !artist.isNullOrBlank() -> RadioMode.ArtistSeed(artist, title)
-            input?.tracks?.isNotEmpty() == true -> RadioMode.PoolBased
+            // Mode B: artist seed, no inline pool, no URL pool
+            hasArtist && !hasUrl && !hasTracks -> RadioMode.ArtistSeed(artist!!, title)
+            // Mode C: explicit pool (URL or inline)
+            hasUrl || hasTracks -> RadioMode.PoolBased
             else -> return DeepLinkAction.Unknown(uri.toString())
         }
         return DeepLinkAction.PlayRadio(

--- a/app/src/main/java/com/parachord/android/deeplink/DeepLinkHandler.kt
+++ b/app/src/main/java/com/parachord/android/deeplink/DeepLinkHandler.kt
@@ -283,9 +283,8 @@ class DeepLinkHandler constructor() {
      *   yields [DeepLinkAction.Unknown].
      * - none of the above → [DeepLinkAction.Unknown].
      *
-     * `?name=` (precedence: `name` > `title` > resolved name > "Radio") is the
-     * station display name; `PlayRadio.refillUrl` carries either `?refill=` or
-     * `?refillUrl=` for downstream refill fetches.
+     * `?name=` is the station display name; `PlayRadio.refillUrl` carries
+     * either `?refill=` or `?refillUrl=` for downstream refill fetches.
      */
     private fun parsePlayRadio(uri: Uri): DeepLinkAction {
         val input = parseProtocolPlayInput(uri)

--- a/app/src/main/java/com/parachord/android/deeplink/DeepLinkViewModel.kt
+++ b/app/src/main/java/com/parachord/android/deeplink/DeepLinkViewModel.kt
@@ -40,7 +40,19 @@ sealed class DeepLinkNavEvent {
     data object Settings : DeepLinkNavEvent()
     data class Search(val query: String?) : DeepLinkNavEvent()
     data class Chat(val prompt: String?) : DeepLinkNavEvent()
-    data class Toast(val message: String) : DeepLinkNavEvent()
+
+    /**
+     * Acknowledgment toasts for slow operations (radio fetch, listen-along
+     * lookup) opt into [longDuration]=true so they read as ~3.5s rather
+     * than ~2s. Desktop uses a 30s clearing-on-event toast — Android Toast
+     * doesn't support arbitrary durations or programmatic dismiss-on-event,
+     * so we approximate via LENGTH_LONG. Future polish: convert to a
+     * Compose Snackbar with explicit duration + clear-on-track-change.
+     */
+    data class Toast(
+        val message: String,
+        val longDuration: Boolean = false,
+    ) : DeepLinkNavEvent()
 
     /**
      * `parachord://listen-along` resolved to a Friend (saved or
@@ -373,7 +385,7 @@ class DeepLinkViewModel constructor(
      * count once the pool is built.
      */
     private suspend fun dispatchPlayRadio(action: DeepLinkAction.PlayRadio) {
-        _navEvents.emit(DeepLinkNavEvent.Toast("Building radio…"))
+        _navEvents.emit(DeepLinkNavEvent.Toast("Building radio…", longDuration = true))
         when (val r = playRadioDispatcher.dispatch(action)) {
             is PlayRadioResult.StartedModeB -> {
                 // Mode B doesn't need a follow-up toast — the banner shows
@@ -396,7 +408,7 @@ class DeepLinkViewModel constructor(
      * lookup misses and we have to round-trip the now-playing API.
      */
     private suspend fun dispatchListenAlong(action: DeepLinkAction.ListenAlong) {
-        _navEvents.emit(DeepLinkNavEvent.Toast("Catching up to ${action.user}…"))
+        _navEvents.emit(DeepLinkNavEvent.Toast("Catching up to ${action.user}…", longDuration = true))
         when (val r = listenAlongDispatcher.dispatch(action)) {
             is ListenAlongResult.Started -> {
                 // MainActivity collects this and calls

--- a/app/src/main/java/com/parachord/android/deeplink/DeepLinkViewModel.kt
+++ b/app/src/main/java/com/parachord/android/deeplink/DeepLinkViewModel.kt
@@ -63,15 +63,11 @@ class DeepLinkViewModel constructor(
     private val chatService: AiChatService,
     private val protocolPlayHandler: ProtocolPlayHandler,
     private val protocolPlayTeardown: com.parachord.shared.deeplink.ProtocolPlayTeardown,
+    private val playRadioDispatcher: PlayRadioDispatcher,
 ) : ViewModel() {
 
     private val _navEvents = MutableSharedFlow<DeepLinkNavEvent>()
     val navEvents: SharedFlow<DeepLinkNavEvent> = _navEvents.asSharedFlow()
-
-    private val playRadioDispatcher = PlayRadioDispatcher(
-        playbackController = playbackController,
-        teardown = protocolPlayTeardown,
-    ) { msg -> _navEvents.emit(DeepLinkNavEvent.Toast(msg)) }
 
     private val _pendingConfirmation = MutableStateFlow<DeepLinkConfirmation?>(null)
     val pendingConfirmation: StateFlow<DeepLinkConfirmation?> = _pendingConfirmation.asStateFlow()
@@ -319,7 +315,7 @@ class DeepLinkViewModel constructor(
                 is DeepLinkAction.PlayPlaylist -> dispatchProtocolPlay(action)
 
                 // ── Phase 3 (#121) ──
-                is DeepLinkAction.PlayRadio -> playRadioDispatcher.dispatch(action)
+                is DeepLinkAction.PlayRadio -> dispatchPlayRadio(action)
                 is DeepLinkAction.ListenAlong -> {
                     Log.d(TAG, "Protocol handler not yet wired (Phase 3): $action")
                     _navEvents.emit(DeepLinkNavEvent.Toast("Coming soon"))
@@ -353,6 +349,32 @@ class DeepLinkViewModel constructor(
                 DeepLinkNavEvent.Toast("Playing ${r.displayName} (${r.trackCount} tracks)")
             )
             is ProtocolPlayResult.Failed -> _navEvents.emit(DeepLinkNavEvent.Toast(r.reason))
+        }
+    }
+
+    /**
+     * Dispatch a `parachord://play/radio` action through
+     * [PlayRadioDispatcher] and surface the result as a toast.
+     *
+     * The acknowledgment toast ("Building radio…") fires BEFORE the
+     * dispatcher runs since Mode C URL fetch can take seconds and the
+     * user needs feedback within ~500ms. Mode B doesn't need a follow-up
+     * toast (the banner shows the radio name); Mode C reports the track
+     * count once the pool is built.
+     */
+    private suspend fun dispatchPlayRadio(action: DeepLinkAction.PlayRadio) {
+        _navEvents.emit(DeepLinkNavEvent.Toast("Building radio…"))
+        when (val r = playRadioDispatcher.dispatch(action)) {
+            is PlayRadioResult.StartedModeB -> {
+                // Mode B doesn't need a follow-up toast — the banner shows
+                // the radio name. (The acknowledgment above is enough.)
+            }
+            is PlayRadioResult.StartedModeC -> _navEvents.emit(
+                DeepLinkNavEvent.Toast("Playing ${r.displayName} (${r.trackCount} tracks)")
+            )
+            is PlayRadioResult.Failed -> _navEvents.emit(
+                DeepLinkNavEvent.Toast("Radio failed: ${r.reason}")
+            )
         }
     }
 

--- a/app/src/main/java/com/parachord/android/deeplink/DeepLinkViewModel.kt
+++ b/app/src/main/java/com/parachord/android/deeplink/DeepLinkViewModel.kt
@@ -41,6 +41,18 @@ sealed class DeepLinkNavEvent {
     data class Search(val query: String?) : DeepLinkNavEvent()
     data class Chat(val prompt: String?) : DeepLinkNavEvent()
     data class Toast(val message: String) : DeepLinkNavEvent()
+
+    /**
+     * `parachord://listen-along` resolved to a Friend (saved or
+     * transient). MainActivity collects this and calls
+     * `MainViewModel.startListenAlong(friend)`.
+     *
+     * Event-based dispatch is preferred over a direct callback: it
+     * matches every other deeplink-driven nav transition, keeps the
+     * ViewModel free of an Activity-scoped reference, and survives
+     * recompositions cleanly.
+     */
+    data class StartListenAlong(val friend: com.parachord.shared.model.Friend) : DeepLinkNavEvent()
 }
 
 /**
@@ -64,6 +76,7 @@ class DeepLinkViewModel constructor(
     private val protocolPlayHandler: ProtocolPlayHandler,
     private val protocolPlayTeardown: com.parachord.shared.deeplink.ProtocolPlayTeardown,
     private val playRadioDispatcher: PlayRadioDispatcher,
+    private val listenAlongDispatcher: ListenAlongDispatcher,
 ) : ViewModel() {
 
     private val _navEvents = MutableSharedFlow<DeepLinkNavEvent>()
@@ -316,10 +329,7 @@ class DeepLinkViewModel constructor(
 
                 // ── Phase 3 (#121) ──
                 is DeepLinkAction.PlayRadio -> dispatchPlayRadio(action)
-                is DeepLinkAction.ListenAlong -> {
-                    Log.d(TAG, "Protocol handler not yet wired (Phase 3): $action")
-                    _navEvents.emit(DeepLinkNavEvent.Toast("Coming soon"))
-                }
+                is DeepLinkAction.ListenAlong -> dispatchListenAlong(action)
             }
         }
     }
@@ -374,6 +384,39 @@ class DeepLinkViewModel constructor(
             )
             is PlayRadioResult.Failed -> _navEvents.emit(
                 DeepLinkNavEvent.Toast("Radio failed: ${r.reason}")
+            )
+        }
+    }
+
+    /**
+     * Dispatch a `parachord://listen-along` action through
+     * [ListenAlongDispatcher]. Acknowledgment toast fires immediately
+     * (per issue #121's "UX polish" addendum — feedback within ~500ms
+     * of the deeplink) so the user sees something even if the local
+     * lookup misses and we have to round-trip the now-playing API.
+     */
+    private suspend fun dispatchListenAlong(action: DeepLinkAction.ListenAlong) {
+        _navEvents.emit(DeepLinkNavEvent.Toast("Catching up to ${action.user}…"))
+        when (val r = listenAlongDispatcher.dispatch(action)) {
+            is ListenAlongResult.Started -> {
+                // MainActivity collects this and calls
+                // mainViewModel.startListenAlong(friend), which
+                // internally runs stopListenAlong(silent=true) before
+                // starting the new loop — the swap is atomic.
+                _navEvents.emit(DeepLinkNavEvent.StartListenAlong(r.friend))
+            }
+            is ListenAlongResult.NotPlaying -> {
+                val serviceLabel = when (r.service) {
+                    "lastfm" -> "Last.fm"
+                    "listenbrainz" -> "ListenBrainz"
+                    else -> r.service
+                }
+                _navEvents.emit(
+                    DeepLinkNavEvent.Toast("${r.username} is not currently listening on $serviceLabel")
+                )
+            }
+            is ListenAlongResult.Failed -> _navEvents.emit(
+                DeepLinkNavEvent.Toast("Listen along failed: ${r.reason}")
             )
         }
     }

--- a/app/src/main/java/com/parachord/android/deeplink/DeepLinkViewModel.kt
+++ b/app/src/main/java/com/parachord/android/deeplink/DeepLinkViewModel.kt
@@ -392,7 +392,10 @@ class DeepLinkViewModel constructor(
                 // the radio name. (The acknowledgment above is enough.)
             }
             is PlayRadioResult.StartedModeC -> _navEvents.emit(
-                DeepLinkNavEvent.Toast("Playing ${r.displayName} (${r.trackCount} tracks)")
+                // No track count — radio stations are seeded with a small
+                // initial pool and refill on the fly, so "(5 tracks)" would
+                // misrepresent the station as a fixed-length playlist.
+                DeepLinkNavEvent.Toast("Playing ${r.displayName}")
             )
             is PlayRadioResult.Failed -> _navEvents.emit(
                 DeepLinkNavEvent.Toast("Radio failed: ${r.reason}")

--- a/app/src/main/java/com/parachord/android/deeplink/DeepLinkViewModel.kt
+++ b/app/src/main/java/com/parachord/android/deeplink/DeepLinkViewModel.kt
@@ -68,6 +68,11 @@ class DeepLinkViewModel constructor(
     private val _navEvents = MutableSharedFlow<DeepLinkNavEvent>()
     val navEvents: SharedFlow<DeepLinkNavEvent> = _navEvents.asSharedFlow()
 
+    private val playRadioDispatcher = PlayRadioDispatcher(
+        playbackController = playbackController,
+        teardown = protocolPlayTeardown,
+    ) { msg -> _navEvents.emit(DeepLinkNavEvent.Toast(msg)) }
+
     private val _pendingConfirmation = MutableStateFlow<DeepLinkConfirmation?>(null)
     val pendingConfirmation: StateFlow<DeepLinkConfirmation?> = _pendingConfirmation.asStateFlow()
 
@@ -313,8 +318,8 @@ class DeepLinkViewModel constructor(
                 is DeepLinkAction.PlayAlbum -> dispatchProtocolPlay(action)
                 is DeepLinkAction.PlayPlaylist -> dispatchProtocolPlay(action)
 
-                // ── Phase 3 (#121) — to be wired ──
-                is DeepLinkAction.PlayRadio,
+                // ── Phase 3 (#121) ──
+                is DeepLinkAction.PlayRadio -> playRadioDispatcher.dispatch(action)
                 is DeepLinkAction.ListenAlong -> {
                     Log.d(TAG, "Protocol handler not yet wired (Phase 3): $action")
                     _navEvents.emit(DeepLinkNavEvent.Toast("Coming soon"))

--- a/app/src/main/java/com/parachord/android/deeplink/ListenAlongDispatcher.kt
+++ b/app/src/main/java/com/parachord/android/deeplink/ListenAlongDispatcher.kt
@@ -1,0 +1,121 @@
+package com.parachord.android.deeplink
+
+import com.parachord.shared.deeplink.DeepLinkAction
+import com.parachord.shared.deeplink.ProtocolPlayTeardown
+import com.parachord.shared.model.Friend
+import com.parachord.shared.platform.Log
+import com.parachord.shared.repository.FriendsRepository
+
+/**
+ * Result of a `parachord://listen-along` dispatch. Mirrors the result
+ * shape of [PlayRadioResult] / [ProtocolPlayResult] — the
+ * [DeepLinkViewModel] turns these into toasts and emits a
+ * [DeepLinkNavEvent.StartListenAlong] for [Started].
+ */
+sealed class ListenAlongResult {
+    /**
+     * Found a Friend (saved OR transient). [friend] is the entity to
+     * pass to `MainViewModel.startListenAlong`; [displayName] is what
+     * the toast surface should show.
+     */
+    data class Started(val friend: Friend, val displayName: String) : ListenAlongResult()
+
+    /**
+     * Calm "they're not on the air" outcome — user is reachable but
+     * has nothing currently playing. Caller surfaces as
+     * `"<user> is not currently listening on <service>."`.
+     */
+    data class NotPlaying(val username: String, val service: String) : ListenAlongResult()
+
+    /** Hard failure — bad service, network error before we got an answer. */
+    data class Failed(val reason: String) : ListenAlongResult()
+}
+
+/**
+ * Orchestrator for `parachord://listen-along?service=…&user=…` (issue
+ * #121, Phase 3 Task 7).
+ *
+ * Strategy:
+ *
+ * 1. Validate the service against the supported set
+ *    (`listenbrainz` | `lastfm`). Anything else returns [ListenAlongResult.Failed].
+ * 2. Try a local-friends lookup via
+ *    [FriendsRepository.findByServiceAndUsername] (case-insensitive on
+ *    username). On hit, run the listen-along handover teardown and
+ *    return [ListenAlongResult.Started] with the saved Friend.
+ * 3. On miss, fetch the user's now-playing via
+ *    [FriendsRepository.fetchTransientFriendNowPlaying]. If they're
+ *    actively scrobbling, build a transient Friend (id
+ *    `transient:{service}:{user}`, `transient = true`) and return
+ *    [ListenAlongResult.Started].
+ * 4. If they're not currently listening, return
+ *    [ListenAlongResult.NotPlaying] — caller surfaces a calm "not
+ *    currently listening" toast rather than an error.
+ *
+ * **Why a "handover" teardown, not the standard one?** The full
+ * [ProtocolPlayTeardown.prepareForNewPlayback] runs three steps:
+ * exit-spinoff, stop-listen-along, clear-queue. Using it here would
+ * stop a possibly-active listen-along loop right before
+ * `MainViewModel.startListenAlong` (which itself starts by calling
+ * `stopListenAlong(silent=true)`) — a stop+start race where the
+ * dying loop's last poll tick can clobber the new friend's track.
+ * [ProtocolPlayTeardown.prepareForListenAlongHandover] runs only steps
+ * 1 and 3, leaving the listen-along stop to `startListenAlong`.
+ */
+class ListenAlongDispatcher(
+    private val friendsRepository: FriendsRepository,
+    private val teardown: ProtocolPlayTeardown,
+) {
+    suspend fun dispatch(action: DeepLinkAction.ListenAlong): ListenAlongResult {
+        // Validate service. The deeplink parser doesn't gate this — the
+        // string from the URL flows through unchanged — so this is the
+        // first place where bogus values are caught.
+        if (action.service !in SUPPORTED_SERVICES) {
+            Log.w(TAG, "Unknown service: ${action.service}")
+            return ListenAlongResult.Failed("Unknown service: ${action.service}")
+        }
+
+        if (action.user.isBlank()) {
+            return ListenAlongResult.Failed("Username is required")
+        }
+
+        // 1. Local lookup. Case-insensitive — see
+        //    findByServiceAndUsername KDoc.
+        val saved = try {
+            friendsRepository.findByServiceAndUsername(action.service, action.user)
+        } catch (e: Exception) {
+            Log.w(TAG, "Local friend lookup failed", e)
+            null
+        }
+
+        if (saved != null) {
+            teardown.prepareForListenAlongHandover()
+            return ListenAlongResult.Started(saved, saved.displayName)
+        }
+
+        // 2. Transient fallback. The repo method returns null on both
+        //    "not currently playing" and "API failed" — we treat both
+        //    as NotPlaying so the user gets a calm message instead of
+        //    a scary error. (A genuinely failed request usually means
+        //    the user has zero recent activity anyway, since the API
+        //    endpoints we hit don't 5xx for valid users in practice.)
+        val transient = try {
+            friendsRepository.fetchTransientFriendNowPlaying(action.service, action.user)
+        } catch (e: Exception) {
+            Log.w(TAG, "Transient now-playing fetch failed", e)
+            return ListenAlongResult.Failed("Failed to fetch ${action.user}'s now-playing")
+        }
+
+        if (transient == null) {
+            return ListenAlongResult.NotPlaying(action.user, action.service)
+        }
+
+        teardown.prepareForListenAlongHandover()
+        return ListenAlongResult.Started(transient, action.user)
+    }
+
+    companion object {
+        private const val TAG = "ListenAlongDispatcher"
+        private val SUPPORTED_SERVICES = setOf("listenbrainz", "lastfm")
+    }
+}

--- a/app/src/main/java/com/parachord/android/deeplink/ListenAlongDispatcher.kt
+++ b/app/src/main/java/com/parachord/android/deeplink/ListenAlongDispatcher.kt
@@ -15,10 +15,11 @@ import com.parachord.shared.repository.FriendsRepository
 sealed class ListenAlongResult {
     /**
      * Found a Friend (saved OR transient). [friend] is the entity to
-     * pass to `MainViewModel.startListenAlong`; [displayName] is what
-     * the toast surface should show.
+     * pass to `MainViewModel.startListenAlong`. The toast surface uses
+     * `friend.displayName` directly — there's no separate field because
+     * the VM never reads anything else.
      */
-    data class Started(val friend: Friend, val displayName: String) : ListenAlongResult()
+    data class Started(val friend: Friend) : ListenAlongResult()
 
     /**
      * Calm "they're not on the air" outcome — user is reachable but
@@ -90,7 +91,7 @@ class ListenAlongDispatcher(
 
         if (saved != null) {
             teardown.prepareForListenAlongHandover()
-            return ListenAlongResult.Started(saved, saved.displayName)
+            return ListenAlongResult.Started(saved)
         }
 
         // 2. Transient fallback. The repo method returns null on both
@@ -111,7 +112,7 @@ class ListenAlongDispatcher(
         }
 
         teardown.prepareForListenAlongHandover()
-        return ListenAlongResult.Started(transient, action.user)
+        return ListenAlongResult.Started(transient)
     }
 
     companion object {

--- a/app/src/main/java/com/parachord/android/deeplink/PlayRadioDispatcher.kt
+++ b/app/src/main/java/com/parachord/android/deeplink/PlayRadioDispatcher.kt
@@ -46,6 +46,12 @@ class PlayRadioDispatcher(
                     displayName = action.name
                         ?: mode.title?.let { "Radio: ${mode.artist} – $it" }
                         ?: "Radio: ${mode.artist}",
+                    // Mode B is "start fresh radio now" semantics — kick
+                    // the first pool track immediately rather than
+                    // waiting for an existing song to finish (the
+                    // teardown above clears the queue but doesn't stop
+                    // whatever's currently playing).
+                    kickStartFirstTrack = true,
                 )
             }
             is RadioMode.PoolBased -> {

--- a/app/src/main/java/com/parachord/android/deeplink/PlayRadioDispatcher.kt
+++ b/app/src/main/java/com/parachord/android/deeplink/PlayRadioDispatcher.kt
@@ -77,11 +77,22 @@ class PlayRadioDispatcher(
                 playbackController.setPoolFetcher { url ->
                     protocolPlayHandler.resolveTrackList(url)
                 }
-                when (val r = protocolPlayHandler.handle(action)) {
-                    is ProtocolPlayResult.Started ->
-                        PlayRadioResult.StartedModeC(r.displayName, r.trackCount)
-                    is ProtocolPlayResult.Failed ->
-                        PlayRadioResult.Failed(r.reason)
+                // Show the mini-player spinner during the URL fetch +
+                // parse + resolve cascade (can take multiple seconds).
+                // try/finally guarantees the flag clears on failure
+                // paths too, even though startPoolBasedSpinoff()'s
+                // playTrack call would otherwise clear it via the
+                // currentTrack=null → non-null transition.
+                playbackController.setPlaybarLoading(true)
+                try {
+                    when (val r = protocolPlayHandler.handle(action)) {
+                        is ProtocolPlayResult.Started ->
+                            PlayRadioResult.StartedModeC(r.displayName, r.trackCount)
+                        is ProtocolPlayResult.Failed ->
+                            PlayRadioResult.Failed(r.reason)
+                    }
+                } finally {
+                    playbackController.setPlaybarLoading(false)
                 }
             }
         }

--- a/app/src/main/java/com/parachord/android/deeplink/PlayRadioDispatcher.kt
+++ b/app/src/main/java/com/parachord/android/deeplink/PlayRadioDispatcher.kt
@@ -4,9 +4,15 @@ import com.parachord.android.playback.PlaybackController
 import com.parachord.shared.deeplink.DeepLinkAction
 import com.parachord.shared.deeplink.ProtocolPlayTeardown
 import com.parachord.shared.deeplink.RadioMode
-import com.parachord.shared.platform.Log
 
-private const val TAG = "PlayRadioDispatcher"
+/** One-shot result for the toast / log surface. Mirrors [ProtocolPlayResult]. */
+sealed class PlayRadioResult {
+    /** Mode B successfully kicked off (Last.fm fetch starts in background). */
+    data class StartedModeB(val displayName: String) : PlayRadioResult()
+    /** Mode C successfully kicked off — N tracks in pool. */
+    data class StartedModeC(val displayName: String, val trackCount: Int) : PlayRadioResult()
+    data class Failed(val reason: String) : PlayRadioResult()
+}
 
 /**
  * Orchestrator for `parachord://play/radio` (Phase 3, issue #121).
@@ -18,14 +24,15 @@ private const val TAG = "PlayRadioDispatcher"
  *    [PlaybackController.startSpinoffWithSeed]. Title-bearing seeds use
  *    Last.fm `track.getsimilar`; artist-only seeds fall back to
  *    `artist.getTopTracks`.
- *  - **Mode C (pool-based)** — `?url=`/`?tracks=`/`?refill=`. Wired in
- *    Task 4 (this file is left intentionally minimal until then).
+ *  - **Mode C (pool-based)** — `?url=`/`?tracks=`/`?refill=`. Delegates
+ *    to [ProtocolPlayHandler] for resolve + teardown + entity build, then
+ *    [PlaybackController.startPoolBasedSpinoff] for the pool kick-off.
+ *    The acknowledgment toast ("Building radio…") is the VM's
+ *    responsibility — emitted before [dispatch] runs since Mode C URL
+ *    fetch can take seconds and the user needs feedback.
  *
- * Acknowledgment toast ("Building radio…") fires before teardown so the
- * user gets immediate feedback that the deeplink was understood.
- *
- * **Teardown semantics**: Mode B clears the queue + exits any active
- * spinoff + stops listen-along, matching the Phase 2 album/playlist
+ * **Teardown semantics**: both modes clear the queue + exit any active
+ * spinoff + stop listen-along, matching the Phase 2 album/playlist
  * behavior. The in-app right-click → Spinoff path does NOT call teardown
  * (it preserves the queue and returns to it on exit), but the deeplink
  * path is "start fresh radio" semantics, so teardown is correct here.
@@ -33,19 +40,19 @@ private const val TAG = "PlayRadioDispatcher"
 class PlayRadioDispatcher(
     private val playbackController: PlaybackController,
     private val teardown: ProtocolPlayTeardown,
-    private val toast: suspend (String) -> Unit,
+    private val protocolPlayHandler: ProtocolPlayHandler,
 ) {
-    suspend fun dispatch(action: DeepLinkAction.PlayRadio) {
-        when (val mode = action.mode) {
+    suspend fun dispatch(action: DeepLinkAction.PlayRadio): PlayRadioResult {
+        return when (val mode = action.mode) {
             is RadioMode.ArtistSeed -> {
-                toast("Building radio…")
                 teardown.prepareForNewPlayback()
+                val displayName = action.name
+                    ?: mode.title?.let { "Radio: ${mode.artist} – $it" }
+                    ?: "Radio: ${mode.artist}"
                 playbackController.startSpinoffWithSeed(
                     seedArtist = mode.artist,
                     seedTitle = mode.title,
-                    displayName = action.name
-                        ?: mode.title?.let { "Radio: ${mode.artist} – $it" }
-                        ?: "Radio: ${mode.artist}",
+                    displayName = displayName,
                     // Mode B is "start fresh radio now" semantics — kick
                     // the first pool track immediately rather than
                     // waiting for an existing song to finish (the
@@ -53,11 +60,18 @@ class PlayRadioDispatcher(
                     // whatever's currently playing).
                     kickStartFirstTrack = true,
                 )
+                PlayRadioResult.StartedModeB(displayName)
             }
             is RadioMode.PoolBased -> {
-                // Wired in Task 4.
-                Log.d(TAG, "Mode C (pool-based) not yet wired: $action")
-                toast("Mode C coming next commit")
+                // Mode C delegates resolve + teardown + entity build to
+                // ProtocolPlayHandler. Translate its result into our
+                // result type so the VM only has one sealed match site.
+                when (val r = protocolPlayHandler.handle(action)) {
+                    is ProtocolPlayResult.Started ->
+                        PlayRadioResult.StartedModeC(r.displayName, r.trackCount)
+                    is ProtocolPlayResult.Failed ->
+                        PlayRadioResult.Failed(r.reason)
+                }
             }
         }
     }

--- a/app/src/main/java/com/parachord/android/deeplink/PlayRadioDispatcher.kt
+++ b/app/src/main/java/com/parachord/android/deeplink/PlayRadioDispatcher.kt
@@ -66,6 +66,17 @@ class PlayRadioDispatcher(
                 // Mode C delegates resolve + teardown + entity build to
                 // ProtocolPlayHandler. Translate its result into our
                 // result type so the VM only has one sealed match site.
+                //
+                // Wire the refill fetcher BEFORE the handler runs so
+                // startPoolBasedSpinoff() — invoked synchronously inside
+                // handle() — sees a configured fetcher when it sets the
+                // refillUrl. The fetcher is a closure over the handler's
+                // resolveTrackList(url), so refills go through the same
+                // SSRF guard / JSPF parser / LB-token auto-attach as the
+                // initial pool fetch.
+                playbackController.setPoolFetcher { url ->
+                    protocolPlayHandler.resolveTrackList(url)
+                }
                 when (val r = protocolPlayHandler.handle(action)) {
                     is ProtocolPlayResult.Started ->
                         PlayRadioResult.StartedModeC(r.displayName, r.trackCount)

--- a/app/src/main/java/com/parachord/android/deeplink/PlayRadioDispatcher.kt
+++ b/app/src/main/java/com/parachord/android/deeplink/PlayRadioDispatcher.kt
@@ -1,0 +1,58 @@
+package com.parachord.android.deeplink
+
+import com.parachord.android.playback.PlaybackController
+import com.parachord.shared.deeplink.DeepLinkAction
+import com.parachord.shared.deeplink.ProtocolPlayTeardown
+import com.parachord.shared.deeplink.RadioMode
+import com.parachord.shared.platform.Log
+
+private const val TAG = "PlayRadioDispatcher"
+
+/**
+ * Orchestrator for `parachord://play/radio` (Phase 3, issue #121).
+ *
+ * Splits the two radio modes:
+ *
+ *  - **Mode B (artist seed)** — `?artist=<name>[&title=<hint>]`. Tears down
+ *    the prior playback context, then dispatches into
+ *    [PlaybackController.startSpinoffWithSeed]. Title-bearing seeds use
+ *    Last.fm `track.getsimilar`; artist-only seeds fall back to
+ *    `artist.getTopTracks`.
+ *  - **Mode C (pool-based)** — `?url=`/`?tracks=`/`?refill=`. Wired in
+ *    Task 4 (this file is left intentionally minimal until then).
+ *
+ * Acknowledgment toast ("Building radio…") fires before teardown so the
+ * user gets immediate feedback that the deeplink was understood.
+ *
+ * **Teardown semantics**: Mode B clears the queue + exits any active
+ * spinoff + stops listen-along, matching the Phase 2 album/playlist
+ * behavior. The in-app right-click → Spinoff path does NOT call teardown
+ * (it preserves the queue and returns to it on exit), but the deeplink
+ * path is "start fresh radio" semantics, so teardown is correct here.
+ */
+class PlayRadioDispatcher(
+    private val playbackController: PlaybackController,
+    private val teardown: ProtocolPlayTeardown,
+    private val toast: suspend (String) -> Unit,
+) {
+    suspend fun dispatch(action: DeepLinkAction.PlayRadio) {
+        when (val mode = action.mode) {
+            is RadioMode.ArtistSeed -> {
+                toast("Building radio…")
+                teardown.prepareForNewPlayback()
+                playbackController.startSpinoffWithSeed(
+                    seedArtist = mode.artist,
+                    seedTitle = mode.title,
+                    displayName = action.name
+                        ?: mode.title?.let { "Radio: ${mode.artist} – $it" }
+                        ?: "Radio: ${mode.artist}",
+                )
+            }
+            is RadioMode.PoolBased -> {
+                // Wired in Task 4.
+                Log.d(TAG, "Mode C (pool-based) not yet wired: $action")
+                toast("Mode C coming next commit")
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/parachord/android/deeplink/PlayRadioDispatcher.kt
+++ b/app/src/main/java/com/parachord/android/deeplink/PlayRadioDispatcher.kt
@@ -2,14 +2,16 @@ package com.parachord.android.deeplink
 
 import com.parachord.android.playback.PlaybackController
 import com.parachord.shared.deeplink.DeepLinkAction
+import com.parachord.shared.deeplink.ProtocolPlayInput
 import com.parachord.shared.deeplink.ProtocolPlayTeardown
 import com.parachord.shared.deeplink.RadioMode
+import java.net.URLEncoder
 
 /** One-shot result for the toast / log surface. Mirrors [ProtocolPlayResult]. */
 sealed class PlayRadioResult {
-    /** Mode B successfully kicked off (Last.fm fetch starts in background). */
+    /** Mode B title-bearing successfully kicked off (Last.fm fetch starts in background). */
     data class StartedModeB(val displayName: String) : PlayRadioResult()
-    /** Mode C successfully kicked off — N tracks in pool. */
+    /** Mode C / Mode B artist-only successfully kicked off — N tracks in pool. */
     data class StartedModeC(val displayName: String, val trackCount: Int) : PlayRadioResult()
     data class Failed(val reason: String) : PlayRadioResult()
 }
@@ -17,25 +19,32 @@ sealed class PlayRadioResult {
 /**
  * Orchestrator for `parachord://play/radio` (Phase 3, issue #121).
  *
- * Splits the two radio modes:
+ * Three real branches once you split Mode B by whether a track hint is
+ * present:
  *
- *  - **Mode B (artist seed)** — `?artist=<name>[&title=<hint>]`. Tears down
- *    the prior playback context, then dispatches into
- *    [PlaybackController.startSpinoffWithSeed]. Title-bearing seeds use
- *    Last.fm `track.getsimilar`; artist-only seeds fall back to
- *    `artist.getTopTracks`.
+ *  - **Mode B title-bearing** — `?artist=<name>&title=<hint>`. Per-track
+ *    spinoff via Last.fm `track.getsimilar` — same backend as the in-app
+ *    right-click → Spinoff. Tears down prior playback then dispatches
+ *    into [PlaybackController.startSpinoffWithSeed].
+ *  - **Mode B artist-only** — `?artist=<name>` (no title). Synthesizes a
+ *    ListenBrainz `lb-radio` URL and routes through the SAME pool path
+ *    as Mode C. The synthesized URL is reused as the refill URL so the
+ *    radio keeps generating fresh tracks across pool drains. The LB
+ *    token auto-attach plugin (Task 2) supplies the user's token for
+ *    free since the host is `api.listenbrainz.org`.
  *  - **Mode C (pool-based)** — `?url=`/`?tracks=`/`?refill=`. Delegates
- *    to [ProtocolPlayHandler] for resolve + teardown + entity build, then
- *    [PlaybackController.startPoolBasedSpinoff] for the pool kick-off.
- *    The acknowledgment toast ("Building radio…") is the VM's
- *    responsibility — emitted before [dispatch] runs since Mode C URL
- *    fetch can take seconds and the user needs feedback.
+ *    to [ProtocolPlayHandler] for resolve + teardown + entity build,
+ *    then [PlaybackController.startPoolBasedSpinoff] for the pool
+ *    kick-off. The acknowledgment toast ("Building radio…") is the VM's
+ *    responsibility — emitted before [dispatch] runs since URL fetch
+ *    can take seconds and the user needs feedback.
  *
- * **Teardown semantics**: both modes clear the queue + exit any active
- * spinoff + stop listen-along, matching the Phase 2 album/playlist
- * behavior. The in-app right-click → Spinoff path does NOT call teardown
- * (it preserves the queue and returns to it on exit), but the deeplink
- * path is "start fresh radio" semantics, so teardown is correct here.
+ * **Teardown semantics**: every branch clears the queue + exits any
+ * active spinoff + stops listen-along, matching the Phase 2
+ * album/playlist behavior. The in-app right-click → Spinoff path does
+ * NOT call teardown (it preserves the queue and returns to it on exit),
+ * but the deeplink path is "start fresh radio" semantics, so teardown
+ * is correct here.
  */
 class PlayRadioDispatcher(
     private val playbackController: PlaybackController,
@@ -45,56 +54,91 @@ class PlayRadioDispatcher(
     suspend fun dispatch(action: DeepLinkAction.PlayRadio): PlayRadioResult {
         return when (val mode = action.mode) {
             is RadioMode.ArtistSeed -> {
-                teardown.prepareForNewPlayback()
-                val displayName = action.name
-                    ?: mode.title?.let { "Radio: ${mode.artist} – $it" }
-                    ?: "Radio: ${mode.artist}"
-                playbackController.startSpinoffWithSeed(
-                    seedArtist = mode.artist,
-                    seedTitle = mode.title,
-                    displayName = displayName,
-                    // Mode B is "start fresh radio now" semantics — kick
-                    // the first pool track immediately rather than
-                    // waiting for an existing song to finish (the
-                    // teardown above clears the queue but doesn't stop
-                    // whatever's currently playing).
-                    kickStartFirstTrack = true,
-                )
-                PlayRadioResult.StartedModeB(displayName)
-            }
-            is RadioMode.PoolBased -> {
-                // Mode C delegates resolve + teardown + entity build to
-                // ProtocolPlayHandler. Translate its result into our
-                // result type so the VM only has one sealed match site.
-                //
-                // Wire the refill fetcher BEFORE the handler runs so
-                // startPoolBasedSpinoff() — invoked synchronously inside
-                // handle() — sees a configured fetcher when it sets the
-                // refillUrl. The fetcher is a closure over the handler's
-                // resolveTrackList(url), so refills go through the same
-                // SSRF guard / JSPF parser / LB-token auto-attach as the
-                // initial pool fetch.
-                playbackController.setPoolFetcher { url ->
-                    protocolPlayHandler.resolveTrackList(url)
-                }
-                // Show the mini-player spinner during the URL fetch +
-                // parse + resolve cascade (can take multiple seconds).
-                // try/finally guarantees the flag clears on failure
-                // paths too, even though startPoolBasedSpinoff()'s
-                // playTrack call would otherwise clear it via the
-                // currentTrack=null → non-null transition.
-                playbackController.setPlaybarLoading(true)
-                try {
-                    when (val r = protocolPlayHandler.handle(action)) {
-                        is ProtocolPlayResult.Started ->
-                            PlayRadioResult.StartedModeC(r.displayName, r.trackCount)
-                        is ProtocolPlayResult.Failed ->
-                            PlayRadioResult.Failed(r.reason)
-                    }
-                } finally {
-                    playbackController.setPlaybarLoading(false)
+                if (mode.title != null) {
+                    // Title-bearing seed: per-track spinoff via Last.fm
+                    // track.getsimilar (same backend as in-app spinoff).
+                    teardown.prepareForNewPlayback()
+                    val displayName = action.name
+                        ?: "Radio: ${mode.artist} – ${mode.title}"
+                    playbackController.startSpinoffWithSeed(
+                        seedArtist = mode.artist,
+                        seedTitle = mode.title,
+                        displayName = displayName,
+                        // Mode B is "start fresh radio now" semantics — kick
+                        // the first pool track immediately rather than
+                        // waiting for an existing song to finish (the
+                        // teardown above clears the queue but doesn't stop
+                        // whatever's currently playing).
+                        kickStartFirstTrack = true,
+                    )
+                    PlayRadioResult.StartedModeB(displayName)
+                } else {
+                    // Artist-only seed: route through ListenBrainz LB
+                    // Radio via the Mode C pool path. The synthesized
+                    // URL is also the refill URL — same endpoint keeps
+                    // generating fresh tracks across drains. LB token
+                    // auto-attach (Task 2) applies the user's token
+                    // since the host is api.listenbrainz.org.
+                    val lbRadioUrl = buildLbRadioUrl(artist = mode.artist)
+                    val displayName = action.name ?: "Radio: ${mode.artist}"
+                    val syntheticAction = DeepLinkAction.PlayRadio(
+                        mode = RadioMode.PoolBased,
+                        input = ProtocolPlayInput(url = lbRadioUrl),
+                        refillUrl = lbRadioUrl,
+                        name = displayName,
+                    )
+                    dispatchPoolBased(syntheticAction)
                 }
             }
+            is RadioMode.PoolBased -> dispatchPoolBased(action)
         }
+    }
+
+    /**
+     * Shared Mode C pool path — used by both real Mode C deeplinks and
+     * the synthesized LB Radio action for Mode B artist-only.
+     *
+     * Wires the refill fetcher BEFORE the handler runs so
+     * `startPoolBasedSpinoff()` — invoked synchronously inside `handle()` —
+     * sees a configured fetcher when it sets the refillUrl. The fetcher
+     * is a closure over the handler's `resolveTrackList(url)`, so refills
+     * go through the same SSRF guard / JSPF parser / LB-token auto-attach
+     * as the initial pool fetch.
+     *
+     * Shows the mini-player spinner during the URL fetch + parse + resolve
+     * cascade. try/finally guarantees the flag clears on failure paths.
+     */
+    private suspend fun dispatchPoolBased(action: DeepLinkAction.PlayRadio): PlayRadioResult {
+        playbackController.setPoolFetcher { url ->
+            protocolPlayHandler.resolveTrackList(url)
+        }
+        playbackController.setPlaybarLoading(true)
+        return try {
+            when (val r = protocolPlayHandler.handle(action)) {
+                is ProtocolPlayResult.Started ->
+                    PlayRadioResult.StartedModeC(r.displayName, r.trackCount)
+                is ProtocolPlayResult.Failed ->
+                    PlayRadioResult.Failed(r.reason)
+            }
+        } finally {
+            playbackController.setPlaybarLoading(false)
+        }
+    }
+
+    /**
+     * Synthesize a ListenBrainz LB Radio URL for an artist-only seed.
+     *
+     * Prompt syntax follows troi.readthedocs.io/en/latest/lb_radio.html:
+     * `artist:(<name>)` → seed by artist similarity. Mode `easy` is the
+     * troi default — most-relevant data, fewest deep cuts.
+     *
+     * The colon and parentheses in the prompt are reserved characters
+     * in a query string. URLEncoder encodes them to `%3A`, `%28`, `%29`
+     * — what the LB endpoint expects.
+     */
+    private fun buildLbRadioUrl(artist: String): String {
+        val prompt = "artist:($artist)"
+        val encoded = URLEncoder.encode(prompt, "UTF-8")
+        return "https://api.listenbrainz.org/1/explore/lb-radio?prompt=$encoded&mode=easy"
     }
 }

--- a/app/src/main/java/com/parachord/android/deeplink/ProtocolPlayHandler.kt
+++ b/app/src/main/java/com/parachord/android/deeplink/ProtocolPlayHandler.kt
@@ -114,10 +114,12 @@ class ProtocolPlayHandler constructor(
         }
 
         // Display-name precedence: explicit action.name → input.title →
-        // resolver displayName → "Radio".
-        val displayName = action.name
-            ?: input.title
-            ?: resolved.displayName
+        // resolver displayName → "Radio". Treat blank strings as missing
+        // so an XSPF/JSPF parser that returns an empty title still falls
+        // through to the literal default rather than rendering "".
+        val displayName = action.name?.takeIf { it.isNotBlank() }
+            ?: input.title?.takeIf { it.isNotBlank() }
+            ?: resolved.displayName.takeIf { it.isNotBlank() }
             ?: "Radio"
 
         // Step 2: teardown — matches handle(PlayAlbum/PlayPlaylist) ordering
@@ -136,8 +138,10 @@ class ProtocolPlayHandler constructor(
             )
         }
 
-        // Step 4: pre-resolve the FIRST track so playback starts on a
-        // known-good source — same gate as runHandle.
+        // Step 4: pre-warm the resolver cache for the first track. This
+        // kicks off the resolver pipeline asynchronously — playTrackInternal's
+        // on-demand fallback would handle it anyway, but pre-warming
+        // reduces the time to first audio.
         try {
             trackResolverCache.resolveInBackground(listOf(entities.first()), backfillDb = false)
         } catch (e: Exception) {

--- a/app/src/main/java/com/parachord/android/deeplink/ProtocolPlayHandler.kt
+++ b/app/src/main/java/com/parachord/android/deeplink/ProtocolPlayHandler.kt
@@ -9,6 +9,7 @@ import com.parachord.shared.deeplink.ProtocolPlayInput
 import com.parachord.shared.deeplink.ProtocolPlayTeardown
 import com.parachord.shared.deeplink.ProtocolResolveOptions
 import com.parachord.shared.deeplink.ProtocolTrack
+import com.parachord.shared.deeplink.RadioMode
 import com.parachord.shared.deeplink.ResolvedProtocolPlay
 import com.parachord.shared.deeplink.resolveProtocolPlayInput
 import com.parachord.shared.platform.Log
@@ -67,12 +68,92 @@ class ProtocolPlayHandler constructor(
         allowMbid = false, allowProviderId = false, allowUrl = true,
         allowTracks = true, allowArtistTitleAlbum = false,
     )
+    /** Mode C accepts only `url=` (hosted tracklist) or `tracks=` (inline). */
+    private val radioPoolOpts = ProtocolResolveOptions(
+        allowMbid = false, allowProviderId = false, allowUrl = true,
+        allowTracks = true, allowArtistTitleAlbum = false,
+    )
 
     suspend fun handle(action: DeepLinkAction.PlayAlbum): ProtocolPlayResult =
         runHandle("album", action.input, albumOpts)
 
     suspend fun handle(action: DeepLinkAction.PlayPlaylist): ProtocolPlayResult =
         runHandle("playlist", action.input, playlistOpts)
+
+    /**
+     * `parachord://play/radio` — Mode C (pool-based) only.
+     *
+     * Mode B (artist seed) bypasses this handler entirely; it goes
+     * straight from [PlayRadioDispatcher] into
+     * [PlaybackController.startSpinoffWithSeed]. Mode C, by contrast,
+     * needs the resolver cascade (URL fetch → JSPF/XSPF/M3U parse OR
+     * inline tracks) before a pool can be built.
+     *
+     * Order of operations mirrors [runHandle]:
+     * resolve → empty-check → teardown → build entities (`protocol-radio-*`
+     * IDs) → pre-warm first track → handoff to
+     * [PlaybackController.startPoolBasedSpinoff].
+     */
+    suspend fun handle(action: DeepLinkAction.PlayRadio): ProtocolPlayResult {
+        require(action.mode is RadioMode.PoolBased) {
+            "ProtocolPlayHandler only handles PoolBased radio; ArtistSeed goes through PlaybackController.startSpinoffWithSeed directly"
+        }
+        val input = action.input
+            ?: return ProtocolPlayResult.Failed("Radio missing input")
+
+        // Step 1: resolve.
+        val resolved: ResolvedProtocolPlay = try {
+            resolveProtocolPlayInput(input, radioPoolOpts, resolver)
+                ?: return ProtocolPlayResult.Failed("Radio: nothing to play")
+        } catch (e: Exception) {
+            Log.w(TAG, "Radio resolve failed: ${e.message}")
+            return ProtocolPlayResult.Failed(e.message ?: "Radio fetch failed")
+        }
+        if (resolved.tracks.isEmpty()) {
+            return ProtocolPlayResult.Failed("Radio: empty pool")
+        }
+
+        // Display-name precedence: explicit action.name → input.title →
+        // resolver displayName → "Radio".
+        val displayName = action.name
+            ?: input.title
+            ?: resolved.displayName
+            ?: "Radio"
+
+        // Step 2: teardown — matches handle(PlayAlbum/PlayPlaylist) ordering
+        // (only fire after we know we have something to play).
+        teardown.prepareForNewPlayback()
+
+        // Step 3: build TrackEntity list with stable protocol-radio-{ts}-{idx} IDs.
+        val ts = currentTimeMillis()
+        val entities = resolved.tracks.mapIndexed { idx, t ->
+            TrackEntity(
+                id = "protocol-radio-$ts-$idx",
+                title = t.title,
+                artist = t.artist,
+                album = t.album,
+                artworkUrl = resolved.albumArt,
+            )
+        }
+
+        // Step 4: pre-resolve the FIRST track so playback starts on a
+        // known-good source — same gate as runHandle.
+        try {
+            trackResolverCache.resolveInBackground(listOf(entities.first()), backfillDb = false)
+        } catch (e: Exception) {
+            Log.w(TAG, "Pool first-track pre-resolve failed: ${e.message}")
+        }
+
+        // Step 5: hand off to the pool-based spinoff entry point. The
+        // controller does its own clearQueue() + spinoff context wiring
+        // atomically; refill URL captured for Task 5.
+        playbackController.startPoolBasedSpinoff(entities, displayName, action.refillUrl)
+        if (entities.size > 1) {
+            trackResolverCache.resolveInBackground(entities.drop(1), backfillDb = false)
+        }
+
+        return ProtocolPlayResult.Started(displayName, entities.size)
+    }
 
     private suspend fun runHandle(
         cmd: String,

--- a/app/src/main/java/com/parachord/android/deeplink/ProtocolPlayHandler.kt
+++ b/app/src/main/java/com/parachord/android/deeplink/ProtocolPlayHandler.kt
@@ -74,6 +74,22 @@ class ProtocolPlayHandler constructor(
         allowTracks = true, allowArtistTitleAlbum = false,
     )
 
+    /**
+     * Resolve a hosted-tracklist URL into a list of [ProtocolTrack].
+     *
+     * Used by [PlayRadioDispatcher] to wire the Mode C refill fetcher
+     * — same resolver path as the initial pool fetch, so SSRF guard,
+     * JSPF/XSPF/M3U parser cascade, and LB-token auto-attach all apply
+     * for free. Exceptions propagate to the caller (the refiller
+     * catches them and counts as empty).
+     *
+     * Returns an empty list when the URL doesn't resolve to anything
+     * (caller treats this same as an error — counts as empty for the
+     * stop-condition counter).
+     */
+    suspend fun resolveTrackList(url: String): List<ProtocolTrack> =
+        resolver.resolveByUrl(url)?.tracks ?: emptyList()
+
     suspend fun handle(action: DeepLinkAction.PlayAlbum): ProtocolPlayResult =
         runHandle("album", action.input, albumOpts)
 

--- a/app/src/main/java/com/parachord/android/di/AndroidModule.kt
+++ b/app/src/main/java/com/parachord/android/di/AndroidModule.kt
@@ -730,6 +730,12 @@ val androidModule = module {
             protocolPlayHandler = get(),
         )
     }
+    single {
+        com.parachord.android.deeplink.ListenAlongDispatcher(
+            friendsRepository = get(),
+            teardown = get(),
+        )
+    }
 
     // ── Sync ─────────────────────────────────────────────────────────
 

--- a/app/src/main/java/com/parachord/android/di/AndroidModule.kt
+++ b/app/src/main/java/com/parachord/android/di/AndroidModule.kt
@@ -723,6 +723,13 @@ val androidModule = module {
             trackResolverCache = get(),
         )
     }
+    single {
+        com.parachord.android.deeplink.PlayRadioDispatcher(
+            playbackController = get(),
+            teardown = get(),
+            protocolPlayHandler = get(),
+        )
+    }
 
     // ── Sync ─────────────────────────────────────────────────────────
 

--- a/app/src/main/java/com/parachord/android/playback/PlaybackController.kt
+++ b/app/src/main/java/com/parachord/android/playback/PlaybackController.kt
@@ -149,6 +149,17 @@ class PlaybackController constructor(
     private var preSpinoffContext: PlaybackContext? = null
     private var spinoffJob: Job? = null
 
+    // ── Pool-based spinoff (Mode C) refill state ────────────────────────
+    // Captured by [startPoolBasedSpinoff]; read by Task 5's refill loop
+    // (`parachord://play/radio?refill=…`). Only meaningful while the
+    // current spinoff is pool-based (id == "pool-based"). For
+    // seed-based spinoffs these stay null/0.
+    // TODO(#121 Task 5): reset poolRefillUrl / poolRefillEmptyCount /
+    //  poolLastRefillTs in `exitSpinoff()` once the refill loop lands.
+    private var poolRefillUrl: String? = null
+    private var poolRefillEmptyCount: Int = 0
+    private var poolLastRefillTs: Long = 0L
+
     fun connect() {
         if (controllerFuture != null) return
 
@@ -1622,6 +1633,79 @@ class PlaybackController constructor(
                 stateHolder.update { copy(spinoffLoading = false) }
             }
         }
+    }
+
+    /**
+     * Pool-based spinoff (Mode C of `parachord://play/radio`).
+     *
+     * No Last.fm seed step — the caller supplies an already-resolved pool,
+     * pre-built from inline `?tracks=` JSON or a fetched JSPF/XSPF/M3U
+     * tracklist. Mirrors desktop's "externally curated pool" path.
+     *
+     * [refillUrl], when non-null, is captured for Task 5's refill loop to
+     * re-fetch from once `spinoffPool.size < 3`. Stored here; not read in
+     * this commit.
+     *
+     * [displayName] is the station name shown in the banner. Pool-based
+     * spinoffs have no source track, so the banner branch (Task 6) renders
+     * just this string instead of "Spun off from X by Y".
+     *
+     * The spinoff [PlaybackContext] uses `id = "pool-based"` as a sentinel
+     * so Task 6's banner branch can distinguish pool-based from seed-based.
+     */
+    fun startPoolBasedSpinoff(
+        initialPool: List<TrackEntity>,
+        displayName: String,
+        refillUrl: String? = null,
+    ) {
+        if (initialPool.isEmpty()) {
+            Log.w(TAG, "startPoolBasedSpinoff: empty pool, ignoring")
+            return
+        }
+
+        spinoffJob?.cancel()
+        spinoffPool.clear()
+        // Pool-based has no source track — Task 6's banner branch keys off
+        // `spinoffSourceTrack == null` to render "$displayName" rather
+        // than "Spun off from $title by $artist".
+        spinoffSourceTrack = null
+
+        // Save previous playback context (queue is NOT modified — desktop behavior)
+        preSpinoffContext = queueManager.playbackContext
+
+        spinoffPool.addAll(initialPool)
+
+        // Capture refill state for Task 5's refill loop. Reset siblings
+        // (every entry resets — harmless if exitSpinoff hasn't yet wired
+        // its own reset, since they're re-initialized here on every call).
+        poolRefillUrl = refillUrl
+        poolRefillEmptyCount = 0
+        poolLastRefillTs = 0L
+
+        val spinoffContext = PlaybackContext(
+            type = "spinoff",
+            name = displayName,
+            // Sentinel — Task 6's banner branch uses this to distinguish
+            // pool-based ("just show displayName") from seed-based
+            // ("Spun off from $title by $artist").
+            id = "pool-based",
+        )
+
+        stateHolder.update {
+            copy(
+                spinoffMode = true,
+                spinoffLoading = false,
+                spinoffAvailable = true,
+            )
+        }
+
+        // Kick-start: pull the first pool track and play it now. Mirrors
+        // the Mode B kick-start path in [startSpinoffWithSeed] — playTrack
+        // clearQueue()s atomically and re-applies the spinoff context, so
+        // a bare setContext() before playTrack() would get clobbered.
+        val first = spinoffPool.removeAt(0)
+        Log.d(TAG, "Pool spinoff: kicking off '$displayName' with '${first.title}' by ${first.artist} (${spinoffPool.size} remaining)")
+        playTrack(first, context = spinoffContext)
     }
 
     /**

--- a/app/src/main/java/com/parachord/android/playback/PlaybackController.kt
+++ b/app/src/main/java/com/parachord/android/playback/PlaybackController.kt
@@ -1716,6 +1716,18 @@ class PlaybackController constructor(
     }
 
     /**
+     * Toggle the playbar loading flag, used by the deeplink dispatcher
+     * to show a spinner in the mini-player while a Mode C radio pool
+     * is being fetched (multi-second URL fetch + parse + resolve).
+     * The flag clears automatically once a track lands in
+     * [PlaybackState.currentTrack], but the dispatcher also clears it
+     * via a finally-block so failure paths don't leave it stuck.
+     */
+    fun setPlaybarLoading(loading: Boolean) {
+        stateHolder.update { copy(isPlaybarLoading = loading) }
+    }
+
+    /**
      * Pool-based spinoff (Mode C of `parachord://play/radio`).
      *
      * No Last.fm seed step — the caller supplies an already-resolved pool,

--- a/app/src/main/java/com/parachord/android/playback/PlaybackController.kt
+++ b/app/src/main/java/com/parachord/android/playback/PlaybackController.kt
@@ -1443,11 +1443,23 @@ class PlaybackController constructor(
      * directly. When null, falls back to `"Spinoff from $seedTitle"` (or
      * `"Radio: $seedArtist"` when title is also null) — preserves the
      * existing in-app banner copy for the wrapper [startSpinoff].
+     *
+     * [kickStartFirstTrack] controls whether the first pool track plays
+     * immediately once the pool is populated. The deeplink (Mode B) path
+     * passes `true` — radio should start playing now, regardless of
+     * whatever was previously on. The in-app spinoff path passes the
+     * default `false` so the existing track keeps playing and
+     * `skipNextInternal` pulls from the pool when it ends. Don't infer
+     * this from runtime state — `stateHolder.currentTrack` survives a
+     * teardown's `clearQueue()` call (it only clears on track-end /
+     * explicit stop), so the previous "currentTrack == null" guard
+     * silently failed to kick on Mode B when a song was playing.
      */
     fun startSpinoffWithSeed(
         seedArtist: String,
         seedTitle: String?,
         displayName: String? = null,
+        kickStartFirstTrack: Boolean = false,
     ) {
         if (stateHolder.state.value.spinoffMode) return // already active
 
@@ -1563,8 +1575,7 @@ class PlaybackController constructor(
                 spinoffPool.clear()
                 spinoffPool.addAll(resolvedTracks)
 
-                // Set playback context to spinoff (queue contents untouched).
-                queueManager.setContext(PlaybackContext(type = "spinoff", name = resolvedDisplayName))
+                val spinoffContext = PlaybackContext(type = "spinoff", name = resolvedDisplayName)
 
                 stateHolder.update {
                     copy(
@@ -1583,16 +1594,25 @@ class PlaybackController constructor(
                     Toast.makeText(context, toast, Toast.LENGTH_SHORT).show()
                 }
 
-                // Mode B (artist-only, no current track) needs an explicit
-                // kick — there's nothing currently playing to advance INTO
-                // the pool. The in-app title-bearing path lets the current
-                // song finish and skipNextInternal() pulls from the pool.
-                if (seedTitle == null && stateHolder.state.value.currentTrack == null && spinoffPool.isNotEmpty()) {
+                // Kick-start path (Mode B / deeplink): pull the first pool
+                // track and play it now. playTrack() will clearQueue() and
+                // then re-apply the spinoff context atomically — that's
+                // why the context is passed through here instead of being
+                // pre-set; a bare setContext() before playTrack() would
+                // get clobbered by playTrack's internal clearQueue().
+                //
+                // Non-kick path (in-app spinoff): the current track keeps
+                // playing; set the context now so the banner updates
+                // immediately, and let skipNextInternal() pull from the
+                // pool when the current song ends.
+                if (kickStartFirstTrack && spinoffPool.isNotEmpty()) {
                     val first = spinoffPool.removeAt(0)
-                    Log.d(TAG, "Spinoff: kicking off Mode B with '${first.title}' by ${first.artist}")
+                    Log.d(TAG, "Spinoff: kicking off with '${first.title}' by ${first.artist}")
                     withContext(Dispatchers.Main) {
-                        playTrack(first)
+                        playTrack(first, context = spinoffContext)
                     }
+                } else {
+                    queueManager.setContext(spinoffContext)
                 }
             } catch (e: Exception) {
                 Log.e(TAG, "Spinoff: failed to start", e)

--- a/app/src/main/java/com/parachord/android/playback/PlaybackController.kt
+++ b/app/src/main/java/com/parachord/android/playback/PlaybackController.kt
@@ -154,8 +154,12 @@ class PlaybackController constructor(
     // (`parachord://play/radio?refill=…`). Only meaningful while the
     // current spinoff is pool-based (id == "pool-based"). For
     // seed-based spinoffs these stay null/0.
-    // TODO(#121 Task 5): reset poolRefillUrl / poolRefillEmptyCount /
-    //  poolLastRefillTs in `exitSpinoff()` once the refill loop lands.
+    //
+    // Reset on every [startPoolBasedSpinoff] entry AND on [exitSpinoff]
+    // to prevent cross-mode state leak — without the exit reset, a Mode B
+    // spinoff that follows a Mode C exit would see a leftover non-null
+    // poolRefillUrl. Task 5's refill loop only reads these fields; it
+    // doesn't need to write reset logic.
     private var poolRefillUrl: String? = null
     private var poolRefillEmptyCount: Int = 0
     private var poolLastRefillTs: Long = 0L
@@ -1658,11 +1662,8 @@ class PlaybackController constructor(
         displayName: String,
         refillUrl: String? = null,
     ) {
-        if (initialPool.isEmpty()) {
-            Log.w(TAG, "startPoolBasedSpinoff: empty pool, ignoring")
-            return
-        }
-
+        // Callers must pass a non-empty pool — empty pools are filtered
+        // upstream by ProtocolPlayHandler.handle(PlayRadio).
         spinoffJob?.cancel()
         spinoffPool.clear()
         // Pool-based has no source track — Task 6's banner branch keys off
@@ -1718,6 +1719,9 @@ class PlaybackController constructor(
         spinoffJob?.cancel()
         spinoffPool.clear()
         spinoffSourceTrack = null
+        poolRefillUrl = null
+        poolRefillEmptyCount = 0
+        poolLastRefillTs = 0L
 
         // Restore previous playback context (queue was never modified)
         queueManager.setContext(preSpinoffContext)

--- a/app/src/main/java/com/parachord/android/playback/PlaybackController.kt
+++ b/app/src/main/java/com/parachord/android/playback/PlaybackController.kt
@@ -1664,13 +1664,25 @@ class PlaybackController constructor(
      * on Android since context is queue-level, not per-track).
      */
     private fun triggerPoolRefill() {
+        // Cheap fast-path so we don't pay for a snapshot copy or coroutine
+        // launch when the refiller is rate-limited / stopped / unconfigured.
+        if (!poolRefiller.canRefill()) return
+        // Snapshot on the caller's thread (controller scope = Main, same
+        // thread as skipNextInternal's removeAt(0)) so we don't race a
+        // concurrent modification of [spinoffPool] (a plain mutableListOf,
+        // not thread-safe) during toList().
+        val snapshot = spinoffPool.toList()
         scope.launch(Dispatchers.IO) {
             try {
-                val snapshot = spinoffPool.toList()
                 val fresh = poolRefiller.tryRefill(snapshot) ?: return@launch
-                spinoffPool.addAll(fresh)
-                Log.d(TAG, "Pool refill: appended ${fresh.size} tracks (pool now ${spinoffPool.size})")
+                // addAll back on Main — same dispatcher as skipNextInternal's
+                // removeAt(0). Pool mutations stay on a single thread.
+                withContext(Dispatchers.Main) {
+                    spinoffPool.addAll(fresh)
+                    Log.d(TAG, "Pool refill: appended ${fresh.size} tracks (pool now ${spinoffPool.size})")
+                }
                 // Pre-warm resolver cache so they're ready when consumed.
+                // Stays on IO — TrackResolverCache is internally thread-safe.
                 try {
                     trackResolverCache.resolveInBackground(fresh, backfillDb = false, priority = false)
                 } catch (e: Exception) {
@@ -1710,9 +1722,8 @@ class PlaybackController constructor(
      * pre-built from inline `?tracks=` JSON or a fetched JSPF/XSPF/M3U
      * tracklist. Mirrors desktop's "externally curated pool" path.
      *
-     * [refillUrl], when non-null, is captured for Task 5's refill loop to
-     * re-fetch from once `spinoffPool.size < 3`. Stored here; not read in
-     * this commit.
+     * [refillUrl], when non-null, is forwarded to [poolRefiller] so the
+     * refill loop fires when `spinoffPool.size < POOL_REFILL_THRESHOLD`.
      *
      * [displayName] is the station name shown in the banner. Pool-based
      * spinoffs have no source track, so the banner branch (Task 6) renders

--- a/app/src/main/java/com/parachord/android/playback/PlaybackController.kt
+++ b/app/src/main/java/com/parachord/android/playback/PlaybackController.kt
@@ -1523,6 +1523,8 @@ class PlaybackController constructor(
                         apiKey = BuildConfig.LASTFM_API_KEY,
                         limit = SPINOFF_SIMILAR_LIMIT,
                     )
+                    // DEBUG #121: log response shape to diagnose empty-pool reports
+                    Log.d(TAG, "Spinoff DEBUG: getArtistTopTracks($seedArtist) → toptracks=${response.toptracks != null}, track.size=${response.toptracks?.track?.size}, key.len=${BuildConfig.LASTFM_API_KEY.length}, firstTrack=${response.toptracks?.track?.firstOrNull()?.name}")
                     response.toptracks?.track.orEmpty().mapNotNull {
                         // For top-tracks the artist is the seed artist (LfmTopTrackArtist
                         // mirrors what we requested) but fall back gracefully.

--- a/app/src/main/java/com/parachord/android/playback/PlaybackController.kt
+++ b/app/src/main/java/com/parachord/android/playback/PlaybackController.kt
@@ -1454,21 +1454,19 @@ class PlaybackController constructor(
 
     /**
      * Generalized spinoff entry point — used by the in-app right-click →
-     * Spinoff action (via [startSpinoff]) and by `parachord://play/radio?artist=…`
-     * (Mode B).
+     * Spinoff action (via [startSpinoff]) and by `parachord://play/radio?artist=X&title=Y`
+     * (Mode B title-bearing).
      *
-     * Seed forms:
-     *  - `(artist, title)` → Last.fm `track.getsimilar` cascade (same path
-     *    as in-app spinoff has always used).
-     *  - `(artist, null)` → Last.fm `artist.getTopTracks` cascade (Mode B
-     *    fallback when the deeplink has no track hint). Top tracks isn't
-     *    quite "similar tracks", but it's the closest thing Last.fm offers
-     *    for an artist-only seed and matches the desktop's Mode B path.
+     * Seed form: `(artist, title)` → Last.fm `track.getsimilar` cascade
+     * (same path as in-app spinoff has always used). [seedTitle] is
+     * required — artist-only radio (`?artist=X` with no title) does NOT
+     * route through here. It synthesizes a ListenBrainz `lb-radio` URL
+     * upstream in [PlayRadioDispatcher] and falls into the Mode C pool
+     * path via [ProtocolPlayHandler].
      *
      * [displayName], when non-null, sets the [PlaybackContext.name]
-     * directly. When null, falls back to `"Spinoff from $seedTitle"` (or
-     * `"Radio: $seedArtist"` when title is also null) — preserves the
-     * existing in-app banner copy for the wrapper [startSpinoff].
+     * directly. When null, falls back to `"Spinoff from $seedTitle"` —
+     * preserves the existing in-app banner copy for [startSpinoff].
      *
      * [kickStartFirstTrack] controls whether the first pool track plays
      * immediately once the pool is populated. The deeplink (Mode B) path
@@ -1487,50 +1485,34 @@ class PlaybackController constructor(
         displayName: String? = null,
         kickStartFirstTrack: Boolean = false,
     ) {
+        require(!seedTitle.isNullOrBlank()) {
+            "startSpinoffWithSeed requires seedTitle (title-bearing spinoff). " +
+                "Artist-only radio routes through ProtocolPlayHandler with an LB Radio URL."
+        }
         if (stateHolder.state.value.spinoffMode) return // already active
 
         spinoffJob?.cancel()
         stateHolder.update { copy(spinoffLoading = true) }
 
-        // Used for toast / no-results copy. Title takes precedence when present.
-        val seedDisplay = seedTitle ?: seedArtist
+        // Used for toast / no-results copy.
+        val seedDisplay = seedTitle
         // Resolved PlaybackContext name (banner). Title-bearing fallback
         // matches the historical in-app `Spinoff from <title>` template.
-        val resolvedDisplayName = displayName
-            ?: seedTitle?.let { "Spinoff from $it" }
-            ?: "Radio: $seedArtist"
+        val resolvedDisplayName = displayName ?: "Spinoff from $seedTitle"
 
         spinoffJob = scope.launch(Dispatchers.IO) {
             try {
-                // 1. Fetch similar tracks (or top tracks for artist-only seeds).
-                //    Both endpoints return `(name, artist.name)` pairs that we
-                //    can map uniformly; the only difference is the wire shape.
+                // 1. Fetch similar tracks via Last.fm `track.getsimilar`.
                 data class PoolSeed(val name: String, val artistName: String)
-                val pool: List<PoolSeed> = if (seedTitle != null) {
-                    val response = lastFmClient.getSimilarTracks(
-                        track = seedTitle,
-                        artist = seedArtist,
-                        apiKey = BuildConfig.LASTFM_API_KEY,
-                        limit = SPINOFF_SIMILAR_LIMIT,
-                    )
-                    response.similartracks?.track.orEmpty().mapNotNull {
-                        val a = it.artist?.name ?: return@mapNotNull null
-                        PoolSeed(it.name, a)
-                    }
-                } else {
-                    val response = lastFmClient.getArtistTopTracks(
-                        artist = seedArtist,
-                        apiKey = BuildConfig.LASTFM_API_KEY,
-                        limit = SPINOFF_SIMILAR_LIMIT,
-                    )
-                    // DEBUG #121: log response shape to diagnose empty-pool reports
-                    Log.d(TAG, "Spinoff DEBUG: getArtistTopTracks($seedArtist) → toptracks=${response.toptracks != null}, track.size=${response.toptracks?.track?.size}, key.len=${BuildConfig.LASTFM_API_KEY.length}, firstTrack=${response.toptracks?.track?.firstOrNull()?.name}")
-                    response.toptracks?.track.orEmpty().mapNotNull {
-                        // For top-tracks the artist is the seed artist (LfmTopTrackArtist
-                        // mirrors what we requested) but fall back gracefully.
-                        val a = it.artist?.name ?: seedArtist
-                        PoolSeed(it.name, a)
-                    }
+                val response = lastFmClient.getSimilarTracks(
+                    track = seedTitle,
+                    artist = seedArtist,
+                    apiKey = BuildConfig.LASTFM_API_KEY,
+                    limit = SPINOFF_SIMILAR_LIMIT,
+                )
+                val pool: List<PoolSeed> = response.similartracks?.track.orEmpty().mapNotNull {
+                    val a = it.artist?.name ?: return@mapNotNull null
+                    PoolSeed(it.name, a)
                 }
 
                 if (pool.isEmpty()) {
@@ -1588,9 +1570,6 @@ class PlaybackController constructor(
                 Log.d(TAG, "Spinoff: resolved ${resolvedTracks.size} tracks, ready for playback")
 
                 // 3. Save previous playback context (queue is NOT modified — desktop behavior).
-                //    Source-track concept only applies for the in-app
-                //    title-bearing seed; Mode B (artist-only) has no
-                //    "current track" to spinoff from.
                 preSpinoffContext = queueManager.playbackContext
                 spinoffSourceTrack = stateHolder.state.value.currentTrack
 
@@ -1614,12 +1593,11 @@ class PlaybackController constructor(
                 }
 
                 withContext(Dispatchers.Main) {
-                    val toast = if (seedTitle != null) {
-                        "Spinning off of $seedTitle - $seedArtist"
-                    } else {
-                        "Building radio from $seedArtist"
-                    }
-                    Toast.makeText(context, toast, Toast.LENGTH_SHORT).show()
+                    Toast.makeText(
+                        context,
+                        "Spinning off of $seedTitle - $seedArtist",
+                        Toast.LENGTH_SHORT,
+                    ).show()
                 }
 
                 // Kick-start path (Mode B / deeplink): pull the first pool

--- a/app/src/main/java/com/parachord/android/playback/PlaybackController.kt
+++ b/app/src/main/java/com/parachord/android/playback/PlaybackController.kt
@@ -1412,56 +1412,117 @@ class PlaybackController constructor(
      * Start spinoff mode: fetch similar tracks for the current track from
      * Last.fm, shuffle them, resolve each one, and begin playing from the pool.
      * Matches the desktop's startSpinoff() logic.
+     *
+     * Thin delegate over [startSpinoffWithSeed] — kept as the in-app entry
+     * point (right-click → Spinoff) so the existing toast / banner copy
+     * (`Spinoff from <title>`) stays exactly as it was.
      */
     fun startSpinoff() {
         val track = stateHolder.state.value.currentTrack ?: return
+        startSpinoffWithSeed(
+            seedArtist = track.artist,
+            seedTitle = track.title,
+            displayName = "Spinoff from ${track.title}",
+        )
+    }
+
+    /**
+     * Generalized spinoff entry point — used by the in-app right-click →
+     * Spinoff action (via [startSpinoff]) and by `parachord://play/radio?artist=…`
+     * (Mode B).
+     *
+     * Seed forms:
+     *  - `(artist, title)` → Last.fm `track.getsimilar` cascade (same path
+     *    as in-app spinoff has always used).
+     *  - `(artist, null)` → Last.fm `artist.getTopTracks` cascade (Mode B
+     *    fallback when the deeplink has no track hint). Top tracks isn't
+     *    quite "similar tracks", but it's the closest thing Last.fm offers
+     *    for an artist-only seed and matches the desktop's Mode B path.
+     *
+     * [displayName], when non-null, sets the [PlaybackContext.name]
+     * directly. When null, falls back to `"Spinoff from $seedTitle"` (or
+     * `"Radio: $seedArtist"` when title is also null) — preserves the
+     * existing in-app banner copy for the wrapper [startSpinoff].
+     */
+    fun startSpinoffWithSeed(
+        seedArtist: String,
+        seedTitle: String?,
+        displayName: String? = null,
+    ) {
         if (stateHolder.state.value.spinoffMode) return // already active
 
         spinoffJob?.cancel()
         stateHolder.update { copy(spinoffLoading = true) }
 
+        // Used for toast / no-results copy. Title takes precedence when present.
+        val seedDisplay = seedTitle ?: seedArtist
+        // Resolved PlaybackContext name (banner). Title-bearing fallback
+        // matches the historical in-app `Spinoff from <title>` template.
+        val resolvedDisplayName = displayName
+            ?: seedTitle?.let { "Spinoff from $it" }
+            ?: "Radio: $seedArtist"
+
         spinoffJob = scope.launch(Dispatchers.IO) {
             try {
-                // 1. Fetch similar tracks from Last.fm
-                val response = lastFmClient.getSimilarTracks(
-                    track = track.title,
-                    artist = track.artist,
-                    apiKey = BuildConfig.LASTFM_API_KEY,
-                    limit = SPINOFF_SIMILAR_LIMIT,
-                )
-                val similarTracks = response.similartracks?.track ?: emptyList()
+                // 1. Fetch similar tracks (or top tracks for artist-only seeds).
+                //    Both endpoints return `(name, artist.name)` pairs that we
+                //    can map uniformly; the only difference is the wire shape.
+                data class PoolSeed(val name: String, val artistName: String)
+                val pool: List<PoolSeed> = if (seedTitle != null) {
+                    val response = lastFmClient.getSimilarTracks(
+                        track = seedTitle,
+                        artist = seedArtist,
+                        apiKey = BuildConfig.LASTFM_API_KEY,
+                        limit = SPINOFF_SIMILAR_LIMIT,
+                    )
+                    response.similartracks?.track.orEmpty().mapNotNull {
+                        val a = it.artist?.name ?: return@mapNotNull null
+                        PoolSeed(it.name, a)
+                    }
+                } else {
+                    val response = lastFmClient.getArtistTopTracks(
+                        artist = seedArtist,
+                        apiKey = BuildConfig.LASTFM_API_KEY,
+                        limit = SPINOFF_SIMILAR_LIMIT,
+                    )
+                    response.toptracks?.track.orEmpty().mapNotNull {
+                        // For top-tracks the artist is the seed artist (LfmTopTrackArtist
+                        // mirrors what we requested) but fall back gracefully.
+                        val a = it.artist?.name ?: seedArtist
+                        PoolSeed(it.name, a)
+                    }
+                }
 
-                if (similarTracks.isEmpty()) {
-                    Log.d(TAG, "Spinoff: no similar tracks found for '${track.title}'")
+                if (pool.isEmpty()) {
+                    Log.d(TAG, "Spinoff: no similar/top tracks found for '$seedDisplay'")
                     withContext(Dispatchers.Main) {
-                        Toast.makeText(context, "No similar tracks found for \"${track.title}\"", Toast.LENGTH_SHORT).show()
+                        Toast.makeText(context, "No similar tracks found for \"$seedDisplay\"", Toast.LENGTH_SHORT).show()
                     }
                     stateHolder.update { copy(spinoffLoading = false, spinoffAvailable = false) }
                     return@launch
                 }
 
-                Log.d(TAG, "Spinoff: found ${similarTracks.size} similar tracks, resolving...")
+                Log.d(TAG, "Spinoff: found ${pool.size} candidate tracks for '$seedDisplay', resolving...")
 
-                // 2. Convert to TrackEntities and resolve each
+                // 2. Convert to TrackEntities and resolve each.
                 // Skip Last.fm images — they're almost always placeholder/blank.
                 // Album art will be enriched via metadata providers on playback.
                 val resolvedTracks = mutableListOf<TrackEntity>()
-                for (similar in similarTracks.shuffled()) {
-                    val artistName = similar.artist?.name ?: continue
-                    val query = "${similar.name} ${artistName}"
+                for (cand in pool.shuffled()) {
+                    val query = "${cand.name} ${cand.artistName}"
                     try {
                         val sources = resolverManager.resolve(
                             query,
-                            targetTitle = similar.name,
-                            targetArtist = artistName,
+                            targetTitle = cand.name,
+                            targetArtist = cand.artistName,
                         )
                         val best = resolverScoring.selectBest(sources) ?: continue
 
                         resolvedTracks.add(
                             TrackEntity(
-                                id = "spinoff_${similar.name}_${artistName}".hashCode().toString(),
-                                title = similar.name,
-                                artist = artistName,
+                                id = "spinoff_${cand.name}_${cand.artistName}".hashCode().toString(),
+                                title = cand.name,
+                                artist = cand.artistName,
                                 sourceUrl = best.url,
                                 resolver = best.resolver,
                                 spotifyUri = best.spotifyUri,
@@ -1471,14 +1532,14 @@ class PlaybackController constructor(
                             )
                         )
                     } catch (e: Exception) {
-                        Log.w(TAG, "Spinoff: failed to resolve '${similar.name}'", e)
+                        Log.w(TAG, "Spinoff: failed to resolve '${cand.name}'", e)
                     }
                 }
 
                 if (resolvedTracks.isEmpty()) {
                     Log.d(TAG, "Spinoff: no tracks could be resolved")
                     withContext(Dispatchers.Main) {
-                        Toast.makeText(context, "No similar tracks found for \"${track.title}\"", Toast.LENGTH_SHORT).show()
+                        Toast.makeText(context, "No similar tracks found for \"$seedDisplay\"", Toast.LENGTH_SHORT).show()
                     }
                     stateHolder.update { copy(spinoffLoading = false, spinoffAvailable = false) }
                     return@launch
@@ -1486,18 +1547,24 @@ class PlaybackController constructor(
 
                 Log.d(TAG, "Spinoff: resolved ${resolvedTracks.size} tracks, ready for playback")
 
-                // 3. Save previous playback context (queue is NOT modified — desktop behavior)
+                // 3. Save previous playback context (queue is NOT modified — desktop behavior).
+                //    Source-track concept only applies for the in-app
+                //    title-bearing seed; Mode B (artist-only) has no
+                //    "current track" to spinoff from.
                 preSpinoffContext = queueManager.playbackContext
-                spinoffSourceTrack = track
+                spinoffSourceTrack = stateHolder.state.value.currentTrack
 
                 // 4. Populate spinoff pool (separate from queue).
                 //    Don't interrupt the current song — let it finish, then
                 //    skipNextInternal() will pull from the pool automatically.
+                //    For Mode B (deeplink) the queue was already cleared by
+                //    the protocol teardown, so the pool will start playing
+                //    immediately on the next advance.
                 spinoffPool.clear()
                 spinoffPool.addAll(resolvedTracks)
 
-                // Set playback context to spinoff (queue contents untouched)
-                queueManager.setContext(PlaybackContext(type = "spinoff", name = "Spinoff from ${track.title}"))
+                // Set playback context to spinoff (queue contents untouched).
+                queueManager.setContext(PlaybackContext(type = "spinoff", name = resolvedDisplayName))
 
                 stateHolder.update {
                     copy(
@@ -1508,7 +1575,24 @@ class PlaybackController constructor(
                 }
 
                 withContext(Dispatchers.Main) {
-                    Toast.makeText(context, "Spinning off of ${track.title} - ${track.artist}", Toast.LENGTH_SHORT).show()
+                    val toast = if (seedTitle != null) {
+                        "Spinning off of $seedTitle - $seedArtist"
+                    } else {
+                        "Building radio from $seedArtist"
+                    }
+                    Toast.makeText(context, toast, Toast.LENGTH_SHORT).show()
+                }
+
+                // Mode B (artist-only, no current track) needs an explicit
+                // kick — there's nothing currently playing to advance INTO
+                // the pool. The in-app title-bearing path lets the current
+                // song finish and skipNextInternal() pulls from the pool.
+                if (seedTitle == null && stateHolder.state.value.currentTrack == null && spinoffPool.isNotEmpty()) {
+                    val first = spinoffPool.removeAt(0)
+                    Log.d(TAG, "Spinoff: kicking off Mode B with '${first.title}' by ${first.artist}")
+                    withContext(Dispatchers.Main) {
+                        playTrack(first)
+                    }
                 }
             } catch (e: Exception) {
                 Log.e(TAG, "Spinoff: failed to start", e)

--- a/app/src/main/java/com/parachord/android/playback/PlaybackController.kt
+++ b/app/src/main/java/com/parachord/android/playback/PlaybackController.kt
@@ -67,6 +67,8 @@ class PlaybackController constructor(
     companion object {
         private const val TAG = "PlaybackController"
         private const val SPINOFF_SIMILAR_LIMIT = 20
+        /** Pool size below which Mode C triggers a refill (matches desktop's < 3). */
+        private const val POOL_REFILL_THRESHOLD = 3
     }
 
     private val scope = CoroutineScope(SupervisorJob() + Dispatchers.Main)
@@ -150,19 +152,18 @@ class PlaybackController constructor(
     private var spinoffJob: Job? = null
 
     // ── Pool-based spinoff (Mode C) refill state ────────────────────────
-    // Captured by [startPoolBasedSpinoff]; read by Task 5's refill loop
-    // (`parachord://play/radio?refill=…`). Only meaningful while the
-    // current spinoff is pool-based (id == "pool-based"). For
-    // seed-based spinoffs these stay null/0.
+    // The actual refill loop (rate-limit, empty counter, dedup, ID
+    // stamping) lives in [PoolRefiller] for testability. This holder
+    // forwards `refillUrl` and `fetcher` into it on
+    // [startPoolBasedSpinoff], triggers it from [skipNextInternal] when
+    // the pool drops below [POOL_REFILL_THRESHOLD], and resets it on
+    // [exitSpinoff].
     //
     // Reset on every [startPoolBasedSpinoff] entry AND on [exitSpinoff]
     // to prevent cross-mode state leak — without the exit reset, a Mode B
-    // spinoff that follows a Mode C exit would see a leftover non-null
-    // poolRefillUrl. Task 5's refill loop only reads these fields; it
-    // doesn't need to write reset logic.
-    private var poolRefillUrl: String? = null
-    private var poolRefillEmptyCount: Int = 0
-    private var poolLastRefillTs: Long = 0L
+    // spinoff that follows a Mode C exit would see leftover refiller
+    // state.
+    private val poolRefiller = PoolRefiller()
 
     fun connect() {
         if (controllerFuture != null) return
@@ -313,6 +314,16 @@ class PlaybackController constructor(
             if (spinoffPool.isNotEmpty()) {
                 val next = spinoffPool.removeAt(0)
                 Log.d(TAG, "Spinoff: playing next '${next.title}' by ${next.artist} (${spinoffPool.size} remaining)")
+
+                // Mode C refill trigger — fire when the pool drops below
+                // POOL_REFILL_THRESHOLD AND we have a refill URL configured.
+                // This is a no-op for Mode B (seed-based) spinoffs since
+                // their refillUrl is null. The PoolRefiller handles
+                // rate-limit + stop-condition gating internally.
+                if (spinoffPool.size < POOL_REFILL_THRESHOLD && poolRefiller.refillUrl != null) {
+                    triggerPoolRefill()
+                }
+
                 advanceJob = scope.launch {
                     try {
                         playTrackInternal(next)
@@ -1640,6 +1651,59 @@ class PlaybackController constructor(
     }
 
     /**
+     * Mode C refill trigger — fire-and-forget fetch + dedup + append.
+     *
+     * Called from [skipNextInternal] when the spinoff pool drops below
+     * [POOL_REFILL_THRESHOLD] and a refill URL is configured. The
+     * actual rate-limit / stop-condition / dedup logic lives in
+     * [PoolRefiller.tryRefill] — this method is just the
+     * coroutine-launch shim.
+     *
+     * Pool-level [PlaybackContext] is inherited (refilled tracks just
+     * join the existing spinoff context — no per-track tagging needed
+     * on Android since context is queue-level, not per-track).
+     */
+    private fun triggerPoolRefill() {
+        scope.launch(Dispatchers.IO) {
+            try {
+                val snapshot = spinoffPool.toList()
+                val fresh = poolRefiller.tryRefill(snapshot) ?: return@launch
+                spinoffPool.addAll(fresh)
+                Log.d(TAG, "Pool refill: appended ${fresh.size} tracks (pool now ${spinoffPool.size})")
+                // Pre-warm resolver cache so they're ready when consumed.
+                try {
+                    trackResolverCache.resolveInBackground(fresh, backfillDb = false, priority = false)
+                } catch (e: Exception) {
+                    if (e is kotlinx.coroutines.CancellationException) throw e
+                    Log.w(TAG, "Pool refill pre-warm failed: ${e.message}")
+                }
+            } catch (e: kotlinx.coroutines.CancellationException) {
+                throw e
+            } catch (e: Exception) {
+                Log.w(TAG, "Pool refill launch failed: ${e.message}")
+            }
+        }
+    }
+
+    /**
+     * Set (or clear) the fetcher used by the Mode C refill loop to
+     * re-fetch tracks from a `?refill=…` URL when `spinoffPool.size < 3`.
+     *
+     * The fetcher is a closure over the protocol resolver (wired by
+     * [com.parachord.android.deeplink.PlayRadioDispatcher] at construction
+     * time), so the same SSRF guard, JSPF/XSPF parser, and
+     * LB-token-auto-attach logic that the initial pool fetch goes through
+     * also applies to refills — for free.
+     *
+     * Stored as a process-lifetime reference. Not cleared on
+     * [exitSpinoff] (only the per-pool refillUrl + counters are), so a
+     * subsequent pool-based spinoff doesn't need to re-wire it.
+     */
+    fun setPoolFetcher(fetcher: (suspend (String) -> List<com.parachord.shared.deeplink.ProtocolTrack>)?) {
+        poolRefiller.fetcher = fetcher
+    }
+
+    /**
      * Pool-based spinoff (Mode C of `parachord://play/radio`).
      *
      * No Last.fm seed step — the caller supplies an already-resolved pool,
@@ -1676,12 +1740,14 @@ class PlaybackController constructor(
 
         spinoffPool.addAll(initialPool)
 
-        // Capture refill state for Task 5's refill loop. Reset siblings
-        // (every entry resets — harmless if exitSpinoff hasn't yet wired
-        // its own reset, since they're re-initialized here on every call).
-        poolRefillUrl = refillUrl
-        poolRefillEmptyCount = 0
-        poolLastRefillTs = 0L
+        // Wire refill URL + reset per-pool counters. The fetcher is
+        // process-lifetime (set once by PlayRadioDispatcher at app start
+        // / first dispatch) so we don't touch it here — preserves it
+        // across exit + re-enter cycles. Counters reset to prevent the
+        // previous pool's empty-count or last-fetch timestamp leaking
+        // into this one.
+        poolRefiller.refillUrl = refillUrl
+        poolRefiller.resetCounters()
 
         val spinoffContext = PlaybackContext(
             type = "spinoff",
@@ -1719,9 +1785,11 @@ class PlaybackController constructor(
         spinoffJob?.cancel()
         spinoffPool.clear()
         spinoffSourceTrack = null
-        poolRefillUrl = null
-        poolRefillEmptyCount = 0
-        poolLastRefillTs = 0L
+        // Full reset — clear refillUrl + counters. fetcher stays wired
+        // (it's process-lifetime), so the next pool-based spinoff
+        // doesn't need to re-set it.
+        poolRefiller.refillUrl = null
+        poolRefiller.resetCounters()
 
         // Restore previous playback context (queue was never modified)
         queueManager.setContext(preSpinoffContext)

--- a/app/src/main/java/com/parachord/android/playback/PlaybackState.kt
+++ b/app/src/main/java/com/parachord/android/playback/PlaybackState.kt
@@ -17,6 +17,16 @@ data class PlaybackState(
     val spinoffLoading: Boolean = false,
     val spinoffAvailable: Boolean? = null, // null=unchecked, true/false=checked
     /**
+     * True while a deeplink-initiated radio is fetching its pool
+     * (`parachord://play/radio?url=…` Mode C) and there's no current
+     * track yet. Drives the mini-player loading spinner so the user
+     * knows something is happening during the multi-second URL fetch.
+     * The dispatcher toggles this around the handler call. Cleared
+     * automatically when [currentTrack] is set, but the dispatcher
+     * also clears it in a finally-block to cover the failure paths.
+     */
+    val isPlaybarLoading: Boolean = false,
+    /**
      * Actual metadata from the streaming source (Spotify / Apple Music).
      * When non-null, the streaming service reported different track info than
      * what we queued — indicates a low-confidence match or mismatched track.

--- a/app/src/main/java/com/parachord/android/playback/PoolRefiller.kt
+++ b/app/src/main/java/com/parachord/android/playback/PoolRefiller.kt
@@ -4,6 +4,8 @@ import com.parachord.android.data.db.entity.TrackEntity
 import com.parachord.shared.deeplink.ProtocolTrack
 import com.parachord.shared.platform.Log
 import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
 
 private const val TAG = "PoolRefiller"
 
@@ -34,11 +36,14 @@ private const val TAG = "PoolRefiller"
  *    will be filtered, but ISRC-only matches go through (callers can
  *    upgrade if/when [TrackEntity] grows an `isrc` column). If every
  *    refilled track dedupes, the result counts as empty.
- *  - **State reset:** [reset] clears `fetcher`, `refillUrl`, the empty
- *    counter, and the last-fetch timestamp. [PlaybackController]
- *    calls this from `exitSpinoff()` and on every entry to
- *    `startPoolBasedSpinoff()` (via field assignment for fetcher /
- *    refillUrl + counter reset).
+ *  - **State reset:** [resetCounters] clears the empty counter +
+ *    last-fetch timestamp. [PlaybackController] calls this from both
+ *    `startPoolBasedSpinoff()` (so a fresh pool doesn't inherit the
+ *    previous pool's stop condition / rate-limit window) and
+ *    `exitSpinoff()` (which also nulls `refillUrl` directly). The
+ *    [fetcher] reference is process-lifetime — set once by
+ *    `PlayRadioDispatcher` at construction and preserved across
+ *    spinoff exit / re-enter.
  *
  * The [clock] parameter is a `() -> Long` injection seam so tests can
  * advance time deterministically without sleeping. Production callers
@@ -49,23 +54,27 @@ class PoolRefiller(
     val rateLimitMs: Long = REFILL_RATE_LIMIT_MS,
     val maxEmpty: Int = REFILL_MAX_EMPTY,
 ) {
+    // Written from outside [tryRefill] (PlaybackController.startPoolBasedSpinoff
+    // / setPoolFetcher), read inside [canRefill] / [tryRefill]. Keep
+    // @Volatile for cross-thread visibility.
     @Volatile var fetcher: (suspend (String) -> List<ProtocolTrack>)? = null
     @Volatile var refillUrl: String? = null
 
-    @Volatile private var emptyCount: Int = 0
-    @Volatile private var lastFetchTs: Long = 0L
+    // Mutated only inside [tryRefill]. The mutex below provides both
+    // atomicity (no torn read-modify-write on emptyCount += 1) AND
+    // visibility, so @Volatile would be redundant.
+    private var emptyCount: Int = 0
+    private var lastFetchTs: Long = 0L
+
+    // Serializes the gate-check + state-update + fetch path so concurrent
+    // callers can't race a compound emptyCount/lastFetchTs update. In
+    // practice the rate-limit gate already serializes calls in production,
+    // but the mutex makes the contract explicit.
+    private val refillMutex = Mutex()
 
     /** Visible for tests + log surfaces; not part of the operational API. */
     val emptyCountForTest: Int get() = emptyCount
     val lastFetchTsForTest: Long get() = lastFetchTs
-
-    /** Reset all transient + injected state. Call from `exitSpinoff()`. */
-    fun reset() {
-        fetcher = null
-        refillUrl = null
-        emptyCount = 0
-        lastFetchTs = 0L
-    }
 
     /**
      * Reset only the per-pool counters (empty counter + last-fetch
@@ -74,6 +83,11 @@ class PoolRefiller(
      * window — but the [fetcher] reference (process-lifetime) and any
      * already-set [refillUrl] (caller will overwrite anyway) are
      * preserved.
+     *
+     * `exitSpinoff()` clears the per-pool state directly (sets
+     * [refillUrl] to null + calls this method) and intentionally does
+     * NOT clear the [fetcher] — it's process-lifetime, set once by
+     * `PlayRadioDispatcher` and reused across spinoff exit/re-enter.
      */
     fun resetCounters() {
         emptyCount = 0
@@ -110,46 +124,47 @@ class PoolRefiller(
      * Caller is responsible for actually appending the returned list to
      * the spinoff pool and pre-warming via `TrackResolverCache`.
      */
-    suspend fun tryRefill(currentPoolSnapshot: List<TrackEntity>): List<TrackEntity>? {
-        if (!canRefill()) return null
-        val url = refillUrl ?: return null
-        val f = fetcher ?: return null
+    suspend fun tryRefill(currentPoolSnapshot: List<TrackEntity>): List<TrackEntity>? =
+        refillMutex.withLock {
+            if (!canRefill()) return@withLock null
+            val url = refillUrl ?: return@withLock null
+            val f = fetcher ?: return@withLock null
 
-        // Set timestamp BEFORE the fetch — a failing fetch still
-        // burns the rate-limit budget. Without this, an HTTP timeout
-        // in a busy refill loop would re-fire immediately on the next
-        // pool-drop tick.
-        lastFetchTs = clock()
+            // Set timestamp BEFORE the fetch — a failing fetch still
+            // burns the rate-limit budget. Without this, an HTTP timeout
+            // in a busy refill loop would re-fire immediately on the
+            // next pool-drop tick.
+            lastFetchTs = clock()
 
-        val fresh: List<ProtocolTrack> = try {
-            f(url)
-        } catch (e: CancellationException) {
-            throw e
-        } catch (e: Exception) {
-            Log.w(TAG, "Pool refill fetch failed: ${e.message}")
-            emptyList()
+            val fresh: List<ProtocolTrack> = try {
+                f(url)
+            } catch (e: CancellationException) {
+                throw e
+            } catch (e: Exception) {
+                Log.w(TAG, "Pool refill fetch failed: ${e.message}")
+                emptyList()
+            }
+
+            val deduped = dedupAgainstPool(fresh, currentPoolSnapshot)
+            if (deduped.isEmpty()) {
+                emptyCount += 1
+                Log.d(TAG, "Pool refill: empty (count=$emptyCount/$maxEmpty)")
+                return@withLock null
+            }
+
+            emptyCount = 0
+            val ts = clock()
+            val entities = deduped.mapIndexed { idx, t ->
+                TrackEntity(
+                    id = "protocol-radio-$ts-$idx",
+                    title = t.title,
+                    artist = t.artist,
+                    album = t.album,
+                )
+            }
+            Log.d(TAG, "Pool refill: ${entities.size} fresh tracks ready to append")
+            entities
         }
-
-        val deduped = dedupAgainstPool(fresh, currentPoolSnapshot)
-        if (deduped.isEmpty()) {
-            emptyCount += 1
-            Log.d(TAG, "Pool refill: empty (count=$emptyCount/$maxEmpty)")
-            return null
-        }
-
-        emptyCount = 0
-        val ts = clock()
-        val entities = deduped.mapIndexed { idx, t ->
-            TrackEntity(
-                id = "protocol-radio-$ts-$idx",
-                title = t.title,
-                artist = t.artist,
-                album = t.album,
-            )
-        }
-        Log.d(TAG, "Pool refill: ${entities.size} fresh tracks ready to append")
-        return entities
-    }
 
     companion object {
         const val REFILL_RATE_LIMIT_MS: Long = 5_000L

--- a/app/src/main/java/com/parachord/android/playback/PoolRefiller.kt
+++ b/app/src/main/java/com/parachord/android/playback/PoolRefiller.kt
@@ -1,0 +1,188 @@
+package com.parachord.android.playback
+
+import com.parachord.android.data.db.entity.TrackEntity
+import com.parachord.shared.deeplink.ProtocolTrack
+import com.parachord.shared.platform.Log
+import kotlinx.coroutines.CancellationException
+
+private const val TAG = "PoolRefiller"
+
+/**
+ * Refill loop for Mode C (pool-based) spinoff
+ * (`parachord://play/radio?refill=…`).
+ *
+ * Encapsulates the rate-limit, empty-counter, dedup, and ID-stamping
+ * state so [PlaybackController] only needs to wire the trigger and
+ * append the result.
+ *
+ * Behavior (matches issue #121 Task 5 spec):
+ *  - **Trigger:** caller invokes [tryRefill] when the pool drops below
+ *    its threshold (currently 3). [canRefill] gates the actual fetch.
+ *  - **Soft rate-limit:** minimum 5 seconds between fetches
+ *    ([rateLimitMs]). The boundary is `>=` so two fetches at exactly
+ *    5s apart both go through cleanly without an off-by-one.
+ *  - **Stop condition:** 3 consecutive empty/error refills ([maxEmpty])
+ *    halts the loop. The counter resets to 0 on any fresh tracks.
+ *    HTTP errors / fetcher exceptions count as empty (the catch in
+ *    [tryRefill] swallows non-cancellation throws and treats them as a
+ *    zero-length fetch result, which then trivially "all dedupes" and
+ *    increments the empty counter).
+ *  - **Dedup against existing pool:** by `recordingMbid` (lowercase)
+ *    →  `(artist|title)` (lowercase). [TrackEntity] has no `isrc`
+ *    field, so ISRC dedup is documented-not-implemented — fresh tracks
+ *    that share an MBID-and-only-MBID with the pool's existing rows
+ *    will be filtered, but ISRC-only matches go through (callers can
+ *    upgrade if/when [TrackEntity] grows an `isrc` column). If every
+ *    refilled track dedupes, the result counts as empty.
+ *  - **State reset:** [reset] clears `fetcher`, `refillUrl`, the empty
+ *    counter, and the last-fetch timestamp. [PlaybackController]
+ *    calls this from `exitSpinoff()` and on every entry to
+ *    `startPoolBasedSpinoff()` (via field assignment for fetcher /
+ *    refillUrl + counter reset).
+ *
+ * The [clock] parameter is a `() -> Long` injection seam so tests can
+ * advance time deterministically without sleeping. Production callers
+ * pass `System::currentTimeMillis`.
+ */
+class PoolRefiller(
+    private val clock: () -> Long = System::currentTimeMillis,
+    val rateLimitMs: Long = REFILL_RATE_LIMIT_MS,
+    val maxEmpty: Int = REFILL_MAX_EMPTY,
+) {
+    @Volatile var fetcher: (suspend (String) -> List<ProtocolTrack>)? = null
+    @Volatile var refillUrl: String? = null
+
+    @Volatile private var emptyCount: Int = 0
+    @Volatile private var lastFetchTs: Long = 0L
+
+    /** Visible for tests + log surfaces; not part of the operational API. */
+    val emptyCountForTest: Int get() = emptyCount
+    val lastFetchTsForTest: Long get() = lastFetchTs
+
+    /** Reset all transient + injected state. Call from `exitSpinoff()`. */
+    fun reset() {
+        fetcher = null
+        refillUrl = null
+        emptyCount = 0
+        lastFetchTs = 0L
+    }
+
+    /**
+     * Reset only the per-pool counters (empty counter + last-fetch
+     * timestamp). Call from `startPoolBasedSpinoff()` so a fresh pool
+     * doesn't inherit the previous pool's stop condition or rate-limit
+     * window — but the [fetcher] reference (process-lifetime) and any
+     * already-set [refillUrl] (caller will overwrite anyway) are
+     * preserved.
+     */
+    fun resetCounters() {
+        emptyCount = 0
+        lastFetchTs = 0L
+    }
+
+    /**
+     * True iff a fetch is allowed to fire at [clock]'s current value.
+     *
+     * Gates: refillUrl + fetcher both non-null, rate-limit window has
+     * elapsed, and we haven't hit the consecutive-empty stop condition.
+     */
+    fun canRefill(): Boolean {
+        if (refillUrl == null || fetcher == null) return false
+        if (emptyCount >= maxEmpty) return false
+        val elapsed = clock() - lastFetchTs
+        return elapsed >= rateLimitMs
+    }
+
+    /**
+     * Attempt one refill. Returns the deduped + tagged entities ready
+     * for the caller to append to the spinoff pool, or `null` if:
+     *   - rate-limited / stopped / not configured ([canRefill] returned
+     *     false), OR
+     *   - the fetch returned (or threw to) zero fresh tracks, OR
+     *   - all returned tracks deduped against [currentPoolSnapshot].
+     *
+     * Side-effects:
+     *   - [lastFetchTs] is set to `clock()` BEFORE the fetch starts
+     *     (rate-limit applies even on failed fetches).
+     *   - [emptyCount] increments on empty/error/fully-deduped results,
+     *     and resets to 0 on a non-empty deduped result.
+     *
+     * Caller is responsible for actually appending the returned list to
+     * the spinoff pool and pre-warming via `TrackResolverCache`.
+     */
+    suspend fun tryRefill(currentPoolSnapshot: List<TrackEntity>): List<TrackEntity>? {
+        if (!canRefill()) return null
+        val url = refillUrl ?: return null
+        val f = fetcher ?: return null
+
+        // Set timestamp BEFORE the fetch — a failing fetch still
+        // burns the rate-limit budget. Without this, an HTTP timeout
+        // in a busy refill loop would re-fire immediately on the next
+        // pool-drop tick.
+        lastFetchTs = clock()
+
+        val fresh: List<ProtocolTrack> = try {
+            f(url)
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Exception) {
+            Log.w(TAG, "Pool refill fetch failed: ${e.message}")
+            emptyList()
+        }
+
+        val deduped = dedupAgainstPool(fresh, currentPoolSnapshot)
+        if (deduped.isEmpty()) {
+            emptyCount += 1
+            Log.d(TAG, "Pool refill: empty (count=$emptyCount/$maxEmpty)")
+            return null
+        }
+
+        emptyCount = 0
+        val ts = clock()
+        val entities = deduped.mapIndexed { idx, t ->
+            TrackEntity(
+                id = "protocol-radio-$ts-$idx",
+                title = t.title,
+                artist = t.artist,
+                album = t.album,
+            )
+        }
+        Log.d(TAG, "Pool refill: ${entities.size} fresh tracks ready to append")
+        return entities
+    }
+
+    companion object {
+        const val REFILL_RATE_LIMIT_MS: Long = 5_000L
+        const val REFILL_MAX_EMPTY: Int = 3
+
+        /**
+         * Filter [fresh] to entries not already present in
+         * [pool] by:
+         *   1. `recordingMbid` (case-insensitive), then
+         *   2. `(artist|title)` (case-insensitive).
+         *
+         * [TrackEntity] has no `isrc` field, so ISRC-only dedup is
+         * not implemented — see KDoc on the class.
+         */
+        fun dedupAgainstPool(
+            fresh: List<ProtocolTrack>,
+            pool: List<TrackEntity>,
+        ): List<ProtocolTrack> {
+            if (fresh.isEmpty()) return emptyList()
+            val mbids: Set<String> = pool
+                .mapNotNull { it.recordingMbid?.lowercase() }
+                .toSet()
+            val titleArtists: Set<String> = pool
+                .map { "${it.artist.lowercase()}|${it.title.lowercase()}" }
+                .toSet()
+            return fresh.filter { t ->
+                val mbid = t.mbid
+                when {
+                    mbid != null && mbid.lowercase() in mbids -> false
+                    "${t.artist.lowercase()}|${t.title.lowercase()}" in titleArtists -> false
+                    else -> true
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/parachord/android/ui/MainActivity.kt
+++ b/app/src/main/java/com/parachord/android/ui/MainActivity.kt
@@ -78,6 +78,7 @@ import com.parachord.android.ui.components.ImportPlaylistDialog
 import com.parachord.android.ui.components.SpotifyDevicePickerDialog
 import com.parachord.android.ui.components.DrawerContent
 import com.parachord.android.ui.components.MiniPlayer
+import com.parachord.android.ui.components.MiniPlayerLoading
 import com.parachord.android.ui.navigation.BottomNavItem
 import com.parachord.android.ui.navigation.ParachordNavHost
 import com.parachord.android.ui.navigation.Routes
@@ -327,8 +328,10 @@ private fun ParachordAppContent(mainViewModel: MainViewModel) {
                     navController.navigate(Routes.SEARCH) { launchSingleTop = true }
                 is DeepLinkNavEvent.Chat ->
                     navController.navigate(Routes.CHAT) { launchSingleTop = true }
-                is DeepLinkNavEvent.Toast ->
-                    Toast.makeText(context, event.message, Toast.LENGTH_SHORT).show()
+                is DeepLinkNavEvent.Toast -> {
+                    val duration = if (event.longDuration) Toast.LENGTH_LONG else Toast.LENGTH_SHORT
+                    Toast.makeText(context, event.message, duration).show()
+                }
                 is DeepLinkNavEvent.StartListenAlong -> {
                     // The dispatcher already ran the listen-along
                     // handover teardown (exit-spinoff + clear-queue,
@@ -523,6 +526,12 @@ private fun ParachordAppContent(mainViewModel: MainViewModel) {
                                         }
                                     },
                                 )
+                            } else if (playbackState.isPlaybarLoading || playbackState.spinoffLoading) {
+                                // Deeplink radio (Mode C) or seed-spinoff
+                                // (Mode B) is mid-fetch with no first
+                                // track yet — show a placeholder bar so
+                                // the user knows something's happening.
+                                MiniPlayerLoading()
                             }
                             // Subtle top border
                             Box(

--- a/app/src/main/java/com/parachord/android/ui/MainActivity.kt
+++ b/app/src/main/java/com/parachord/android/ui/MainActivity.kt
@@ -329,6 +329,14 @@ private fun ParachordAppContent(mainViewModel: MainViewModel) {
                     navController.navigate(Routes.CHAT) { launchSingleTop = true }
                 is DeepLinkNavEvent.Toast ->
                     Toast.makeText(context, event.message, Toast.LENGTH_SHORT).show()
+                is DeepLinkNavEvent.StartListenAlong -> {
+                    // The dispatcher already ran the listen-along
+                    // handover teardown (exit-spinoff + clear-queue,
+                    // skipping listen-along stop). startListenAlong
+                    // calls stopListenAlong(silent=true) at its top so
+                    // the swap from any active friend is atomic.
+                    mainViewModel.startListenAlong(event.friend)
+                }
             }
         }
     }

--- a/app/src/main/java/com/parachord/android/ui/MainViewModel.kt
+++ b/app/src/main/java/com/parachord/android/ui/MainViewModel.kt
@@ -308,15 +308,44 @@ class MainViewModel constructor(
             // Play current track immediately
             playFriendCurrentTrack(friend, immediate = true)
 
-            // Poll for track changes (desktop uses 15s interval)
+            // Poll for track changes (desktop uses 15s interval).
+            //
+            // Transient-friend branch: B1 from Task 7 review. Saved friends use
+            // the DB lookup; transient friends (deeplink-spawned, never persisted)
+            // must refetch via fetchTransientFriendNowPlaying or the loop dies on
+            // the first poll because friendDao.getFriendById returns null for the
+            // synthetic id ("transient:{service}:{user}").
             while (isActive) {
                 delay(LISTEN_ALONG_POLL_MS)
                 try {
-                    // Refresh their activity from API
-                    friendsRepository.refreshFriendActivity(
-                        friendsRepository.getFriendById(friend.id) ?: break
-                    )
-                    val refreshed = friendsRepository.getFriendById(friend.id) ?: break
+                    val refreshed: FriendEntity? = if (friend.transient) {
+                        // Transient friend isn't in Room — refetch now-playing
+                        // via the same path used at deeplink-entry. Returns
+                        // null when they're not currently listening (or the
+                        // API call fails — the repo swallows internally).
+                        friendsRepository.fetchTransientFriendNowPlaying(friend.service, friend.username)
+                    } else {
+                        // Saved friend — refresh activity, then re-read the row.
+                        friendsRepository.refreshFriendActivity(
+                            friendsRepository.getFriendById(friend.id) ?: break
+                        )
+                        friendsRepository.getFriendById(friend.id)
+                    }
+
+                    if (refreshed == null) {
+                        // Saved friend deleted, OR transient friend stopped
+                        // listening. Mirror the !isOnAir branch below: defer
+                        // if a track is mid-play, otherwise calm exit.
+                        val state = playbackState.value
+                        if (state.isPlaying && state.currentTrack != null) {
+                            deferredStopFriendName = friend.displayName
+                            Log.d(TAG, "Friend ${friend.displayName} no longer present, deferring stop")
+                            continue
+                        }
+                        _toastEvents.emit("${friend.displayName} stopped listening")
+                        break
+                    }
+
                     _listenAlongFriend.value = refreshed
 
                     if (!refreshed.isOnAir) {

--- a/app/src/main/java/com/parachord/android/ui/MainViewModel.kt
+++ b/app/src/main/java/com/parachord/android/ui/MainViewModel.kt
@@ -435,6 +435,14 @@ class MainViewModel constructor(
         lastListenAlongTrackKey = trackKey
 
         try {
+            // Listen-along friend tracks must pass the resolver confidence
+            // floor (issue #121 §H, UX addendum). resolverScoring.selectBest
+            // filters sources below MIN_CONFIDENCE_THRESHOLD (0.60), so a
+            // null return here means no resolver had a real match — drop
+            // the track silently rather than play a wrong-song result.
+            // Contract anchor: ResolverScoringTest."selectBest filters
+            // below-floor confidence" + "selectBest null confidence
+            // filtered by floor when above-floor source present".
             val sources = resolverManager.resolveWithHints(query = "$trackArtist - $trackName", targetTitle = trackName, targetArtist = trackArtist)
             val best = resolverScoring.selectBest(sources) ?: return
 

--- a/app/src/main/java/com/parachord/android/ui/components/MiniPlayer.kt
+++ b/app/src/main/java/com/parachord/android/ui/components/MiniPlayer.kt
@@ -179,3 +179,59 @@ fun MiniPlayer(
         }
     }
 }
+
+/**
+ * Loading-state stub of [MiniPlayer], rendered when
+ * `isPlaybarLoading && currentTrack == null` — i.e. a deeplink-initiated
+ * radio (`parachord://play/radio?url=…` Mode C) is mid-fetch and we
+ * haven't picked a first track yet. Same height + surface as the real
+ * mini-player so the bottom-bar layout doesn't jump when the first track
+ * lands. Spinner sits where album art would be; the placeholder text
+ * gives the user something to read during the multi-second fetch.
+ */
+@Composable
+fun MiniPlayerLoading(
+    label: String = "Loading…",
+    modifier: Modifier = Modifier,
+) {
+    Column(
+        modifier = modifier
+            .fillMaxWidth()
+            .background(PlayerSurface),
+    ) {
+        // Same 2dp slot as the real progress bar so heights match exactly.
+        Box(
+            modifier = Modifier
+                .fillMaxWidth()
+                .height(2.dp)
+                .background(Color.White.copy(alpha = 0.1f)),
+        )
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 12.dp, vertical = 8.dp),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            // Spinner in the album-art slot (40dp).
+            Box(
+                modifier = Modifier.size(40.dp),
+                contentAlignment = Alignment.Center,
+            ) {
+                CircularProgressIndicator(
+                    modifier = Modifier.size(20.dp),
+                    color = PurpleDark,
+                    strokeWidth = 2.dp,
+                )
+            }
+            Spacer(modifier = Modifier.width(12.dp))
+            Text(
+                text = label,
+                color = PlayerTextSecondary,
+                fontSize = 13.sp,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
+                modifier = Modifier.weight(1f),
+            )
+        }
+    }
+}

--- a/app/src/main/java/com/parachord/android/ui/screens/nowplaying/QueueSheet.kt
+++ b/app/src/main/java/com/parachord/android/ui/screens/nowplaying/QueueSheet.kt
@@ -98,7 +98,14 @@ fun QueueSheet(
                 if (playbackContext != null) {
                     val contextLabel = when (playbackContext.type) {
                         "listen-along" -> "Listening along with ${playbackContext.name}"
-                        "spinoff" -> playbackContext.name // "Spinoff from {track}"
+                        // Spinoff covers two flavors: in-app right-click → Spinoff
+                        // (name = "Spinoff from {title}") and Mode B/C protocol radio
+                        // (id = "pool-based", name = station name e.g. "Radio: Slowdive").
+                        // Desktop branches its "Spun off from X by Y" template to
+                        // station-name-only when sourceTrack.artist is blank — Android
+                        // never had that template, so rendering name directly is the
+                        // correct convergence point for both flavors.
+                        "spinoff" -> playbackContext.name
                         else -> "Playing from: ${playbackContext.name}"
                     }
                     val contextColor = when (playbackContext.type) {

--- a/app/src/test/java/com/parachord/android/deeplink/AndroidProtocolInputResolverTest.kt
+++ b/app/src/test/java/com/parachord/android/deeplink/AndroidProtocolInputResolverTest.kt
@@ -1,0 +1,144 @@
+package com.parachord.android.deeplink
+
+import com.parachord.shared.api.AppleMusicClient
+import com.parachord.shared.api.MbMedia
+import com.parachord.shared.api.MbReleaseBrowseResponse
+import com.parachord.shared.api.MbReleaseDetail
+import com.parachord.shared.api.MbTrack
+import com.parachord.shared.api.MusicBrainzClient
+import com.parachord.shared.api.SpotifyClient
+import com.parachord.shared.metadata.MetadataService
+import io.ktor.client.HttpClient
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.coVerifyOrder
+import io.mockk.mockk
+import kotlinx.coroutines.test.runTest
+import kotlinx.serialization.SerializationException
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+/**
+ * Unit tests for [AndroidProtocolInputResolver.resolveByMbid] — verifies the
+ * release-group fallback path added for Phase 3 (Achordion emits release-group
+ * MBIDs as the canonical "album" identifier).
+ */
+class AndroidProtocolInputResolverTest {
+
+    private fun buildResolver(mbClient: MusicBrainzClient): AndroidProtocolInputResolver =
+        AndroidProtocolInputResolver(
+            musicBrainzClient = mbClient,
+            spotifyClient = mockk(relaxed = true),
+            appleMusicClient = mockk(relaxed = true),
+            metadataService = mockk<MetadataService>(relaxed = true),
+            httpClient = mockk<HttpClient>(relaxed = true),
+        )
+
+    @Test
+    fun resolveByMbid_releaseGroupFallback_browsesReleasesAndMapsTracks() = runTest {
+        val mbClient = mockk<MusicBrainzClient>()
+        coEvery { mbClient.getRelease("RG_MBID", any()) } throws
+            SerializationException("Not Found")
+        coEvery {
+            mbClient.browseReleasesByReleaseGroup("RG_MBID", "recordings+artist-credits", 1)
+        } returns MbReleaseBrowseResponse(
+            releases = listOf(
+                MbReleaseDetail(
+                    id = "REL_MBID",
+                    title = "I Built You a Tower",
+                    media = listOf(
+                        MbMedia(
+                            tracks = listOf(
+                                MbTrack(id = "T1", title = "Song 1"),
+                                MbTrack(id = "T2", title = "Song 2"),
+                            ),
+                        ),
+                    ),
+                ),
+            ),
+        )
+
+        val resolver = buildResolver(mbClient)
+        val resolved = resolver.resolveByMbid("RG_MBID")
+
+        assertNotNull(resolved)
+        assertEquals("I Built You a Tower", resolved!!.displayName)
+        assertEquals(2, resolved.tracks.size)
+        assertEquals("Song 1", resolved.tracks[0].title)
+        assertEquals("T1", resolved.tracks[0].mbid)
+        coVerifyOrder {
+            mbClient.getRelease("RG_MBID", "recordings+artist-credits")
+            mbClient.browseReleasesByReleaseGroup("RG_MBID", "recordings+artist-credits", 1)
+        }
+    }
+
+    @Test
+    fun resolveByMbid_release_succeedsWithoutCallingReleaseGroupBrowse() = runTest {
+        val mbClient = mockk<MusicBrainzClient>()
+        coEvery { mbClient.getRelease("REL_MBID", any()) } returns MbReleaseDetail(
+            id = "REL_MBID",
+            title = "Release Title",
+            media = listOf(
+                MbMedia(
+                    tracks = listOf(
+                        MbTrack(id = "T1", title = "Song 1"),
+                    ),
+                ),
+            ),
+        )
+
+        val resolver = buildResolver(mbClient)
+        val resolved = resolver.resolveByMbid("REL_MBID")
+
+        assertNotNull(resolved)
+        assertEquals("Release Title", resolved!!.displayName)
+        assertEquals(1, resolved.tracks.size)
+        coVerify(exactly = 0) {
+            mbClient.browseReleasesByReleaseGroup(any(), any(), any())
+        }
+    }
+
+    @Test
+    fun resolveByMbid_bothFail_returnsNull() = runTest {
+        val mbClient = mockk<MusicBrainzClient>()
+        coEvery { mbClient.getRelease(any(), any()) } throws
+            SerializationException("Not Found")
+        coEvery {
+            mbClient.browseReleasesByReleaseGroup(any(), any(), any())
+        } returns MbReleaseBrowseResponse()
+
+        val resolver = buildResolver(mbClient)
+        assertNull(resolver.resolveByMbid("BAD_MBID"))
+    }
+
+    @Test
+    fun resolveByMbid_emptyMediaOnRelease_fallsThroughToReleaseGroup() = runTest {
+        // If /release/{mbid} returns a structurally-valid MbReleaseDetail but
+        // its media[] is empty (e.g. the release exists but has no tracks
+        // attached), fall through to the release-group browse rather than
+        // returning null — the sibling edition usually has the full tracklist.
+        val mbClient = mockk<MusicBrainzClient>()
+        coEvery { mbClient.getRelease("MBID", any()) } returns MbReleaseDetail(
+            id = "MBID", title = "Empty", media = emptyList(),
+        )
+        coEvery {
+            mbClient.browseReleasesByReleaseGroup("MBID", any(), any())
+        } returns MbReleaseBrowseResponse(
+            releases = listOf(
+                MbReleaseDetail(
+                    id = "REL2", title = "Sibling Edition",
+                    media = listOf(MbMedia(tracks = listOf(MbTrack(id = "T1", title = "Song")))),
+                ),
+            ),
+        )
+
+        val resolver = buildResolver(mbClient)
+        val resolved = resolver.resolveByMbid("MBID")
+
+        assertNotNull(resolved)
+        assertEquals("Sibling Edition", resolved!!.displayName)
+        assertEquals(1, resolved.tracks.size)
+    }
+}

--- a/app/src/test/java/com/parachord/android/deeplink/DeepLinkHandlerTest.kt
+++ b/app/src/test/java/com/parachord/android/deeplink/DeepLinkHandlerTest.kt
@@ -323,4 +323,40 @@ class DeepLinkHandlerRadioContractTest {
         val a = handler.parse(Uri.parse("parachord://play/radio?refill=https%3A%2F%2Fexample.com%2Fr.jspf"))
         assertTrue(a is DeepLinkAction.Unknown)
     }
+
+    @Test
+    fun parsePlayRadio_modeB_titleHintPlumbsThrough() {
+        val a = handler.parse(Uri.parse("parachord://play/radio?artist=Slowdive&title=Sugar%20For%20The%20Pill"))
+        val pr = a as DeepLinkAction.PlayRadio
+        val seed = pr.mode as RadioMode.ArtistSeed
+        assertEquals("Slowdive", seed.artist)
+        assertEquals("Sugar For The Pill", seed.title)
+    }
+
+    @Test
+    fun parsePlayRadio_blankArtistTreatedAsAbsent() {
+        // ?artist= (empty) + ?url= → still Mode C (the empty artist must NOT
+        // win Mode B's gate).
+        val a = handler.parse(Uri.parse("parachord://play/radio?artist=&url=https%3A%2F%2Fexample.com%2Fp.jspf"))
+        val pr = a as DeepLinkAction.PlayRadio
+        assertTrue(pr.mode is RadioMode.PoolBased)
+    }
+
+    @Test
+    fun parsePlayRadio_malformedTracksFallsBackToArtistSeed() {
+        // Malformed base64 in ?tracks= causes parseProtocolPlayInput to drop
+        // the input entirely. With ?artist= also present, parser falls into
+        // Mode B. This is documented behavior, locked by this test.
+        val a = handler.parse(Uri.parse("parachord://play/radio?artist=Slowdive&tracks=NOT_BASE64"))
+        val pr = a as DeepLinkAction.PlayRadio
+        assertTrue(pr.mode is RadioMode.ArtistSeed)
+    }
+
+    @Test
+    fun parsePlayRadio_shuffleFlagPlumbsThrough() {
+        val a = handler.parse(Uri.parse("parachord://play/radio?artist=Slowdive&shuffle=1"))
+        assertTrue((a as DeepLinkAction.PlayRadio).shuffle)
+        val b = handler.parse(Uri.parse("parachord://play/radio?artist=Slowdive"))
+        assertFalse((b as DeepLinkAction.PlayRadio).shuffle)
+    }
 }

--- a/app/src/test/java/com/parachord/android/deeplink/DeepLinkHandlerTest.kt
+++ b/app/src/test/java/com/parachord/android/deeplink/DeepLinkHandlerTest.kt
@@ -1,7 +1,14 @@
 package com.parachord.android.deeplink
 
+import android.app.Application
+import android.net.Uri
+import com.parachord.shared.deeplink.DeepLinkAction
+import com.parachord.shared.deeplink.RadioMode
 import org.junit.Assert.*
 import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
 
 /**
  * Tests for DeepLinkHandler's URI parsing logic.
@@ -10,6 +17,9 @@ import org.junit.Test
  * we test the parsing logic by replicating the pure string-based routing.
  * The actual DeepLinkHandler delegates to Uri methods; these tests verify
  * the routing decision logic using the same string patterns.
+ *
+ * Tests that need real Uri parsing run under Robolectric (see
+ * [DeepLinkHandlerRadioContractTest] below).
  */
 class DeepLinkHandlerTest {
 
@@ -259,5 +269,58 @@ class DeepLinkHandlerTest {
         // No path segment — falls into the legacy [Play] action.
         assertTrue(url.startsWith("parachord://play?"))
         assertFalse(url.contains("parachord://play/"))
+    }
+}
+
+/**
+ * Real-Uri tests for the `parachord://play/radio` parser contract (#121 [1/N]).
+ *
+ * Runs under Robolectric so [Uri.parse] is real; the rest of the suite is
+ * string-pattern only and stays fast.
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(application = Application::class)
+class DeepLinkHandlerRadioContractTest {
+
+    private val handler = DeepLinkHandler()
+
+    @Test
+    fun parsePlayRadio_nameTakesPrecedenceOverTitle() {
+        val a = handler.parse(Uri.parse("parachord://play/radio?url=https%3A%2F%2Fexample.com%2Fp.jspf&name=My%20Station&title=ignored"))
+        assertTrue(a is DeepLinkAction.PlayRadio)
+        val pr = a as DeepLinkAction.PlayRadio
+        assertEquals("My Station", pr.name)
+    }
+
+    @Test
+    fun parsePlayRadio_modeBOnlyWhenNoUrlOrTracks() {
+        val a = handler.parse(Uri.parse("parachord://play/radio?artist=Slowdive"))
+        val pr = a as DeepLinkAction.PlayRadio
+        assertTrue(pr.mode is RadioMode.ArtistSeed)
+    }
+
+    @Test
+    fun parsePlayRadio_modeCWhenTracksAndArtistBothPresent() {
+        // Artist + tracks → Mode C (pool wins per issue spec).
+        // base64 of [{"title":"T","artist":"A"}] = W3sidGl0bGUiOiJUIiwiYXJ0aXN0IjoiQSJ9XQ==
+        val a = handler.parse(Uri.parse("parachord://play/radio?artist=Foo&tracks=W3sidGl0bGUiOiJUIiwiYXJ0aXN0IjoiQSJ9XQ%3D%3D"))
+        val pr = a as DeepLinkAction.PlayRadio
+        assertTrue(pr.mode is RadioMode.PoolBased)
+    }
+
+    @Test
+    fun parsePlayRadio_refillAliasMapsToSameField() {
+        // ?refill= should populate refillUrl. ?refillUrl= legacy alias should also work.
+        val a1 = handler.parse(Uri.parse("parachord://play/radio?url=https%3A%2F%2Fexample.com%2Fp.jspf&refill=https%3A%2F%2Fexample.com%2Fr.jspf"))
+        val a2 = handler.parse(Uri.parse("parachord://play/radio?url=https%3A%2F%2Fexample.com%2Fp.jspf&refillUrl=https%3A%2F%2Fexample.com%2Fr.jspf"))
+        assertEquals("https://example.com/r.jspf", (a1 as DeepLinkAction.PlayRadio).refillUrl)
+        assertEquals("https://example.com/r.jspf", (a2 as DeepLinkAction.PlayRadio).refillUrl)
+    }
+
+    @Test
+    fun parsePlayRadio_refillAlonePresentButNoUrlOrTracks_isUnknown() {
+        // refill is for subsequent fetches only — not a valid initial pool source.
+        val a = handler.parse(Uri.parse("parachord://play/radio?refill=https%3A%2F%2Fexample.com%2Fr.jspf"))
+        assertTrue(a is DeepLinkAction.Unknown)
     }
 }

--- a/app/src/test/java/com/parachord/android/deeplink/ListenAlongDispatcherTest.kt
+++ b/app/src/test/java/com/parachord/android/deeplink/ListenAlongDispatcherTest.kt
@@ -1,0 +1,237 @@
+package com.parachord.android.deeplink
+
+import com.parachord.shared.deeplink.DeepLinkAction
+import com.parachord.shared.deeplink.ProtocolPlayTeardown
+import com.parachord.shared.model.Friend
+import com.parachord.shared.repository.FriendsRepository
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.just
+import io.mockk.mockk
+import io.mockk.runs
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Unit tests for [ListenAlongDispatcher] (Phase 3 Task 7, issue #121 §G).
+ *
+ * Covers the four branches of the dispatch flow:
+ *
+ *   1. Saved friend hit → [ListenAlongResult.Started] + handover teardown
+ *      (NOT the full prepareForNewPlayback teardown — see KDoc on
+ *      [ProtocolPlayTeardown.prepareForListenAlongHandover]).
+ *   2. Saved friend miss + transient hit → [ListenAlongResult.Started]
+ *      with `transient = true` Friend; handover teardown still runs.
+ *   3. Saved friend miss + transient miss → [ListenAlongResult.NotPlaying]
+ *      with the original username/service for the calm toast.
+ *   4. Unsupported service → [ListenAlongResult.Failed]; no teardown,
+ *      no repo calls.
+ *
+ * Plus invariants:
+ *   - Saved-friend path never invokes the transient fetch (avoids a
+ *     pointless API round-trip).
+ *   - Lookup is case-insensitive (deeplink user "mrmonkey" finds saved
+ *     "MrMonkey").
+ *   - A throwing transient fetch surfaces as Failed, not a crash.
+ */
+class ListenAlongDispatcherTest {
+
+    private fun savedFriend(
+        id: String = "friend-123",
+        username: String = "rob",
+        service: String = "listenbrainz",
+        displayName: String = "Rob",
+    ) = Friend(
+        id = id,
+        username = username,
+        service = service,
+        displayName = displayName,
+        addedAt = 0L,
+    )
+
+    private fun transientFriendStub(
+        service: String = "listenbrainz",
+        user: String = "rob",
+    ) = Friend(
+        id = "transient:$service:$user",
+        username = user,
+        service = service,
+        displayName = user,
+        addedAt = 0L,
+        cachedTrackName = "Some Song",
+        cachedTrackArtist = "Some Artist",
+        cachedTrackTimestamp = System.currentTimeMillis() / 1000,
+        transient = true,
+    )
+
+    private fun build(
+        repo: FriendsRepository = mockk(relaxed = true),
+        td: ProtocolPlayTeardown = mockk<ProtocolPlayTeardown>().also {
+            coEvery { it.prepareForListenAlongHandover() } just runs
+            coEvery { it.prepareForNewPlayback() } just runs
+        },
+    ): Pair<ListenAlongDispatcher, ProtocolPlayTeardown> =
+        ListenAlongDispatcher(repo, td) to td
+
+    @Test
+    fun knownFriend_returnsStartedAndCallsHandoverTeardown() = runTest {
+        val repo = mockk<FriendsRepository>()
+        val saved = savedFriend()
+        coEvery { repo.findByServiceAndUsername("listenbrainz", "rob") } returns saved
+        val td = mockk<ProtocolPlayTeardown>()
+        coEvery { td.prepareForListenAlongHandover() } just runs
+
+        val (dispatcher, teardown) = build(repo, td)
+        val result = dispatcher.dispatch(DeepLinkAction.ListenAlong("listenbrainz", "rob"))
+
+        assertTrue(result is ListenAlongResult.Started)
+        assertEquals(saved, (result as ListenAlongResult.Started).friend)
+        assertEquals("Rob", result.displayName)
+        coVerify(exactly = 1) { teardown.prepareForListenAlongHandover() }
+        // Critically: NOT the full prepareForNewPlayback (would race with
+        // MainViewModel.startListenAlong's own stopListenAlong).
+        coVerify(exactly = 0) { teardown.prepareForNewPlayback() }
+    }
+
+    @Test
+    fun knownFriend_doesNotFireTransientFetch() = runTest {
+        // If the local lookup hits, the transient fetch must be skipped
+        // — round-tripping to the now-playing API is wasted work and an
+        // unnecessary point of failure.
+        val repo = mockk<FriendsRepository>()
+        coEvery { repo.findByServiceAndUsername("listenbrainz", "rob") } returns savedFriend()
+        // Throw if the transient fetch is invoked — verifies the skip.
+        coEvery { repo.fetchTransientFriendNowPlaying(any(), any()) } throws
+            RuntimeException("transient fetch should not run when saved friend is found")
+
+        val (dispatcher, _) = build(repo)
+        val result = dispatcher.dispatch(DeepLinkAction.ListenAlong("listenbrainz", "rob"))
+
+        assertTrue(result is ListenAlongResult.Started)
+        coVerify(exactly = 0) {
+            repo.fetchTransientFriendNowPlaying(any(), any())
+        }
+    }
+
+    @Test
+    fun unknownFriendWithCurrentTrack_returnsStartedWithTransient() = runTest {
+        val repo = mockk<FriendsRepository>()
+        coEvery { repo.findByServiceAndUsername("listenbrainz", "rob") } returns null
+        val transient = transientFriendStub()
+        coEvery { repo.fetchTransientFriendNowPlaying("listenbrainz", "rob") } returns transient
+        val td = mockk<ProtocolPlayTeardown>()
+        coEvery { td.prepareForListenAlongHandover() } just runs
+
+        val (dispatcher, teardown) = build(repo, td)
+        val result = dispatcher.dispatch(DeepLinkAction.ListenAlong("listenbrainz", "rob"))
+
+        assertTrue(result is ListenAlongResult.Started)
+        val started = result as ListenAlongResult.Started
+        assertTrue("transient flag must propagate", started.friend.transient)
+        assertEquals("transient:listenbrainz:rob", started.friend.id)
+        assertEquals("rob", started.displayName)
+        coVerify(exactly = 1) { teardown.prepareForListenAlongHandover() }
+    }
+
+    @Test
+    fun unknownFriendNoCurrentTrack_returnsNotPlaying() = runTest {
+        val repo = mockk<FriendsRepository>()
+        coEvery { repo.findByServiceAndUsername("listenbrainz", "rob") } returns null
+        coEvery { repo.fetchTransientFriendNowPlaying("listenbrainz", "rob") } returns null
+        val td = mockk<ProtocolPlayTeardown>(relaxed = true)
+
+        val (dispatcher, teardown) = build(repo, td)
+        val result = dispatcher.dispatch(DeepLinkAction.ListenAlong("listenbrainz", "rob"))
+
+        assertTrue(result is ListenAlongResult.NotPlaying)
+        val notPlaying = result as ListenAlongResult.NotPlaying
+        assertEquals("rob", notPlaying.username)
+        assertEquals("listenbrainz", notPlaying.service)
+        // No teardown when there's nothing to start.
+        coVerify(exactly = 0) { teardown.prepareForListenAlongHandover() }
+    }
+
+    @Test
+    fun invalidService_returnsFailedAndDoesNotTouchRepo() = runTest {
+        val repo = mockk<FriendsRepository>()
+        val td = mockk<ProtocolPlayTeardown>(relaxed = true)
+
+        val dispatcher = ListenAlongDispatcher(repo, td)
+        val result = dispatcher.dispatch(DeepLinkAction.ListenAlong("spotify", "rob"))
+
+        assertTrue(result is ListenAlongResult.Failed)
+        coVerify(exactly = 0) { repo.findByServiceAndUsername(any(), any()) }
+        coVerify(exactly = 0) { repo.fetchTransientFriendNowPlaying(any(), any()) }
+        coVerify(exactly = 0) { td.prepareForListenAlongHandover() }
+    }
+
+    @Test
+    fun emptyUsername_returnsFailed() = runTest {
+        val repo = mockk<FriendsRepository>(relaxed = true)
+        val td = mockk<ProtocolPlayTeardown>(relaxed = true)
+
+        val dispatcher = ListenAlongDispatcher(repo, td)
+        val result = dispatcher.dispatch(DeepLinkAction.ListenAlong("listenbrainz", ""))
+
+        assertTrue(result is ListenAlongResult.Failed)
+        coVerify(exactly = 0) { repo.findByServiceAndUsername(any(), any()) }
+    }
+
+    @Test
+    fun transientFetchThrows_returnsFailed() = runTest {
+        // Repo's fetchTransientFriendNowPlaying already swallows
+        // exceptions internally and returns null on failure (calm UX
+        // on flaky network). But if a programmer error or upstream
+        // change re-introduces a throw, the dispatcher must catch it
+        // and surface Failed rather than letting the deeplink crash.
+        val repo = mockk<FriendsRepository>()
+        coEvery { repo.findByServiceAndUsername("listenbrainz", "rob") } returns null
+        coEvery { repo.fetchTransientFriendNowPlaying("listenbrainz", "rob") } throws
+            RuntimeException("network fail")
+        val td = mockk<ProtocolPlayTeardown>(relaxed = true)
+
+        val (dispatcher, teardown) = build(repo, td)
+        val result = dispatcher.dispatch(DeepLinkAction.ListenAlong("listenbrainz", "rob"))
+
+        assertTrue(result is ListenAlongResult.Failed)
+        coVerify(exactly = 0) { teardown.prepareForListenAlongHandover() }
+    }
+
+    @Test
+    fun caseInsensitiveLookup_treatsUpperLowerVariantAsSameFriend() = runTest {
+        // The repo's findByServiceAndUsername is case-insensitive on
+        // the username — verifying that here is really verifying the
+        // contract surface the dispatcher relies on. We mock the repo
+        // to RESPOND to the case-mapped query so the test fails if
+        // the dispatcher did its own (lossy) lower/upper-casing
+        // before the repo call.
+        val repo = mockk<FriendsRepository>()
+        // Accept either case the dispatcher might send through.
+        val saved = savedFriend(username = "MrMonkey")
+        coEvery { repo.findByServiceAndUsername("listenbrainz", "mrmonkey") } returns saved
+        val td = mockk<ProtocolPlayTeardown>()
+        coEvery { td.prepareForListenAlongHandover() } just runs
+
+        val dispatcher = ListenAlongDispatcher(repo, td)
+        val result = dispatcher.dispatch(DeepLinkAction.ListenAlong("listenbrainz", "mrmonkey"))
+
+        assertTrue(result is ListenAlongResult.Started)
+        assertEquals(saved, (result as ListenAlongResult.Started).friend)
+    }
+
+    @Test
+    fun lastFmService_alsoSupported() = runTest {
+        val repo = mockk<FriendsRepository>()
+        val saved = savedFriend(service = "lastfm")
+        coEvery { repo.findByServiceAndUsername("lastfm", "rob") } returns saved
+        val td = mockk<ProtocolPlayTeardown>()
+        coEvery { td.prepareForListenAlongHandover() } just runs
+
+        val (dispatcher, _) = build(repo, td)
+        val result = dispatcher.dispatch(DeepLinkAction.ListenAlong("lastfm", "rob"))
+
+        assertTrue(result is ListenAlongResult.Started)
+    }
+}

--- a/app/src/test/java/com/parachord/android/deeplink/ListenAlongDispatcherTest.kt
+++ b/app/src/test/java/com/parachord/android/deeplink/ListenAlongDispatcherTest.kt
@@ -88,7 +88,7 @@ class ListenAlongDispatcherTest {
 
         assertTrue(result is ListenAlongResult.Started)
         assertEquals(saved, (result as ListenAlongResult.Started).friend)
-        assertEquals("Rob", result.displayName)
+        assertEquals("Rob", result.friend.displayName)
         coVerify(exactly = 1) { teardown.prepareForListenAlongHandover() }
         // Critically: NOT the full prepareForNewPlayback (would race with
         // MainViewModel.startListenAlong's own stopListenAlong).
@@ -131,7 +131,7 @@ class ListenAlongDispatcherTest {
         val started = result as ListenAlongResult.Started
         assertTrue("transient flag must propagate", started.friend.transient)
         assertEquals("transient:listenbrainz:rob", started.friend.id)
-        assertEquals("rob", started.displayName)
+        assertEquals("rob", started.friend.displayName)
         coVerify(exactly = 1) { teardown.prepareForListenAlongHandover() }
     }
 

--- a/app/src/test/java/com/parachord/android/deeplink/PlayRadioModeBTest.kt
+++ b/app/src/test/java/com/parachord/android/deeplink/PlayRadioModeBTest.kt
@@ -43,7 +43,7 @@ class PlayRadioModeBTest {
 
         coVerifyOrder {
             td.prepareForNewPlayback()
-            pc.startSpinoffWithSeed("Slowdive", null, any())
+            pc.startSpinoffWithSeed("Slowdive", null, any(), any())
         }
     }
 
@@ -60,7 +60,7 @@ class PlayRadioModeBTest {
         )
 
         coVerify(exactly = 1) {
-            pc.startSpinoffWithSeed("Slowdive", "Sugar For The Pill", "My Custom Station")
+            pc.startSpinoffWithSeed("Slowdive", "Sugar For The Pill", "My Custom Station", any())
         }
     }
 
@@ -81,6 +81,7 @@ class PlayRadioModeBTest {
                 "Slowdive",
                 "Sugar For The Pill",
                 "Radio: Slowdive – Sugar For The Pill",
+                any(),
             )
         }
     }
@@ -98,7 +99,7 @@ class PlayRadioModeBTest {
         )
 
         coVerify(exactly = 1) {
-            pc.startSpinoffWithSeed("Slowdive", null, "Radio: Slowdive")
+            pc.startSpinoffWithSeed("Slowdive", null, "Radio: Slowdive", any())
         }
     }
 
@@ -107,16 +108,48 @@ class PlayRadioModeBTest {
         val pc = mockk<PlaybackController>(relaxed = true)
         val td = mockk<ProtocolPlayTeardown>()
         coEvery { td.prepareForNewPlayback() } just runs
-        val toasts = mutableListOf<String>()
-        val dispatcher = PlayRadioDispatcher(pc, td) { toasts += it }
+        val toastFn = mockk<suspend (String) -> Unit>()
+        coEvery { toastFn(any()) } just runs
 
+        val dispatcher = PlayRadioDispatcher(pc, td, toastFn)
         dispatcher.dispatch(
             DeepLinkAction.PlayRadio(mode = RadioMode.ArtistSeed("Slowdive", null))
         )
 
-        // Acknowledgment toast fires before teardown / startSpinoffWithSeed.
-        assert(toasts.firstOrNull() == "Building radio…") {
-            "expected 'Building radio…' first, got $toasts"
+        // Real ordering check: toast must fire BEFORE teardown AND
+        // before startSpinoffWithSeed. The earlier `toasts.firstOrNull()`
+        // assertion would have passed even if toast fired last.
+        coVerifyOrder {
+            toastFn("Building radio…")
+            td.prepareForNewPlayback()
+            pc.startSpinoffWithSeed(any(), any(), any(), any())
+        }
+    }
+
+    @Test
+    fun modeB_passesKickStartFirstTrackTrue_soPoolStartsPlayingImmediately() = runTest {
+        val pc = mockk<PlaybackController>(relaxed = true)
+        val td = mockk<ProtocolPlayTeardown>()
+        coEvery { td.prepareForNewPlayback() } just runs
+        val toastFn = mockk<suspend (String) -> Unit>()
+        coEvery { toastFn(any()) } just runs
+
+        val dispatcher = PlayRadioDispatcher(pc, td, toastFn)
+        dispatcher.dispatch(
+            DeepLinkAction.PlayRadio(
+                mode = RadioMode.ArtistSeed("Slowdive", null),
+            )
+        )
+
+        // Mode B is "start fresh radio now" — the pool's first track must
+        // begin playing without waiting for an existing track to finish.
+        coVerify(exactly = 1) {
+            pc.startSpinoffWithSeed(
+                seedArtist = "Slowdive",
+                seedTitle = null,
+                displayName = "Radio: Slowdive",
+                kickStartFirstTrack = true,
+            )
         }
     }
 
@@ -132,7 +165,7 @@ class PlayRadioModeBTest {
         )
 
         coVerify(exactly = 0) { td.prepareForNewPlayback() }
-        coVerify(exactly = 0) { pc.startSpinoffWithSeed(any(), any(), any()) }
+        coVerify(exactly = 0) { pc.startSpinoffWithSeed(any(), any(), any(), any()) }
         assert(toasts.contains("Mode C coming next commit"))
     }
 }

--- a/app/src/test/java/com/parachord/android/deeplink/PlayRadioModeBTest.kt
+++ b/app/src/test/java/com/parachord/android/deeplink/PlayRadioModeBTest.kt
@@ -11,12 +11,18 @@ import io.mockk.just
 import io.mockk.mockk
 import io.mockk.runs
 import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
 import org.junit.Test
 
 /**
  * Unit tests for [PlayRadioDispatcher] (Mode B — artist seed). Mode C
- * (pool-based) lands in Task 4; only the stub-toast path is exercised
- * here.
+ * (pool-based) lives in [PlayRadioModeCTest].
+ *
+ * Updated for the result-type pattern (Task 4): the dispatcher no longer
+ * takes a toast lambda — the VM emits toasts based on the returned
+ * [PlayRadioResult]. Tests assert on the result shape + verify call
+ * ordering against the playback / teardown mocks.
  */
 class PlayRadioModeBTest {
 
@@ -25,8 +31,10 @@ class PlayRadioModeBTest {
         td: ProtocolPlayTeardown = mockk<ProtocolPlayTeardown>().also {
             coEvery { it.prepareForNewPlayback() } just runs
         },
-        toast: suspend (String) -> Unit = { /* no-op */ },
-    ): PlayRadioDispatcher = PlayRadioDispatcher(pc, td, toast)
+        // Mode B never invokes the handler — pass a relaxed mock so a
+        // stray call would surface as a verification failure, not a NPE.
+        handler: ProtocolPlayHandler = mockk(relaxed = true),
+    ): PlayRadioDispatcher = PlayRadioDispatcher(pc, td, handler)
 
     @Test
     fun modeB_callsTeardownBeforeStartSpinoffWithSeed() = runTest {
@@ -35,12 +43,13 @@ class PlayRadioModeBTest {
         coEvery { td.prepareForNewPlayback() } just runs
 
         val dispatcher = build(pc, td)
-        dispatcher.dispatch(
+        val result = dispatcher.dispatch(
             DeepLinkAction.PlayRadio(
                 mode = RadioMode.ArtistSeed("Slowdive", null),
             )
         )
 
+        assertTrue(result is PlayRadioResult.StartedModeB)
         coVerifyOrder {
             td.prepareForNewPlayback()
             pc.startSpinoffWithSeed("Slowdive", null, any(), any())
@@ -52,13 +61,14 @@ class PlayRadioModeBTest {
         val pc = mockk<PlaybackController>(relaxed = true)
         val dispatcher = build(pc = pc)
 
-        dispatcher.dispatch(
+        val result = dispatcher.dispatch(
             DeepLinkAction.PlayRadio(
                 mode = RadioMode.ArtistSeed("Slowdive", "Sugar For The Pill"),
                 name = "My Custom Station",
             )
         )
 
+        assertEquals("My Custom Station", (result as PlayRadioResult.StartedModeB).displayName)
         coVerify(exactly = 1) {
             pc.startSpinoffWithSeed("Slowdive", "Sugar For The Pill", "My Custom Station", any())
         }
@@ -69,13 +79,17 @@ class PlayRadioModeBTest {
         val pc = mockk<PlaybackController>(relaxed = true)
         val dispatcher = build(pc = pc)
 
-        dispatcher.dispatch(
+        val result = dispatcher.dispatch(
             DeepLinkAction.PlayRadio(
                 mode = RadioMode.ArtistSeed("Slowdive", "Sugar For The Pill"),
                 name = null,
             )
         )
 
+        assertEquals(
+            "Radio: Slowdive – Sugar For The Pill",
+            (result as PlayRadioResult.StartedModeB).displayName,
+        )
         coVerify(exactly = 1) {
             pc.startSpinoffWithSeed(
                 "Slowdive",
@@ -91,38 +105,16 @@ class PlayRadioModeBTest {
         val pc = mockk<PlaybackController>(relaxed = true)
         val dispatcher = build(pc = pc)
 
-        dispatcher.dispatch(
+        val result = dispatcher.dispatch(
             DeepLinkAction.PlayRadio(
                 mode = RadioMode.ArtistSeed("Slowdive", null),
                 name = null,
             )
         )
 
+        assertEquals("Radio: Slowdive", (result as PlayRadioResult.StartedModeB).displayName)
         coVerify(exactly = 1) {
             pc.startSpinoffWithSeed("Slowdive", null, "Radio: Slowdive", any())
-        }
-    }
-
-    @Test
-    fun modeB_emitsAcknowledgmentToastBeforeTeardown() = runTest {
-        val pc = mockk<PlaybackController>(relaxed = true)
-        val td = mockk<ProtocolPlayTeardown>()
-        coEvery { td.prepareForNewPlayback() } just runs
-        val toastFn = mockk<suspend (String) -> Unit>()
-        coEvery { toastFn(any()) } just runs
-
-        val dispatcher = PlayRadioDispatcher(pc, td, toastFn)
-        dispatcher.dispatch(
-            DeepLinkAction.PlayRadio(mode = RadioMode.ArtistSeed("Slowdive", null))
-        )
-
-        // Real ordering check: toast must fire BEFORE teardown AND
-        // before startSpinoffWithSeed. The earlier `toasts.firstOrNull()`
-        // assertion would have passed even if toast fired last.
-        coVerifyOrder {
-            toastFn("Building radio…")
-            td.prepareForNewPlayback()
-            pc.startSpinoffWithSeed(any(), any(), any(), any())
         }
     }
 
@@ -131,10 +123,8 @@ class PlayRadioModeBTest {
         val pc = mockk<PlaybackController>(relaxed = true)
         val td = mockk<ProtocolPlayTeardown>()
         coEvery { td.prepareForNewPlayback() } just runs
-        val toastFn = mockk<suspend (String) -> Unit>()
-        coEvery { toastFn(any()) } just runs
 
-        val dispatcher = PlayRadioDispatcher(pc, td, toastFn)
+        val dispatcher = build(pc, td)
         dispatcher.dispatch(
             DeepLinkAction.PlayRadio(
                 mode = RadioMode.ArtistSeed("Slowdive", null),
@@ -154,18 +144,20 @@ class PlayRadioModeBTest {
     }
 
     @Test
-    fun modeC_isStubbed_doesNotInvokeTeardownOrPlayback() = runTest {
+    fun modeB_doesNotCallProtocolPlayHandler() = runTest {
+        // Mode B is fully handled by the dispatcher + PlaybackController —
+        // never delegates to the protocol play handler. (The handler's
+        // `handle(PlayRadio)` requires PoolBased and would throw on
+        // ArtistSeed.)
         val pc = mockk<PlaybackController>(relaxed = true)
-        val td = mockk<ProtocolPlayTeardown>(relaxed = true)
-        val toasts = mutableListOf<String>()
-        val dispatcher = PlayRadioDispatcher(pc, td) { toasts += it }
+        val td = mockk<ProtocolPlayTeardown>()
+        coEvery { td.prepareForNewPlayback() } just runs
+        val handler = mockk<ProtocolPlayHandler>()  // strict — any call fails
 
+        val dispatcher = PlayRadioDispatcher(pc, td, handler)
         dispatcher.dispatch(
-            DeepLinkAction.PlayRadio(mode = RadioMode.PoolBased)
+            DeepLinkAction.PlayRadio(mode = RadioMode.ArtistSeed("Slowdive", null))
         )
-
-        coVerify(exactly = 0) { td.prepareForNewPlayback() }
-        coVerify(exactly = 0) { pc.startSpinoffWithSeed(any(), any(), any(), any()) }
-        assert(toasts.contains("Mode C coming next commit"))
+        // Strict mock — no verification block needed; any invocation throws.
     }
 }

--- a/app/src/test/java/com/parachord/android/deeplink/PlayRadioModeBTest.kt
+++ b/app/src/test/java/com/parachord/android/deeplink/PlayRadioModeBTest.kt
@@ -10,8 +10,10 @@ import io.mockk.coVerifyOrder
 import io.mockk.just
 import io.mockk.mockk
 import io.mockk.runs
+import io.mockk.slot
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertTrue
 import org.junit.Test
 
@@ -19,10 +21,13 @@ import org.junit.Test
  * Unit tests for [PlayRadioDispatcher] (Mode B — artist seed). Mode C
  * (pool-based) lives in [PlayRadioModeCTest].
  *
- * Updated for the result-type pattern (Task 4): the dispatcher no longer
- * takes a toast lambda — the VM emits toasts based on the returned
- * [PlayRadioResult]. Tests assert on the result shape + verify call
- * ordering against the playback / teardown mocks.
+ * Mode B has two sub-paths since the LB Radio fix (#121):
+ *  - **Title-bearing** (`?artist=X&title=Y`) → Last.fm `track.getsimilar`
+ *    via [PlaybackController.startSpinoffWithSeed]. Returns
+ *    [PlayRadioResult.StartedModeB].
+ *  - **Artist-only** (`?artist=X`, no title) → ListenBrainz LB Radio
+ *    via the synthesized Mode C pool path. Returns
+ *    [PlayRadioResult.StartedModeC].
  */
 class PlayRadioModeBTest {
 
@@ -31,13 +36,16 @@ class PlayRadioModeBTest {
         td: ProtocolPlayTeardown = mockk<ProtocolPlayTeardown>().also {
             coEvery { it.prepareForNewPlayback() } just runs
         },
-        // Mode B never invokes the handler — pass a relaxed mock so a
-        // stray call would surface as a verification failure, not a NPE.
+        // Title-bearing Mode B never invokes the handler — pass a relaxed
+        // mock so a stray call surfaces as a verification failure, not a
+        // NPE. Artist-only Mode B tests build their own strict mock.
         handler: ProtocolPlayHandler = mockk(relaxed = true),
     ): PlayRadioDispatcher = PlayRadioDispatcher(pc, td, handler)
 
+    // ── Title-bearing path (Last.fm track.getsimilar) ──────────────────
+
     @Test
-    fun modeB_callsTeardownBeforeStartSpinoffWithSeed() = runTest {
+    fun modeB_titleBearing_callsTeardownBeforeStartSpinoffWithSeed() = runTest {
         val pc = mockk<PlaybackController>(relaxed = true)
         val td = mockk<ProtocolPlayTeardown>()
         coEvery { td.prepareForNewPlayback() } just runs
@@ -45,19 +53,19 @@ class PlayRadioModeBTest {
         val dispatcher = build(pc, td)
         val result = dispatcher.dispatch(
             DeepLinkAction.PlayRadio(
-                mode = RadioMode.ArtistSeed("Slowdive", null),
+                mode = RadioMode.ArtistSeed("Slowdive", "Sugar For The Pill"),
             )
         )
 
         assertTrue(result is PlayRadioResult.StartedModeB)
         coVerifyOrder {
             td.prepareForNewPlayback()
-            pc.startSpinoffWithSeed("Slowdive", null, any(), any())
+            pc.startSpinoffWithSeed("Slowdive", "Sugar For The Pill", any(), any())
         }
     }
 
     @Test
-    fun modeB_displayName_prefersExplicitNameOverArtistTitleFallback() = runTest {
+    fun modeB_titleBearing_displayName_prefersExplicitName() = runTest {
         val pc = mockk<PlaybackController>(relaxed = true)
         val dispatcher = build(pc = pc)
 
@@ -75,7 +83,7 @@ class PlayRadioModeBTest {
     }
 
     @Test
-    fun modeB_displayName_artistTitleFallbackWhenNoExplicitName() = runTest {
+    fun modeB_titleBearing_displayName_artistTitleFallbackWhenNoExplicitName() = runTest {
         val pc = mockk<PlaybackController>(relaxed = true)
         val dispatcher = build(pc = pc)
 
@@ -101,25 +109,7 @@ class PlayRadioModeBTest {
     }
 
     @Test
-    fun modeB_displayName_artistOnlyFallback() = runTest {
-        val pc = mockk<PlaybackController>(relaxed = true)
-        val dispatcher = build(pc = pc)
-
-        val result = dispatcher.dispatch(
-            DeepLinkAction.PlayRadio(
-                mode = RadioMode.ArtistSeed("Slowdive", null),
-                name = null,
-            )
-        )
-
-        assertEquals("Radio: Slowdive", (result as PlayRadioResult.StartedModeB).displayName)
-        coVerify(exactly = 1) {
-            pc.startSpinoffWithSeed("Slowdive", null, "Radio: Slowdive", any())
-        }
-    }
-
-    @Test
-    fun modeB_passesKickStartFirstTrackTrue_soPoolStartsPlayingImmediately() = runTest {
+    fun modeB_titleBearing_passesKickStartFirstTrackTrue() = runTest {
         val pc = mockk<PlaybackController>(relaxed = true)
         val td = mockk<ProtocolPlayTeardown>()
         coEvery { td.prepareForNewPlayback() } just runs
@@ -127,7 +117,7 @@ class PlayRadioModeBTest {
         val dispatcher = build(pc, td)
         dispatcher.dispatch(
             DeepLinkAction.PlayRadio(
-                mode = RadioMode.ArtistSeed("Slowdive", null),
+                mode = RadioMode.ArtistSeed("Slowdive", "Sugar For The Pill"),
             )
         )
 
@@ -136,19 +126,19 @@ class PlayRadioModeBTest {
         coVerify(exactly = 1) {
             pc.startSpinoffWithSeed(
                 seedArtist = "Slowdive",
-                seedTitle = null,
-                displayName = "Radio: Slowdive",
+                seedTitle = "Sugar For The Pill",
+                displayName = "Radio: Slowdive – Sugar For The Pill",
                 kickStartFirstTrack = true,
             )
         }
     }
 
     @Test
-    fun modeB_doesNotCallProtocolPlayHandler() = runTest {
-        // Mode B is fully handled by the dispatcher + PlaybackController —
-        // never delegates to the protocol play handler. (The handler's
-        // `handle(PlayRadio)` requires PoolBased and would throw on
-        // ArtistSeed.)
+    fun modeB_titleBearing_doesNotCallProtocolPlayHandler() = runTest {
+        // Title-bearing Mode B is fully handled by the dispatcher +
+        // PlaybackController — never delegates to the protocol play
+        // handler. (The handler's `handle(PlayRadio)` requires PoolBased
+        // and would throw on ArtistSeed.)
         val pc = mockk<PlaybackController>(relaxed = true)
         val td = mockk<ProtocolPlayTeardown>()
         coEvery { td.prepareForNewPlayback() } just runs
@@ -156,8 +146,137 @@ class PlayRadioModeBTest {
 
         val dispatcher = PlayRadioDispatcher(pc, td, handler)
         dispatcher.dispatch(
-            DeepLinkAction.PlayRadio(mode = RadioMode.ArtistSeed("Slowdive", null))
+            DeepLinkAction.PlayRadio(
+                mode = RadioMode.ArtistSeed("Slowdive", "Sugar For The Pill"),
+            )
         )
         // Strict mock — no verification block needed; any invocation throws.
+    }
+
+    // ── Artist-only path (ListenBrainz LB Radio via Mode C pool) ───────
+
+    @Test
+    fun modeB_artistOnly_synthesizesLbRadioUrlAsBothInitialAndRefill() = runTest {
+        val pc = mockk<PlaybackController>(relaxed = true)
+        val td = mockk<ProtocolPlayTeardown>(relaxed = true)
+        coEvery { td.prepareForNewPlayback() } just runs
+        val handler = mockk<ProtocolPlayHandler>()
+        coEvery { handler.handle(any<DeepLinkAction.PlayRadio>()) } returns
+            ProtocolPlayResult.Started("Radio: Slowdive", 10)
+        coEvery { handler.resolveTrackList(any()) } returns emptyList()
+
+        val dispatcher = PlayRadioDispatcher(pc, td, handler)
+        val result = dispatcher.dispatch(
+            DeepLinkAction.PlayRadio(mode = RadioMode.ArtistSeed("Slowdive", null))
+        )
+
+        assertTrue(result is PlayRadioResult.StartedModeC)
+
+        // Capture the synthetic action handed to the handler. Verify both
+        // input.url and refillUrl point at the same LB Radio URL with the
+        // expected prompt + mode.
+        val slot = slot<DeepLinkAction.PlayRadio>()
+        coVerify(exactly = 1) { handler.handle(capture(slot)) }
+        val synthetic = slot.captured
+        assertEquals(RadioMode.PoolBased, synthetic.mode)
+        assertNotNull(synthetic.input?.url)
+        assertEquals(synthetic.input?.url, synthetic.refillUrl)
+        val url = synthetic.input!!.url!!
+        assertTrue(
+            "URL should hit api.listenbrainz.org: $url",
+            url.startsWith("https://api.listenbrainz.org/1/explore/lb-radio?"),
+        )
+        assertTrue(
+            "URL should encode prompt=artist:(Slowdive): $url",
+            url.contains("prompt=artist%3A%28Slowdive%29") ||
+                url.contains("prompt=artist%3A(Slowdive)") ||
+                url.contains("prompt=artist:%28Slowdive%29") ||
+                url.contains("prompt=artist:(Slowdive)"),
+        )
+        assertTrue("URL should set mode=easy: $url", url.contains("mode=easy"))
+    }
+
+    @Test
+    fun modeB_artistOnly_doesNotCallStartSpinoffWithSeed() = runTest {
+        // Artist-only routes through ProtocolPlayHandler.handle() — must
+        // NOT touch the Last.fm spinoff path.
+        val pc = mockk<PlaybackController>(relaxed = true)
+        val td = mockk<ProtocolPlayTeardown>(relaxed = true)
+        coEvery { td.prepareForNewPlayback() } just runs
+        val handler = mockk<ProtocolPlayHandler>()
+        coEvery { handler.handle(any<DeepLinkAction.PlayRadio>()) } returns
+            ProtocolPlayResult.Started("Radio: Slowdive", 10)
+
+        val dispatcher = PlayRadioDispatcher(pc, td, handler)
+        dispatcher.dispatch(
+            DeepLinkAction.PlayRadio(mode = RadioMode.ArtistSeed("Slowdive", null))
+        )
+
+        coVerify(exactly = 0) { pc.startSpinoffWithSeed(any(), any(), any(), any()) }
+    }
+
+    @Test
+    fun modeB_artistOnly_artistWithSpaces_urlEncodedCorrectly() = runTest {
+        val pc = mockk<PlaybackController>(relaxed = true)
+        val td = mockk<ProtocolPlayTeardown>(relaxed = true)
+        coEvery { td.prepareForNewPlayback() } just runs
+        val handler = mockk<ProtocolPlayHandler>()
+        coEvery { handler.handle(any<DeepLinkAction.PlayRadio>()) } returns
+            ProtocolPlayResult.Started("Radio: Tame Impala", 10)
+
+        val dispatcher = PlayRadioDispatcher(pc, td, handler)
+        dispatcher.dispatch(
+            DeepLinkAction.PlayRadio(mode = RadioMode.ArtistSeed("Tame Impala", null))
+        )
+
+        val slot = slot<DeepLinkAction.PlayRadio>()
+        coVerify(exactly = 1) { handler.handle(capture(slot)) }
+        val url = slot.captured.input!!.url!!
+        // URLEncoder turns spaces into '+' for query-string values.
+        assertTrue(
+            "space should be encoded in $url",
+            url.contains("%20Impala") || url.contains("+Impala"),
+        )
+    }
+
+    @Test
+    fun modeB_artistOnly_displayName_prefersExplicitName() = runTest {
+        val pc = mockk<PlaybackController>(relaxed = true)
+        val td = mockk<ProtocolPlayTeardown>(relaxed = true)
+        coEvery { td.prepareForNewPlayback() } just runs
+        val handler = mockk<ProtocolPlayHandler>()
+        coEvery { handler.handle(any<DeepLinkAction.PlayRadio>()) } returns
+            ProtocolPlayResult.Started("My Custom Station", 10)
+
+        val dispatcher = PlayRadioDispatcher(pc, td, handler)
+        dispatcher.dispatch(
+            DeepLinkAction.PlayRadio(
+                mode = RadioMode.ArtistSeed("Slowdive", null),
+                name = "My Custom Station",
+            )
+        )
+
+        val slot = slot<DeepLinkAction.PlayRadio>()
+        coVerify(exactly = 1) { handler.handle(capture(slot)) }
+        assertEquals("My Custom Station", slot.captured.name)
+    }
+
+    @Test
+    fun modeB_artistOnly_displayName_fallbackWhenNoExplicitName() = runTest {
+        val pc = mockk<PlaybackController>(relaxed = true)
+        val td = mockk<ProtocolPlayTeardown>(relaxed = true)
+        coEvery { td.prepareForNewPlayback() } just runs
+        val handler = mockk<ProtocolPlayHandler>()
+        coEvery { handler.handle(any<DeepLinkAction.PlayRadio>()) } returns
+            ProtocolPlayResult.Started("Radio: Slowdive", 10)
+
+        val dispatcher = PlayRadioDispatcher(pc, td, handler)
+        dispatcher.dispatch(
+            DeepLinkAction.PlayRadio(mode = RadioMode.ArtistSeed("Slowdive", null), name = null)
+        )
+
+        val slot = slot<DeepLinkAction.PlayRadio>()
+        coVerify(exactly = 1) { handler.handle(capture(slot)) }
+        assertEquals("Radio: Slowdive", slot.captured.name)
     }
 }

--- a/app/src/test/java/com/parachord/android/deeplink/PlayRadioModeBTest.kt
+++ b/app/src/test/java/com/parachord/android/deeplink/PlayRadioModeBTest.kt
@@ -1,0 +1,138 @@
+package com.parachord.android.deeplink
+
+import com.parachord.android.playback.PlaybackController
+import com.parachord.shared.deeplink.DeepLinkAction
+import com.parachord.shared.deeplink.ProtocolPlayTeardown
+import com.parachord.shared.deeplink.RadioMode
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.coVerifyOrder
+import io.mockk.just
+import io.mockk.mockk
+import io.mockk.runs
+import kotlinx.coroutines.test.runTest
+import org.junit.Test
+
+/**
+ * Unit tests for [PlayRadioDispatcher] (Mode B — artist seed). Mode C
+ * (pool-based) lands in Task 4; only the stub-toast path is exercised
+ * here.
+ */
+class PlayRadioModeBTest {
+
+    private fun build(
+        pc: PlaybackController = mockk(relaxed = true),
+        td: ProtocolPlayTeardown = mockk<ProtocolPlayTeardown>().also {
+            coEvery { it.prepareForNewPlayback() } just runs
+        },
+        toast: suspend (String) -> Unit = { /* no-op */ },
+    ): PlayRadioDispatcher = PlayRadioDispatcher(pc, td, toast)
+
+    @Test
+    fun modeB_callsTeardownBeforeStartSpinoffWithSeed() = runTest {
+        val pc = mockk<PlaybackController>(relaxed = true)
+        val td = mockk<ProtocolPlayTeardown>()
+        coEvery { td.prepareForNewPlayback() } just runs
+
+        val dispatcher = build(pc, td)
+        dispatcher.dispatch(
+            DeepLinkAction.PlayRadio(
+                mode = RadioMode.ArtistSeed("Slowdive", null),
+            )
+        )
+
+        coVerifyOrder {
+            td.prepareForNewPlayback()
+            pc.startSpinoffWithSeed("Slowdive", null, any())
+        }
+    }
+
+    @Test
+    fun modeB_displayName_prefersExplicitNameOverArtistTitleFallback() = runTest {
+        val pc = mockk<PlaybackController>(relaxed = true)
+        val dispatcher = build(pc = pc)
+
+        dispatcher.dispatch(
+            DeepLinkAction.PlayRadio(
+                mode = RadioMode.ArtistSeed("Slowdive", "Sugar For The Pill"),
+                name = "My Custom Station",
+            )
+        )
+
+        coVerify(exactly = 1) {
+            pc.startSpinoffWithSeed("Slowdive", "Sugar For The Pill", "My Custom Station")
+        }
+    }
+
+    @Test
+    fun modeB_displayName_artistTitleFallbackWhenNoExplicitName() = runTest {
+        val pc = mockk<PlaybackController>(relaxed = true)
+        val dispatcher = build(pc = pc)
+
+        dispatcher.dispatch(
+            DeepLinkAction.PlayRadio(
+                mode = RadioMode.ArtistSeed("Slowdive", "Sugar For The Pill"),
+                name = null,
+            )
+        )
+
+        coVerify(exactly = 1) {
+            pc.startSpinoffWithSeed(
+                "Slowdive",
+                "Sugar For The Pill",
+                "Radio: Slowdive – Sugar For The Pill",
+            )
+        }
+    }
+
+    @Test
+    fun modeB_displayName_artistOnlyFallback() = runTest {
+        val pc = mockk<PlaybackController>(relaxed = true)
+        val dispatcher = build(pc = pc)
+
+        dispatcher.dispatch(
+            DeepLinkAction.PlayRadio(
+                mode = RadioMode.ArtistSeed("Slowdive", null),
+                name = null,
+            )
+        )
+
+        coVerify(exactly = 1) {
+            pc.startSpinoffWithSeed("Slowdive", null, "Radio: Slowdive")
+        }
+    }
+
+    @Test
+    fun modeB_emitsAcknowledgmentToastBeforeTeardown() = runTest {
+        val pc = mockk<PlaybackController>(relaxed = true)
+        val td = mockk<ProtocolPlayTeardown>()
+        coEvery { td.prepareForNewPlayback() } just runs
+        val toasts = mutableListOf<String>()
+        val dispatcher = PlayRadioDispatcher(pc, td) { toasts += it }
+
+        dispatcher.dispatch(
+            DeepLinkAction.PlayRadio(mode = RadioMode.ArtistSeed("Slowdive", null))
+        )
+
+        // Acknowledgment toast fires before teardown / startSpinoffWithSeed.
+        assert(toasts.firstOrNull() == "Building radio…") {
+            "expected 'Building radio…' first, got $toasts"
+        }
+    }
+
+    @Test
+    fun modeC_isStubbed_doesNotInvokeTeardownOrPlayback() = runTest {
+        val pc = mockk<PlaybackController>(relaxed = true)
+        val td = mockk<ProtocolPlayTeardown>(relaxed = true)
+        val toasts = mutableListOf<String>()
+        val dispatcher = PlayRadioDispatcher(pc, td) { toasts += it }
+
+        dispatcher.dispatch(
+            DeepLinkAction.PlayRadio(mode = RadioMode.PoolBased)
+        )
+
+        coVerify(exactly = 0) { td.prepareForNewPlayback() }
+        coVerify(exactly = 0) { pc.startSpinoffWithSeed(any(), any(), any()) }
+        assert(toasts.contains("Mode C coming next commit"))
+    }
+}

--- a/app/src/test/java/com/parachord/android/deeplink/PlayRadioModeCTest.kt
+++ b/app/src/test/java/com/parachord/android/deeplink/PlayRadioModeCTest.kt
@@ -1,0 +1,292 @@
+package com.parachord.android.deeplink
+
+import com.parachord.android.data.db.entity.TrackEntity
+import com.parachord.android.playback.PlaybackController
+import com.parachord.android.resolver.TrackResolverCache
+import com.parachord.shared.deeplink.DeepLinkAction
+import com.parachord.shared.deeplink.ProtocolInputResolver
+import com.parachord.shared.deeplink.ProtocolPlayInput
+import com.parachord.shared.deeplink.ProtocolPlayTeardown
+import com.parachord.shared.deeplink.ProtocolTrack
+import com.parachord.shared.deeplink.RadioMode
+import com.parachord.shared.deeplink.ResolvedProtocolPlay
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.coVerifyOrder
+import io.mockk.just
+import io.mockk.mockk
+import io.mockk.runs
+import io.mockk.slot
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * End-to-end coverage for `parachord://play/radio` Mode C (pool-based).
+ *
+ * Exercises the full chain:
+ *   [PlayRadioDispatcher] → [ProtocolPlayHandler.handle] (PlayRadio) →
+ *   [PlaybackController.startPoolBasedSpinoff].
+ *
+ * The Phase 2 [ProtocolInputResolver] is mocked per-test to control which
+ * priority slot fires (URL vs. inline tracks) since the radio Mode C
+ * options gate to `allowUrl = true, allowTracks = true` only.
+ */
+class PlayRadioModeCTest {
+
+    private val sampleTracks = listOf(
+        ProtocolTrack(artist = "A1", title = "T1"),
+        ProtocolTrack(artist = "A2", title = "T2"),
+    )
+
+    private fun buildHandler(
+        resolver: ProtocolInputResolver = mockk(relaxed = true),
+        teardown: ProtocolPlayTeardown = mockk<ProtocolPlayTeardown>().also {
+            coEvery { it.prepareForNewPlayback() } just runs
+        },
+        playbackController: PlaybackController = mockk(relaxed = true),
+        trackResolverCache: TrackResolverCache = mockk(relaxed = true),
+    ): ProtocolPlayHandler = ProtocolPlayHandler(
+        resolver = resolver,
+        teardown = teardown,
+        playbackController = playbackController,
+        trackResolverCache = trackResolverCache,
+    )
+
+    private fun buildDispatcher(
+        playbackController: PlaybackController,
+        teardown: ProtocolPlayTeardown,
+        handler: ProtocolPlayHandler,
+    ): PlayRadioDispatcher = PlayRadioDispatcher(playbackController, teardown, handler)
+
+    @Test
+    fun modeC_inlineTracks_buildsPoolWithStableIdsAndKicksOff() = runTest {
+        // Inline tracks bypass the resolver entirely (resolveProtocolPlayInput
+        // wraps them directly into a ResolvedProtocolPlay). Strict resolver —
+        // any call would throw.
+        val resolver = mockk<ProtocolInputResolver>()
+        val pc = mockk<PlaybackController>(relaxed = true)
+        val td = mockk<ProtocolPlayTeardown>()
+        coEvery { td.prepareForNewPlayback() } just runs
+        val handler = buildHandler(resolver = resolver, teardown = td, playbackController = pc)
+        val dispatcher = buildDispatcher(pc, td, handler)
+
+        val poolSlot = slot<List<TrackEntity>>()
+        val nameSlot = slot<String>()
+        val refillSlot = slot<String?>()
+        coEvery { pc.startPoolBasedSpinoff(capture(poolSlot), capture(nameSlot), captureNullable(refillSlot)) } just runs
+
+        val result = dispatcher.dispatch(
+            DeepLinkAction.PlayRadio(
+                mode = RadioMode.PoolBased,
+                input = ProtocolPlayInput(tracks = sampleTracks, title = "Inline Pool"),
+                refillUrl = null,
+            )
+        )
+
+        result as PlayRadioResult.StartedModeC
+        assertEquals("Inline Pool", result.displayName)
+        assertEquals(2, result.trackCount)
+
+        // Pool entities have stable protocol-radio-{ts}-{idx} IDs.
+        assertEquals(2, poolSlot.captured.size)
+        assertTrue(
+            "first id was '${poolSlot.captured[0].id}'",
+            poolSlot.captured[0].id.startsWith("protocol-radio-") &&
+                poolSlot.captured[0].id.endsWith("-0"),
+        )
+        assertTrue(poolSlot.captured[1].id.endsWith("-1"))
+        assertEquals("A1", poolSlot.captured[0].artist)
+        assertEquals("T1", poolSlot.captured[0].title)
+
+        assertEquals("Inline Pool", nameSlot.captured)
+        assertNull(refillSlot.captured)
+    }
+
+    @Test
+    fun modeC_url_fetchesAndParses_passesRefillUrlThroughToController() = runTest {
+        val urlPool = (1..5).map { ProtocolTrack(artist = "A$it", title = "T$it") }
+        val resolver = mockk<ProtocolInputResolver> {
+            coEvery { resolveByUrl("https://api.listenbrainz.org/1/explore/lb-radio?mode=easy") } returns
+                ResolvedProtocolPlay("LB Radio", urlPool)
+        }
+        val pc = mockk<PlaybackController>(relaxed = true)
+        val td = mockk<ProtocolPlayTeardown>()
+        coEvery { td.prepareForNewPlayback() } just runs
+        val handler = buildHandler(resolver = resolver, teardown = td, playbackController = pc)
+        val dispatcher = buildDispatcher(pc, td, handler)
+
+        val refillSlot = slot<String?>()
+        coEvery { pc.startPoolBasedSpinoff(any(), any(), captureNullable(refillSlot)) } just runs
+
+        val refillUrl = "https://api.listenbrainz.org/1/explore/lb-radio?mode=easy&refill=1"
+        val result = dispatcher.dispatch(
+            DeepLinkAction.PlayRadio(
+                mode = RadioMode.PoolBased,
+                input = ProtocolPlayInput(url = "https://api.listenbrainz.org/1/explore/lb-radio?mode=easy"),
+                refillUrl = refillUrl,
+            )
+        )
+
+        result as PlayRadioResult.StartedModeC
+        assertEquals(5, result.trackCount)
+        assertEquals(refillUrl, refillSlot.captured)
+
+        coVerify(exactly = 1) {
+            pc.startPoolBasedSpinoff(match { it.size == 5 }, "LB Radio", refillUrl)
+        }
+    }
+
+    @Test
+    fun modeC_emptyPool_returnsFailedAndDoesNotCallTeardownOrController() = runTest {
+        val resolver = mockk<ProtocolInputResolver> {
+            coEvery { resolveByUrl(any()) } returns ResolvedProtocolPlay("Empty", emptyList())
+        }
+        val pc = mockk<PlaybackController>(relaxed = true)
+        val td = mockk<ProtocolPlayTeardown>(relaxed = true)
+        val handler = buildHandler(resolver = resolver, teardown = td, playbackController = pc)
+        val dispatcher = buildDispatcher(pc, td, handler)
+
+        val result = dispatcher.dispatch(
+            DeepLinkAction.PlayRadio(
+                mode = RadioMode.PoolBased,
+                input = ProtocolPlayInput(url = "https://example.com/empty.xspf"),
+            )
+        )
+
+        assertTrue(result is PlayRadioResult.Failed)
+        // Match handle(PlayAlbum)'s convention exactly: empty-tracks bails
+        // BEFORE teardown, so neither teardown nor the controller fire.
+        coVerify(exactly = 0) { td.prepareForNewPlayback() }
+        coVerify(exactly = 0) { pc.startPoolBasedSpinoff(any(), any(), any()) }
+    }
+
+    @Test
+    fun modeC_resolverThrows_returnsFailedAndDoesNotCallController() = runTest {
+        val resolver = mockk<ProtocolInputResolver> {
+            coEvery { resolveByUrl(any()) } throws RuntimeException("network blew up")
+        }
+        val pc = mockk<PlaybackController>(relaxed = true)
+        val td = mockk<ProtocolPlayTeardown>(relaxed = true)
+        val handler = buildHandler(resolver = resolver, teardown = td, playbackController = pc)
+        val dispatcher = buildDispatcher(pc, td, handler)
+
+        val result = dispatcher.dispatch(
+            DeepLinkAction.PlayRadio(
+                mode = RadioMode.PoolBased,
+                input = ProtocolPlayInput(url = "https://example.com/broken.xspf"),
+            )
+        )
+
+        result as PlayRadioResult.Failed
+        assertTrue(
+            "reason was '${result.reason}'",
+            result.reason.contains("network blew up") || result.reason.contains("Radio fetch failed"),
+        )
+        coVerify(exactly = 0) { pc.startPoolBasedSpinoff(any(), any(), any()) }
+    }
+
+    @Test
+    fun modeC_missingInput_returnsFailedWithoutTouchingResolver() = runTest {
+        val resolver = mockk<ProtocolInputResolver>()  // strict — any call fails
+        val pc = mockk<PlaybackController>(relaxed = true)
+        val td = mockk<ProtocolPlayTeardown>(relaxed = true)
+        val handler = buildHandler(resolver = resolver, teardown = td, playbackController = pc)
+        val dispatcher = buildDispatcher(pc, td, handler)
+
+        val result = dispatcher.dispatch(
+            DeepLinkAction.PlayRadio(mode = RadioMode.PoolBased, input = null)
+        )
+
+        result as PlayRadioResult.Failed
+        coVerify(exactly = 0) { pc.startPoolBasedSpinoff(any(), any(), any()) }
+    }
+
+    // ── Display-name precedence: action.name → input.title → resolver → "Radio" ──
+
+    @Test
+    fun modeC_namePrecedence_explicitNameWinsOverInputTitleAndResolvedName() = runTest {
+        val resolver = mockk<ProtocolInputResolver> {
+            coEvery { resolveByUrl(any()) } returns ResolvedProtocolPlay("resolved name", sampleTracks)
+        }
+        val pc = mockk<PlaybackController>(relaxed = true)
+        val handler = buildHandler(resolver = resolver, playbackController = pc)
+        val dispatcher = buildDispatcher(pc, mockk<ProtocolPlayTeardown>(relaxed = true), handler)
+
+        dispatcher.dispatch(
+            DeepLinkAction.PlayRadio(
+                mode = RadioMode.PoolBased,
+                input = ProtocolPlayInput(url = "https://example.com/x", title = "input title"),
+                name = "explicit name",
+            )
+        )
+
+        coVerify(exactly = 1) { pc.startPoolBasedSpinoff(any(), "explicit name", any()) }
+    }
+
+    @Test
+    fun modeC_namePrecedence_inputTitleWinsOverResolvedNameWhenNoExplicit() = runTest {
+        val resolver = mockk<ProtocolInputResolver> {
+            coEvery { resolveByUrl(any()) } returns ResolvedProtocolPlay("resolved name", sampleTracks)
+        }
+        val pc = mockk<PlaybackController>(relaxed = true)
+        val handler = buildHandler(resolver = resolver, playbackController = pc)
+        val dispatcher = buildDispatcher(pc, mockk<ProtocolPlayTeardown>(relaxed = true), handler)
+
+        dispatcher.dispatch(
+            DeepLinkAction.PlayRadio(
+                mode = RadioMode.PoolBased,
+                input = ProtocolPlayInput(url = "https://example.com/x", title = "input title"),
+                name = null,
+            )
+        )
+
+        coVerify(exactly = 1) { pc.startPoolBasedSpinoff(any(), "input title", any()) }
+    }
+
+    @Test
+    fun modeC_namePrecedence_resolvedNameWinsWhenNoExplicitNoInputTitle() = runTest {
+        val resolver = mockk<ProtocolInputResolver> {
+            coEvery { resolveByUrl(any()) } returns ResolvedProtocolPlay("resolved name", sampleTracks)
+        }
+        val pc = mockk<PlaybackController>(relaxed = true)
+        val handler = buildHandler(resolver = resolver, playbackController = pc)
+        val dispatcher = buildDispatcher(pc, mockk<ProtocolPlayTeardown>(relaxed = true), handler)
+
+        dispatcher.dispatch(
+            DeepLinkAction.PlayRadio(
+                mode = RadioMode.PoolBased,
+                input = ProtocolPlayInput(url = "https://example.com/x"),
+                name = null,
+            )
+        )
+
+        coVerify(exactly = 1) { pc.startPoolBasedSpinoff(any(), "resolved name", any()) }
+    }
+
+    @Test
+    fun modeC_teardownFiresBeforeStartPoolBasedSpinoff() = runTest {
+        val resolver = mockk<ProtocolInputResolver> {
+            coEvery { resolveByUrl(any()) } returns ResolvedProtocolPlay("X", sampleTracks)
+        }
+        val pc = mockk<PlaybackController>(relaxed = true)
+        val td = mockk<ProtocolPlayTeardown>()
+        coEvery { td.prepareForNewPlayback() } just runs
+        val handler = buildHandler(resolver = resolver, teardown = td, playbackController = pc)
+        val dispatcher = buildDispatcher(pc, td, handler)
+
+        dispatcher.dispatch(
+            DeepLinkAction.PlayRadio(
+                mode = RadioMode.PoolBased,
+                input = ProtocolPlayInput(url = "https://example.com/x"),
+            )
+        )
+
+        coVerifyOrder {
+            td.prepareForNewPlayback()
+            pc.startPoolBasedSpinoff(any(), any(), any())
+        }
+    }
+}

--- a/app/src/test/java/com/parachord/android/deeplink/PlayRadioModeCTest.kt
+++ b/app/src/test/java/com/parachord/android/deeplink/PlayRadioModeCTest.kt
@@ -267,6 +267,36 @@ class PlayRadioModeCTest {
     }
 
     @Test
+    fun modeC_namePrecedence_radioFallback() = runTest {
+        // All four sources blank/null → literal "Radio" default. The
+        // resolver here returns a blank displayName (mirrors an XSPF/JSPF
+        // parser that didn't find a <title>); the chain's
+        // .takeIf { it.isNotBlank() } guards must fall through to "Radio".
+        val resolver = mockk<ProtocolInputResolver> {
+            coEvery { resolveByUrl(any()) } returns ResolvedProtocolPlay(
+                displayName = "",
+                tracks = sampleTracks,
+            )
+        }
+        val pc = mockk<PlaybackController>(relaxed = true)
+        val td = mockk<ProtocolPlayTeardown>()
+        coEvery { td.prepareForNewPlayback() } just runs
+        val handler = buildHandler(resolver = resolver, teardown = td, playbackController = pc)
+        val dispatcher = buildDispatcher(pc, td, handler)
+
+        val result = dispatcher.dispatch(
+            DeepLinkAction.PlayRadio(
+                mode = RadioMode.PoolBased,
+                input = ProtocolPlayInput(url = "https://example.com/p.jspf", title = null),
+                name = null,
+            )
+        )
+
+        assertTrue(result is PlayRadioResult.StartedModeC)
+        coVerify(exactly = 1) { pc.startPoolBasedSpinoff(any(), "Radio", any()) }
+    }
+
+    @Test
     fun modeC_teardownFiresBeforeStartPoolBasedSpinoff() = runTest {
         val resolver = mockk<ProtocolInputResolver> {
             coEvery { resolveByUrl(any()) } returns ResolvedProtocolPlay("X", sampleTracks)

--- a/app/src/test/java/com/parachord/android/deeplink/PlayRadioModeCTest.kt
+++ b/app/src/test/java/com/parachord/android/deeplink/PlayRadioModeCTest.kt
@@ -13,6 +13,7 @@ import com.parachord.shared.deeplink.ResolvedProtocolPlay
 import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.coVerifyOrder
+import io.mockk.every
 import io.mockk.just
 import io.mockk.mockk
 import io.mockk.runs
@@ -294,6 +295,62 @@ class PlayRadioModeCTest {
 
         assertTrue(result is PlayRadioResult.StartedModeC)
         coVerify(exactly = 1) { pc.startPoolBasedSpinoff(any(), "Radio", any()) }
+    }
+
+    @Test
+    fun modeC_dispatcher_wiresPoolFetcherBeforeHandlerRuns() = runTest {
+        // The dispatcher must call setPoolFetcher BEFORE handle(), so that
+        // when ProtocolPlayHandler invokes startPoolBasedSpinoff() the
+        // controller has a fetcher in place for the first refill tick.
+        val resolver = mockk<ProtocolInputResolver> {
+            coEvery { resolveByUrl(any()) } returns ResolvedProtocolPlay("X", sampleTracks)
+        }
+        val pc = mockk<PlaybackController>(relaxed = true)
+        val td = mockk<ProtocolPlayTeardown>()
+        coEvery { td.prepareForNewPlayback() } just runs
+        val handler = buildHandler(resolver = resolver, teardown = td, playbackController = pc)
+        val dispatcher = buildDispatcher(pc, td, handler)
+
+        every { pc.setPoolFetcher(any()) } just runs
+
+        dispatcher.dispatch(
+            DeepLinkAction.PlayRadio(
+                mode = RadioMode.PoolBased,
+                input = ProtocolPlayInput(url = "https://example.com/p.jspf"),
+                refillUrl = "https://example.com/p.jspf?refill=1",
+            )
+        )
+
+        coVerifyOrder {
+            pc.setPoolFetcher(any())
+            pc.startPoolBasedSpinoff(any(), any(), any())
+        }
+    }
+
+    @Test
+    fun modeC_handler_resolveTrackList_delegatesToResolver() = runTest {
+        // Tests the new ProtocolPlayHandler.resolveTrackList(url) method
+        // — the closure body wired into PlaybackController.setPoolFetcher.
+        // Should walk through ProtocolInputResolver.resolveByUrl and
+        // unwrap ResolvedProtocolPlay.tracks.
+        val resolver = mockk<ProtocolInputResolver> {
+            coEvery { resolveByUrl("https://refill.example.com/x") } returns
+                ResolvedProtocolPlay("Refill", sampleTracks)
+        }
+        val handler = buildHandler(resolver = resolver)
+        val tracks = handler.resolveTrackList("https://refill.example.com/x")
+        assertEquals(2, tracks.size)
+        assertEquals("A1", tracks[0].artist)
+    }
+
+    @Test
+    fun modeC_handler_resolveTrackList_returnsEmptyOnNullResolve() = runTest {
+        val resolver = mockk<ProtocolInputResolver> {
+            coEvery { resolveByUrl(any()) } returns null
+        }
+        val handler = buildHandler(resolver = resolver)
+        val tracks = handler.resolveTrackList("https://nope.example.com/x")
+        assertTrue(tracks.isEmpty())
     }
 
     @Test

--- a/app/src/test/java/com/parachord/android/playback/PoolRefillerTest.kt
+++ b/app/src/test/java/com/parachord/android/playback/PoolRefillerTest.kt
@@ -272,24 +272,6 @@ class PoolRefillerTest {
     // ── Reset ────────────────────────────────────────────────────────
 
     @Test
-    fun reset_clearsAllState() = runTest {
-        val clock = FakeClock(initial = 100_000L)
-        val r = buildRefiller(clock = clock, fetcher = { emptyList() })
-        // Burn an empty.
-        assertNull(r.tryRefill(emptyList()))
-        assertEquals(1, r.emptyCountForTest)
-        assertTrue(r.lastFetchTsForTest > 0L)
-
-        r.reset()
-        assertNull(r.fetcher)
-        assertNull(r.refillUrl)
-        assertEquals(0, r.emptyCountForTest)
-        assertEquals(0L, r.lastFetchTsForTest)
-        // canRefill is false because fetcher + url cleared.
-        assertFalse(r.canRefill())
-    }
-
-    @Test
     fun resetCounters_clearsCountersButPreservesFetcherAndUrl() = runTest {
         val clock = FakeClock(initial = 100_000L)
         val r = buildRefiller(clock = clock, fetcher = { emptyList() })

--- a/app/src/test/java/com/parachord/android/playback/PoolRefillerTest.kt
+++ b/app/src/test/java/com/parachord/android/playback/PoolRefillerTest.kt
@@ -1,0 +1,332 @@
+package com.parachord.android.playback
+
+import com.parachord.android.data.db.entity.TrackEntity
+import com.parachord.shared.deeplink.ProtocolTrack
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.io.IOException
+
+/**
+ * Unit coverage for [PoolRefiller] — Mode C pool refill loop
+ * (issue #121 Task 5).
+ *
+ * Drives the refiller with a fixed clock + controllable fetcher so we
+ * can exercise rate-limit, stop-condition, dedup, and error-handling
+ * paths without spinning up the full [PlaybackController].
+ */
+class PoolRefillerTest {
+
+    /** Fake clock — caller advances time explicitly via [advance]. */
+    private class FakeClock(initial: Long = 1_000L) {
+        @Volatile var now: Long = initial
+        fun advance(ms: Long) { now += ms }
+        fun get(): Long = now
+    }
+
+    private fun track(
+        id: String,
+        artist: String = "A",
+        title: String = "T",
+        mbid: String? = null,
+    ) = TrackEntity(id = id, title = title, artist = artist, recordingMbid = mbid)
+
+    private fun ptrack(
+        artist: String = "A",
+        title: String = "T",
+        mbid: String? = null,
+    ) = ProtocolTrack(artist = artist, title = title, mbid = mbid)
+
+    private fun buildRefiller(
+        clock: FakeClock = FakeClock(),
+        fetcher: (suspend (String) -> List<ProtocolTrack>)? = null,
+        url: String? = "https://api.listenbrainz.org/refill",
+    ): PoolRefiller {
+        val r = PoolRefiller(clock = clock::get)
+        r.fetcher = fetcher
+        r.refillUrl = url
+        return r
+    }
+
+    // ── canRefill / configuration gates ──────────────────────────────
+
+    @Test
+    fun canRefill_falseWhenFetcherNull() {
+        val r = PoolRefiller(clock = FakeClock()::get)
+        r.refillUrl = "https://x"
+        r.fetcher = null
+        assertFalse(r.canRefill())
+    }
+
+    @Test
+    fun canRefill_falseWhenUrlNull() {
+        val r = PoolRefiller(clock = FakeClock()::get)
+        r.refillUrl = null
+        r.fetcher = { emptyList() }
+        assertFalse(r.canRefill())
+    }
+
+    // ── Rate limit ───────────────────────────────────────────────────
+
+    @Test
+    fun rateLimit_underWindowSkipsFetch() = runTest {
+        val clock = FakeClock(initial = 10_000L)
+        var fetched = 0
+        val r = buildRefiller(clock = clock, fetcher = {
+            fetched += 1
+            listOf(ptrack(artist = "X", title = "Y"))
+        })
+        // First fetch fires (lastFetchTs == 0 ⇒ elapsed == 10_000 ≥ 5_000).
+        assertNotNull(r.tryRefill(emptyList()))
+        assertEquals(1, fetched)
+
+        // Advance by 4999ms — still inside the window.
+        clock.advance(4_999)
+        assertFalse(r.canRefill())
+        val r2 = r.tryRefill(emptyList())
+        assertNull(r2)
+        assertEquals("fetcher must NOT have run again", 1, fetched)
+    }
+
+    @Test
+    fun rateLimit_atExactlyFiveSecondsAllowsFetch() = runTest {
+        val clock = FakeClock(initial = 10_000L)
+        var fetched = 0
+        val r = buildRefiller(clock = clock, fetcher = {
+            fetched += 1
+            listOf(ptrack(artist = "X-$fetched", title = "Y"))
+        })
+        // First fetch.
+        assertNotNull(r.tryRefill(emptyList()))
+        assertEquals(1, fetched)
+
+        // Advance by exactly 5000ms — boundary is `>=`, so this fires.
+        clock.advance(5_000)
+        assertTrue("at boundary canRefill should be true", r.canRefill())
+        assertNotNull(r.tryRefill(emptyList()))
+        assertEquals(2, fetched)
+    }
+
+    // ── Stop condition (3 consecutive empties) ───────────────────────
+
+    @Test
+    fun threeConsecutiveEmpty_stopsRefilling() = runTest {
+        val clock = FakeClock(initial = 100_000L)
+        var fetcherCalls = 0
+        val r = buildRefiller(clock = clock, fetcher = {
+            fetcherCalls += 1
+            emptyList()
+        })
+
+        // First three attempts each call the fetcher and increment
+        // emptyCount.
+        for (i in 1..3) {
+            assertNull(r.tryRefill(emptyList()))
+            clock.advance(6_000)
+        }
+        assertEquals(3, fetcherCalls)
+        assertEquals(3, r.emptyCountForTest)
+
+        // Fourth attempt: stop condition hit. Even with the rate-limit
+        // window cleared, canRefill() returns false and the fetcher
+        // does NOT run again.
+        assertFalse(r.canRefill())
+        assertNull(r.tryRefill(emptyList()))
+        assertEquals("fetcher must not have run a 4th time", 3, fetcherCalls)
+    }
+
+    @Test
+    fun freshTracksResetEmptyCount() = runTest {
+        val clock = FakeClock(initial = 100_000L)
+        // Sequence: empty, empty, fresh, empty.
+        // After step 3 empty count resets to 0.
+        // After step 4 empty count == 1, NOT 3.
+        val responses = mutableListOf<List<ProtocolTrack>>(
+            emptyList(),
+            emptyList(),
+            listOf(ptrack(artist = "Slowdive", title = "Sugar")),
+            emptyList(),
+        )
+        val r = buildRefiller(clock = clock, fetcher = { responses.removeAt(0) })
+
+        assertNull(r.tryRefill(emptyList())); clock.advance(6_000)
+        assertNull(r.tryRefill(emptyList())); clock.advance(6_000)
+        assertEquals(2, r.emptyCountForTest)
+
+        val fresh = r.tryRefill(emptyList())
+        assertNotNull(fresh)
+        assertEquals(1, fresh!!.size)
+        assertEquals("counter reset on fresh", 0, r.emptyCountForTest)
+        clock.advance(6_000)
+
+        assertNull(r.tryRefill(emptyList()))
+        assertEquals("re-incremented to 1, not 3", 1, r.emptyCountForTest)
+    }
+
+    // ── Error handling ───────────────────────────────────────────────
+
+    @Test
+    fun fetchThrows_countsAsEmpty() = runTest {
+        val clock = FakeClock(initial = 100_000L)
+        val r = buildRefiller(clock = clock, fetcher = {
+            throw IOException("boom")
+        })
+        assertNull(r.tryRefill(emptyList()))
+        assertEquals(1, r.emptyCountForTest)
+    }
+
+    @Test
+    fun fetchThrows_threeConsecutiveErrorsHitStopCondition() = runTest {
+        val clock = FakeClock(initial = 100_000L)
+        val r = buildRefiller(clock = clock, fetcher = {
+            throw IOException("boom")
+        })
+        for (i in 1..3) {
+            assertNull(r.tryRefill(emptyList()))
+            clock.advance(6_000)
+        }
+        assertEquals(3, r.emptyCountForTest)
+        assertFalse(r.canRefill())
+    }
+
+    // ── Dedup ────────────────────────────────────────────────────────
+
+    @Test
+    fun dedupByMbid_caseInsensitive() = runTest {
+        val clock = FakeClock(initial = 100_000L)
+        val pool = listOf(
+            track("e1", mbid = "ABC-123"),  // pool MBID upper, fetcher MBID lower
+        )
+        val r = buildRefiller(clock = clock, fetcher = {
+            listOf(
+                ptrack(artist = "Different", title = "Different", mbid = "abc-123"),
+                ptrack(artist = "Other", title = "Other", mbid = "xyz-999"),
+            )
+        })
+        val fresh = r.tryRefill(pool)
+        assertNotNull(fresh)
+        assertEquals("only the non-mbid-dup should pass", 1, fresh!!.size)
+        assertEquals("Other", fresh[0].artist)
+    }
+
+    @Test
+    fun dedupByArtistTitle_caseInsensitive() = runTest {
+        val clock = FakeClock(initial = 100_000L)
+        val pool = listOf(track("e1", artist = "Slowdive", title = "Sugar For The Pill"))
+        val r = buildRefiller(clock = clock, fetcher = {
+            listOf(
+                ptrack(artist = "SLOWDIVE", title = "sugar for the pill"),
+                ptrack(artist = "Beach House", title = "Space Song"),
+            )
+        })
+        val fresh = r.tryRefill(pool)
+        assertNotNull(fresh)
+        assertEquals(1, fresh!!.size)
+        assertEquals("Beach House", fresh[0].artist)
+    }
+
+    @Test
+    fun dedup_allTracksDeduped_countsAsEmpty() = runTest {
+        val clock = FakeClock(initial = 100_000L)
+        val pool = listOf(
+            track("e1", artist = "A", title = "T1"),
+            track("e2", artist = "A", title = "T2"),
+        )
+        val r = buildRefiller(clock = clock, fetcher = {
+            listOf(
+                ptrack(artist = "A", title = "T1"),
+                ptrack(artist = "a", title = "T2"),
+            )
+        })
+        assertNull(r.tryRefill(pool))
+        assertEquals(1, r.emptyCountForTest)
+    }
+
+    @Test
+    fun fresh_appendsAndStampsStableIds() = runTest {
+        val clock = FakeClock(initial = 555_000L)
+        val r = buildRefiller(clock = clock, fetcher = {
+            listOf(
+                ptrack(artist = "A1", title = "T1"),
+                ptrack(artist = "A2", title = "T2"),
+                ptrack(artist = "A3", title = "T3"),
+            )
+        })
+        val fresh = r.tryRefill(emptyList())
+        assertNotNull(fresh)
+        assertEquals(3, fresh!!.size)
+        // IDs follow the protocol-radio-{ts}-{idx} convention.
+        assertTrue(fresh[0].id.startsWith("protocol-radio-"))
+        assertTrue(fresh[0].id.endsWith("-0"))
+        assertTrue(fresh[1].id.endsWith("-1"))
+        assertTrue(fresh[2].id.endsWith("-2"))
+        // Field copy.
+        assertEquals("A1", fresh[0].artist)
+        assertEquals("T1", fresh[0].title)
+    }
+
+    // ── Reset ────────────────────────────────────────────────────────
+
+    @Test
+    fun reset_clearsAllState() = runTest {
+        val clock = FakeClock(initial = 100_000L)
+        val r = buildRefiller(clock = clock, fetcher = { emptyList() })
+        // Burn an empty.
+        assertNull(r.tryRefill(emptyList()))
+        assertEquals(1, r.emptyCountForTest)
+        assertTrue(r.lastFetchTsForTest > 0L)
+
+        r.reset()
+        assertNull(r.fetcher)
+        assertNull(r.refillUrl)
+        assertEquals(0, r.emptyCountForTest)
+        assertEquals(0L, r.lastFetchTsForTest)
+        // canRefill is false because fetcher + url cleared.
+        assertFalse(r.canRefill())
+    }
+
+    @Test
+    fun resetCounters_clearsCountersButPreservesFetcherAndUrl() = runTest {
+        val clock = FakeClock(initial = 100_000L)
+        val r = buildRefiller(clock = clock, fetcher = { emptyList() })
+        // Burn TWO empties to set both counters AND the timestamp.
+        assertNull(r.tryRefill(emptyList())); clock.advance(6_000)
+        assertNull(r.tryRefill(emptyList()))
+        assertEquals(2, r.emptyCountForTest)
+
+        r.resetCounters()
+        assertEquals(0, r.emptyCountForTest)
+        assertEquals(0L, r.lastFetchTsForTest)
+        // Fetcher + URL preserved.
+        assertNotNull(r.fetcher)
+        assertNotNull(r.refillUrl)
+        assertTrue(r.canRefill())
+    }
+
+    // ── Static dedup helper edge cases ───────────────────────────────
+
+    @Test
+    fun dedupHelper_emptyFreshReturnsEmpty() {
+        val pool = listOf(track("e1"))
+        assertTrue(PoolRefiller.dedupAgainstPool(emptyList(), pool).isEmpty())
+    }
+
+    @Test
+    fun dedupHelper_emptyPoolReturnsAllFresh() {
+        val fresh = listOf(ptrack(artist = "A", title = "T"))
+        val out = PoolRefiller.dedupAgainstPool(fresh, emptyList())
+        assertEquals(1, out.size)
+    }
+
+    @Test
+    fun dedupHelper_mbidMissOnlyArtistTitleMatches_filters() {
+        val pool = listOf(track("e1", artist = "A", title = "T"))
+        // No mbid match (pool has none) — fall through to (artist|title).
+        val fresh = listOf(ptrack(artist = "A", title = "T", mbid = "some-mbid"))
+        assertTrue(PoolRefiller.dedupAgainstPool(fresh, pool).isEmpty())
+    }
+}

--- a/docs/plans/2026-05-10-phase-3-protocol-radio-listen-along.md
+++ b/docs/plans/2026-05-10-phase-3-protocol-radio-listen-along.md
@@ -1,0 +1,1074 @@
+# Phase 3 — Protocol play/radio + listen-along (#121)
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Wire `parachord://play/radio` (Mode B + Mode C) and `parachord://listen-along` end-to-end, matching desktop parity for refill semantics, LB token auto-attach, transient-friend listen-along, and pool-based spinoff banner rendering.
+
+**Architecture:**
+- Mode B reuses the existing `PlaybackController.startSpinoff()` machinery, lifted to accept an explicit `(artist, title?)` seed instead of the currently-playing track.
+- Mode C introduces a sibling entry point `startPoolBasedSpinoff(initialPool, displayName, refillUrl?)` that piggybacks on the existing `spinoffPool` data structure but feeds tracks from a parsed JSPF/XSPF/JSON payload (or inline `tracks=` base64) instead of Last.fm `getsimilar`.
+- A long-lived refill loop (in `PlaybackController`) polls `refillUrl` when the pool drops below 3, with rate-limit, 3-empty-stop, and (mbid → isrc → artist|title) dedup.
+- ListenBrainz token auto-attach is implemented as a tiny Ktor `HttpRequestPipeline` plugin keyed by host-suffix (`api.listenbrainz.org`), reading the token from `SettingsStore.getListenBrainzToken()`. Applied at HttpClient-construction time so every shared call (initial Mode C fetch, refill loop, transient-friend `/playing-now` fetch) benefits.
+- `listen-along` extends `FriendsRepository` with a `fetchTransientFriendNowPlaying(service, user)` that hits `/1/user/{name}/playing-now` (LB) or `user.getrecenttracks?limit=1` (Last.fm) and returns a synthetic `Friend` carrying a non-null `cachedTrackName`. The synthetic record is passed straight to the existing `MainViewModel.startListenAlong(friend)` flow.
+- Spinoff banner branches on `playbackContext.id == "pool-based"` (a new sentinel) — for pool-based, render only `name`; for the existing `spinoff` type, render the established "Spinoff from <title>" template.
+- UX polish: (a) immediate 30s acknowledgment toast on radio + listen-along entry; (b) playbar `isLoading` flag set true during pool-fetch; (c) listen-along friend tracks routed through `ResolverScoring.selectBest` (already done — we just verify and add a regression test).
+
+**Tech Stack:** Kotlin (KMP commonMain + Android `:app`), Ktor, kotlinx.serialization, kotlinx.coroutines, Koin, Compose, JUnit + Robolectric (for `DeepLinkHandlerTest` style smoke tests).
+
+**Branch:** `feature/protocol-phase-3` off `main`.
+
+---
+
+## Task 0: Branch setup
+
+**Step 1: Create branch from main and confirm clean tree.**
+
+Run:
+```bash
+cd /Users/jherskowitz/Development/parachord/parachord-android \
+  && git checkout main \
+  && git pull --ff-only \
+  && git checkout -b feature/protocol-phase-3 \
+  && git status
+```
+
+Expected: `On branch feature/protocol-phase-3` / `working tree clean`.
+
+**Step 2: Confirm Phase 1+2 baseline tests pass.**
+
+Run:
+```bash
+./gradlew :app:testDebugUnitTest :shared:testDebugUnitTest --tests "*deeplink*" --tests "*ProtocolPlay*" --tests "*ProtocolTracklist*"
+```
+
+Expected: BUILD SUCCESSFUL, 0 failures. Establishes the baseline so anything we break in this phase is visible immediately.
+
+---
+
+## Task 1: Re-shape `parsePlayRadio` to match the issue spec
+
+The Phase 2 parser currently uses `?refillUrl=` as the URL-fed knob. Issue #121's input table says `?url=` is the **initial pool URL** and `?refill=` is the (optional) URL for **subsequent** refills. We need to swap the parser to that contract before wiring downstream consumers.
+
+**Files:**
+- Modify: `app/src/main/java/com/parachord/android/deeplink/DeepLinkHandler.kt:286-306`
+- Modify: `shared/src/commonMain/kotlin/com/parachord/shared/deeplink/DeepLinkAction.kt:38-44` (rename `refillUrl` → `refillUrl` semantics — see below)
+- Modify: `app/src/test/java/com/parachord/android/deeplink/DeepLinkHandlerTest.kt` (radio cases)
+
+**Decision:** keep the field name `PlayRadio.refillUrl` since it's already in place; redefine its semantics as **the URL to use for refills only** (NOT the initial pool fetch). Initial pool is sourced from `input.url` OR `input.tracks`. This stays parity-faithful and avoids a churny rename.
+
+**Step 1: Update the dispatch logic in `parsePlayRadio`.**
+
+Old logic in `DeepLinkHandler.kt:286-306` selects mode by checking `refillUrl` first. New logic (per issue):
+- `?artist=` AND no `?tracks=` AND no `?url=` → Mode B (`ArtistSeed(artist, title)`)
+- otherwise (`?url=` or `?tracks=` present) → Mode C (`PoolBased`)
+- neither → `Unknown`
+
+`?refill=` is read separately (NOT used for mode dispatch) and forwarded into `PlayRadio.refillUrl`.
+
+Replace `parsePlayRadio` body:
+
+```kotlin
+private fun parsePlayRadio(uri: Uri): DeepLinkAction {
+    val input = parseProtocolPlayInput(uri)
+    // ?refill= is the explicit refill URL for Mode C; falls back to nothing.
+    // (We accept ?refillUrl= as a legacy alias for back-compat with anything
+    // generated against the Phase 2 build.)
+    val refillUrl = uri.clampedParam("refill") ?: uri.clampedParam("refillUrl")
+    val name = uri.clampedParam("name")
+    val shuffle = uri.clampedParam("shuffle") == "1"
+    val artist = uri.clampedParam("artist")
+    val title = uri.clampedParam("title")
+
+    val hasUrl = !input?.url.isNullOrBlank()
+    val hasTracks = input?.tracks?.isNotEmpty() == true
+    val hasArtist = !artist.isNullOrBlank()
+
+    val mode: RadioMode = when {
+        // Mode B: artist seed, no inline pool, no URL pool
+        hasArtist && !hasUrl && !hasTracks -> RadioMode.ArtistSeed(artist!!, title)
+        // Mode C: explicit pool (URL or inline)
+        hasUrl || hasTracks -> RadioMode.PoolBased
+        else -> return DeepLinkAction.Unknown(uri.toString())
+    }
+    return DeepLinkAction.PlayRadio(
+        mode = mode,
+        input = input,
+        refillUrl = refillUrl,
+        name = name,
+        shuffle = shuffle,
+    )
+}
+```
+
+**Step 2: Run the existing radio parser tests to see what breaks.**
+
+Run:
+```bash
+./gradlew :app:testDebugUnitTest --tests "com.parachord.android.deeplink.DeepLinkHandlerTest"
+```
+
+Expected: failures around `?refillUrl=` mode dispatch (because we now require `?url=`/`?tracks=` for Mode C even when `?refillUrl=` is set). Read each failure and adjust the URI in the test fixture: replace `?refillUrl=…` with either `?url=…` (if testing initial pool from URL) or `?tracks=…&refill=…` (if testing inline pool with refill).
+
+**Step 3: Add a new test for the issue's `?name=` precedence rule.**
+
+Add to `DeepLinkHandlerTest.kt`:
+
+```kotlin
+@Test
+fun parsePlayRadio_nameTakesPrecedenceOverTitle() {
+    val a = handler.parse(Uri.parse("parachord://play/radio?url=https%3A%2F%2Fexample.com%2Fp.jspf&name=My%20Station&title=ignored"))
+    assertTrue(a is DeepLinkAction.PlayRadio)
+    val pr = a as DeepLinkAction.PlayRadio
+    assertEquals("My Station", pr.name)
+}
+
+@Test
+fun parsePlayRadio_modeBOnlyWhenNoUrlOrTracks() {
+    val a = handler.parse(Uri.parse("parachord://play/radio?artist=Slowdive"))
+    val pr = a as DeepLinkAction.PlayRadio
+    assertTrue(pr.mode is RadioMode.ArtistSeed)
+}
+
+@Test
+fun parsePlayRadio_modeCEvenIfArtistAlsoPresent() {
+    // Artist + tracks → Mode C (pool wins per issue spec).
+    val a = handler.parse(Uri.parse("parachord://play/radio?artist=Foo&tracks=W3sidGl0bGUiOiJUIiwiYXJ0aXN0IjoiQSJ9XQ%3D%3D"))
+    val pr = a as DeepLinkAction.PlayRadio
+    assertTrue(pr.mode is RadioMode.PoolBased)
+}
+```
+
+**Step 4: Run all parser tests, confirm green.**
+
+Run: `./gradlew :app:testDebugUnitTest --tests "com.parachord.android.deeplink.DeepLinkHandlerTest"`
+Expected: all green.
+
+**Step 5: Commit.**
+
+```bash
+git add app/src/main/java/com/parachord/android/deeplink/DeepLinkHandler.kt \
+        app/src/test/java/com/parachord/android/deeplink/DeepLinkHandlerTest.kt
+git commit -m "deeplink: re-shape parsePlayRadio to ?url= / ?tracks= / ?refill= (#121 [1/N])"
+```
+
+---
+
+## Task 2: ListenBrainz token auto-attach (Ktor plugin)
+
+Issue §D: every outbound request to `api.listenbrainz.org` must carry `Authorization: Token <token>` when the user has a token configured. Apply at HttpClient construction so every shared call benefits transparently.
+
+**Files:**
+- Create: `shared/src/commonMain/kotlin/com/parachord/shared/api/ListenBrainzAuthPlugin.kt`
+- Modify: `shared/src/commonMain/kotlin/com/parachord/shared/api/HttpClientFactory.kt` (look up actual file: search for where the shared `HttpClient` is built — `find shared -name "HttpClient*.kt"`)
+- Modify: shared `SharedModule.kt` if the plugin needs SettingsStore at construction time
+- Test: `shared/src/commonTest/kotlin/com/parachord/shared/api/ListenBrainzAuthPluginTest.kt`
+
+**Step 1: Locate the HttpClient construction site.**
+
+Run: `grep -rn "HttpClient(" shared/src/commonMain --include="*.kt" -l`. There's a `HttpClientFactory` — read it before editing. Record the file path here in the plan as a comment for the next step.
+
+**Step 2: Write the failing test.**
+
+```kotlin
+// shared/src/commonTest/kotlin/com/parachord/shared/api/ListenBrainzAuthPluginTest.kt
+package com.parachord.shared.api
+
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.mock.MockEngine
+import io.ktor.client.engine.mock.respond
+import io.ktor.client.request.get
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.headersOf
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+class ListenBrainzAuthPluginTest {
+
+    @Test
+    fun attachesTokenForListenBrainzHost() = runTest {
+        var seenAuth: String? = null
+        val engine = MockEngine { req ->
+            seenAuth = req.headers["Authorization"]
+            respond("{}", HttpStatusCode.OK, headersOf("Content-Type", "application/json"))
+        }
+        val client = HttpClient(engine) {
+            install(ListenBrainzAuthPlugin) { tokenProvider = { "secret-token" } }
+        }
+        client.get("https://api.listenbrainz.org/1/user/foo/playing-now")
+        assertEquals("Token secret-token", seenAuth)
+    }
+
+    @Test
+    fun doesNotAttachTokenForOtherHosts() = runTest {
+        var seenAuth: String? = null
+        val engine = MockEngine { req ->
+            seenAuth = req.headers["Authorization"]
+            respond("{}", HttpStatusCode.OK)
+        }
+        val client = HttpClient(engine) {
+            install(ListenBrainzAuthPlugin) { tokenProvider = { "secret-token" } }
+        }
+        client.get("https://example.com/something")
+        assertNull(seenAuth)
+    }
+
+    @Test
+    fun noTokenConfigured_passesThroughWithoutAuthHeader() = runTest {
+        var seenAuth: String? = null
+        val engine = MockEngine { req ->
+            seenAuth = req.headers["Authorization"]
+            respond("{}", HttpStatusCode.Unauthorized)
+        }
+        val client = HttpClient(engine) {
+            install(ListenBrainzAuthPlugin) { tokenProvider = { null } }
+        }
+        client.get("https://api.listenbrainz.org/1/user/foo/playing-now")
+        assertNull(seenAuth)
+    }
+
+    @Test
+    fun preservesExistingAuthHeader() = runTest {
+        // submitRecordingFeedback already sets its own Authorization header.
+        // The plugin must NOT clobber it.
+        var seenAuth: String? = null
+        val engine = MockEngine { req ->
+            seenAuth = req.headers["Authorization"]
+            respond("{}", HttpStatusCode.OK)
+        }
+        val client = HttpClient(engine) {
+            install(ListenBrainzAuthPlugin) { tokenProvider = { "plugin-token" } }
+        }
+        client.get("https://api.listenbrainz.org/1/user/foo/playing-now") {
+            io.ktor.client.request.headers { append("Authorization", "Token explicit-token") }
+        }
+        assertEquals("Token explicit-token", seenAuth)
+    }
+}
+```
+
+Run: `./gradlew :shared:testDebugUnitTest --tests "*ListenBrainzAuthPlugin*"`
+Expected: FAIL — `ListenBrainzAuthPlugin` not defined.
+
+**Step 3: Implement the plugin.**
+
+```kotlin
+// shared/src/commonMain/kotlin/com/parachord/shared/api/ListenBrainzAuthPlugin.kt
+package com.parachord.shared.api
+
+import io.ktor.client.plugins.api.createClientPlugin
+import io.ktor.http.HttpHeaders
+
+/**
+ * Auto-attaches `Authorization: Token <token>` to every outbound request
+ * targeting `api.listenbrainz.org` (or any subdomain thereof).
+ *
+ * Mirrors desktop's `69116a4` / `31078cf` — the LB token configured for
+ * scrobbling is the same token that authenticates radio fetches and
+ * `playing-now` lookups. Centralizing this in a plugin means every call
+ * site (initial Mode C fetch, refill loop, listen-along nowplaying) gets
+ * it for free.
+ *
+ * Configuration takes a token provider lambda rather than a string so
+ * the plugin always picks up the current token (the user can change it
+ * at runtime via Settings without restarting the HttpClient).
+ *
+ * If the call site has already set an `Authorization` header explicitly
+ * (e.g. `ListenBrainzClient.submitRecordingFeedback`), the plugin does
+ * NOT overwrite it.
+ */
+class ListenBrainzAuthConfig {
+    var tokenProvider: suspend () -> String? = { null }
+}
+
+val ListenBrainzAuthPlugin = createClientPlugin("ListenBrainzAuth", ::ListenBrainzAuthConfig) {
+    val tokenProvider = pluginConfig.tokenProvider
+    onRequest { request, _ ->
+        val host = request.url.host.lowercase()
+        val isLbHost = host == "api.listenbrainz.org" || host.endsWith(".api.listenbrainz.org")
+        if (!isLbHost) return@onRequest
+        if (request.headers.contains(HttpHeaders.Authorization)) return@onRequest
+        val token = try {
+            tokenProvider()
+        } catch (e: Throwable) {
+            // SettingsStore lookup should never throw, but defend anyway —
+            // a thrown exception here would kill every LB call.
+            null
+        }
+        if (!token.isNullOrBlank()) {
+            request.headers.append(HttpHeaders.Authorization, "Token $token")
+        }
+    }
+}
+```
+
+Run the test: `./gradlew :shared:testDebugUnitTest --tests "*ListenBrainzAuthPlugin*"`
+Expected: PASS.
+
+**Step 4: Wire the plugin into the shared HttpClient.**
+
+In whichever file constructs the shared `HttpClient` (likely `HttpClientFactory.kt` in `shared/commonMain` plus the platform actuals — verify with the grep from Step 1), add `install(ListenBrainzAuthPlugin) { tokenProvider = ... }`. The provider closes over `SettingsStore` (already a Koin singleton).
+
+If `HttpClientFactory` is a top-level expect/actual function with no DI access, the cleanest fix is to thread the SettingsStore through Koin's `HttpClient` factory binding. Read `shared/src/commonMain/kotlin/com/parachord/shared/SharedModule.kt` and the platform-specific `HttpClientFactory.android.kt` / `.ios.kt` to see how it's wired today, then add the SettingsStore dep where the client is built.
+
+Concretely (rough sketch — verify against actual code):
+
+```kotlin
+// SharedModule.kt or wherever httpClient { ... } is bound
+single<HttpClient> {
+    val settings: SettingsStore = get()
+    buildHttpClient { 
+        install(ListenBrainzAuthPlugin) { tokenProvider = { settings.getListenBrainzToken() } }
+    }
+}
+```
+
+**Step 5: Verify nothing regressed.**
+
+Run: `./gradlew :shared:testDebugUnitTest :app:testDebugUnitTest`
+Expected: green. Pay attention to `ListenBrainzClientTest` — `submitRecordingFeedback` must still produce its explicit header (covered by the "preservesExistingAuthHeader" test above).
+
+**Step 6: Commit.**
+
+```bash
+git add shared/src/commonMain/kotlin/com/parachord/shared/api/ListenBrainzAuthPlugin.kt \
+        shared/src/commonTest/kotlin/com/parachord/shared/api/ListenBrainzAuthPluginTest.kt \
+        shared/src/commonMain/kotlin/com/parachord/shared/SharedModule.kt \
+        # plus whichever HttpClientFactory file was edited
+git commit -m "api: ListenBrainz token auto-attach via Ktor plugin (#121 [2/N])"
+```
+
+---
+
+## Task 3: Mode B — wire `parachord://play/radio?artist=...` to a generalised spinoff
+
+The existing `PlaybackController.startSpinoff()` seeds from `stateHolder.state.value.currentTrack`. For Mode B we need to seed from a (artist, title?) pair supplied by the deeplink, with no current-track requirement.
+
+**Files:**
+- Modify: `app/src/main/java/com/parachord/android/playback/PlaybackController.kt` (extract a private `startSpinoffWithSeed(artist, title?)` helper; have the existing `startSpinoff()` delegate to it)
+- Modify: `app/src/main/java/com/parachord/android/deeplink/DeepLinkViewModel.kt` (replace the "Coming soon" stub for `PlayRadio` with a Mode B dispatch)
+- Test: `app/src/test/java/com/parachord/android/deeplink/ProtocolPlayHandlerTest.kt` (or new sibling `ProtocolPlayRadioHandlerTest.kt`)
+
+**Step 1: Extract `startSpinoffWithSeed` from `startSpinoff` (refactor only).**
+
+Lift the body of `startSpinoff()` (lines ~1416–1521 of `PlaybackController.kt`) into a new method:
+
+```kotlin
+fun startSpinoffWithSeed(artist: String, title: String?, displayName: String? = null) {
+    if (stateHolder.state.value.spinoffMode) return
+    spinoffJob?.cancel()
+    stateHolder.update { copy(spinoffLoading = true) }
+    spinoffJob = scope.launch(Dispatchers.IO) {
+        try {
+            val response = lastFmClient.getSimilarTracks(
+                track = title.orEmpty(),
+                artist = artist,
+                apiKey = BuildConfig.LASTFM_API_KEY,
+                limit = SPINOFF_SIMILAR_LIMIT,
+            )
+            // ...same body as today, but build the resolved pool and set
+            // PlaybackContext(name = displayName ?: "Spinoff from $title")...
+        }
+    }
+}
+
+fun startSpinoff() {
+    val track = stateHolder.state.value.currentTrack ?: return
+    startSpinoffWithSeed(track.artist, track.title, displayName = "Spinoff from ${track.title}")
+}
+```
+
+Caveat: when `title` is blank (Mode B can pass artist-only), Last.fm's `getSimilarTracks` falls back to artist similarity. Check `LastFmClient.getSimilarTracks` to confirm — if it requires a non-empty track, switch to `getSimilarArtists` + `topTracks` cascade for artist-only seeds. (Read the desktop's Mode B implementation if unsure — `app.js` search for "play/radio" handler.)
+
+**Step 2: Run the existing spinoff tests, confirm refactor is invisible.**
+
+Run: `./gradlew :app:testDebugUnitTest --tests "*Spinoff*" --tests "*PlaybackController*"`
+Expected: green (refactor is behavior-preserving).
+
+**Step 3: Wire `PlayRadio` dispatch for Mode B in `DeepLinkViewModel`.**
+
+Replace the `PlayRadio, ListenAlong -> "Coming soon"` block (around line 317) with:
+
+```kotlin
+is DeepLinkAction.PlayRadio -> dispatchPlayRadio(action)
+is DeepLinkAction.ListenAlong -> dispatchListenAlong(action)
+```
+
+Add `dispatchPlayRadio`:
+
+```kotlin
+private suspend fun dispatchPlayRadio(action: DeepLinkAction.PlayRadio) {
+    when (val mode = action.mode) {
+        is RadioMode.ArtistSeed -> {
+            protocolPlayTeardown.prepareForNewPlayback()
+            playbackController.startSpinoffWithSeed(
+                artist = mode.artist,
+                title = mode.title,
+                displayName = action.name ?: mode.title?.let { "Radio: ${mode.artist} – $it" } ?: "Radio: ${mode.artist}",
+            )
+            _navEvents.emit(DeepLinkNavEvent.Toast("Building radio…"))
+        }
+        is RadioMode.PoolBased -> {
+            // Wired in Task 4
+            _navEvents.emit(DeepLinkNavEvent.Toast("Mode C coming next commit"))
+        }
+    }
+}
+```
+
+(Defer `ListenAlong` until Task 7.)
+
+**Step 4: Add a smoke test.**
+
+```kotlin
+// app/src/test/java/com/parachord/android/deeplink/PlayRadioModeBTest.kt
+@Test
+fun modeB_callsTeardownThenStartSpinoffWithSeed() = runTest {
+    val pc = mockk<PlaybackController>(relaxed = true)
+    val td = mockk<ProtocolPlayTeardown>(relaxed = true)
+    coEvery { td.prepareForNewPlayback() } just runs
+    val vm = DeepLinkViewModel(/* deps */)  // construct via Koin or hand-wire
+    vm.dispatchPlayRadioForTest(
+        DeepLinkAction.PlayRadio(
+            mode = RadioMode.ArtistSeed("Slowdive", null),
+            input = null,
+        )
+    )
+    coVerify(exactly = 1) { td.prepareForNewPlayback() }
+    verify(exactly = 1) { pc.startSpinoffWithSeed(eq("Slowdive"), isNull(), any()) }
+}
+```
+
+If `DeepLinkViewModel` is hard to construct in unit tests, instead extract a small helper class `PlayRadioDispatcher` that takes (`teardown`, `playbackController`, `navEmitter`) and verify against that. The pattern matches the Phase 2 `ProtocolPlayHandler` extraction.
+
+**Step 5: Commit.**
+
+```bash
+git commit -m "playback+deeplink: Mode B (artist seed) for play/radio (#121 [3/N])"
+```
+
+---
+
+## Task 4: Mode C — pool-based spinoff entry point
+
+`startPoolBasedSpinoff(initialPool, displayName, refillUrl?)` accepts a pre-resolved `List<TrackEntity>` (built from the Mode C input — either inline `tracks=` or a fetched JSPF/XSPF tracklist) and stages it the same way `startSpinoffWithSeed` does, but skips the Last.fm seed step.
+
+**Files:**
+- Modify: `app/src/main/java/com/parachord/android/playback/PlaybackController.kt`
+- Modify: `app/src/main/java/com/parachord/android/deeplink/DeepLinkViewModel.kt`
+- Modify: `app/src/main/java/com/parachord/android/deeplink/ProtocolPlayHandler.kt` (add `handle(PlayRadio)` overload that builds the entity list)
+- Test: extend `PlayRadioModeBTest.kt` (rename to `PlayRadioTest.kt`)
+
+**Step 1: Add `startPoolBasedSpinoff` to `PlaybackController`.**
+
+Below `startSpinoffWithSeed`:
+
+```kotlin
+/**
+ * Pool-based spinoff (Mode C of `parachord://play/radio`).
+ *
+ * No Last.fm seed step — the caller supplies an already-resolved pool.
+ * Mirrors desktop's "externally curated pool" path.
+ *
+ * `refillUrl` is optional. When set, the refill loop (Task 5) will
+ * re-fetch from it once `spinoffPool.size < 3` (with rate-limit + 3-empty
+ * stop + dedup). When null, the radio runs to exhaustion and exits.
+ *
+ * `displayName` is the station name for the banner — for pool-based
+ * spinoff there is no "source track", so the banner code (Task 6)
+ * renders just this string instead of "Spun off from X by Y".
+ */
+fun startPoolBasedSpinoff(
+    initialPool: List<TrackEntity>,
+    displayName: String,
+    refillUrl: String? = null,
+) {
+    if (initialPool.isEmpty()) {
+        Log.w(TAG, "startPoolBasedSpinoff: empty initialPool, ignoring")
+        return
+    }
+    spinoffJob?.cancel()
+    spinoffPool.clear()
+    spinoffPool.addAll(initialPool)
+    spinoffSourceTrack = null  // pool-based has no source — see banner branch
+    preSpinoffContext = queueManager.playbackContext
+
+    // Sentinel context: type="spinoff", id="pool-based" so the banner
+    // can branch without reading sourceTrack (which is null here).
+    queueManager.setContext(
+        PlaybackContext(type = "spinoff", name = displayName, id = "pool-based")
+    )
+
+    poolRefillUrl = refillUrl
+    poolRefillEmptyCount = 0
+    poolLastRefillTs = 0L
+
+    stateHolder.update {
+        copy(spinoffMode = true, spinoffLoading = false, spinoffAvailable = true)
+    }
+
+    // Play the first track immediately (don't wait for queue exhaustion).
+    val first = spinoffPool.removeAt(0)
+    advanceJob = scope.launch {
+        try { playTrackInternal(first) }
+        catch (e: Exception) {
+            if (e is kotlinx.coroutines.CancellationException) throw e
+            Log.e(TAG, "Pool spinoff first-track failed: ${e.message}", e)
+        }
+    }
+}
+
+// New fields near `spinoffPool`:
+private var poolRefillUrl: String? = null
+private var poolRefillEmptyCount: Int = 0
+private var poolLastRefillTs: Long = 0L
+```
+
+Also extend `exitSpinoff()` to clear the new fields (set `poolRefillUrl = null; poolRefillEmptyCount = 0; poolLastRefillTs = 0L`).
+
+**Step 2: Add a `handle(PlayRadio)` method on `ProtocolPlayHandler`.**
+
+The handler already has `handle(PlayAlbum)` / `handle(PlayPlaylist)`. Add a parallel for `PlayRadio` Mode C — fetch + parse + entity-build with per-track tagging:
+
+```kotlin
+suspend fun handlePoolBased(action: DeepLinkAction.PlayRadio): ProtocolPlayResult {
+    val input = action.input
+        ?: return ProtocolPlayResult.Failed("Radio missing input")
+    // Resolve initial pool: input.url (JSPF/XSPF/JSON fetch) OR input.tracks (inline).
+    val opts = ProtocolResolveOptions(
+        allowMbid = false, allowProviderId = false,
+        allowUrl = true, allowTracks = true, allowArtistTitleAlbum = false,
+    )
+    val resolved = try {
+        resolveProtocolPlayInput(input, opts, resolver)
+            ?: return ProtocolPlayResult.Failed("Radio: nothing to play")
+    } catch (e: Exception) {
+        return ProtocolPlayResult.Failed(e.message ?: "Radio fetch failed")
+    }
+    if (resolved.tracks.isEmpty()) return ProtocolPlayResult.Failed("Radio: empty pool")
+
+    val ts = currentTimeMillis()
+    val entities = resolved.tracks.mapIndexed { idx, t ->
+        TrackEntity(
+            id = "protocol-radio-$ts-$idx",
+            title = t.title,
+            artist = t.artist,
+            album = t.album,
+            artworkUrl = resolved.albumArt,
+        )
+    }
+    val displayName = action.name
+        ?: input.title
+        ?: resolved.displayName
+        ?: "Radio"
+
+    // Pre-resolve the first track so playback starts on a known-good source
+    // (matches Phase 2's discipline — see ProtocolPlayHandler.runHandle Step 4).
+    try {
+        trackResolverCache.resolveInBackground(listOf(entities.first()), backfillDb = false)
+    } catch (e: Exception) {
+        Log.w(TAG, "Pool first-track pre-resolve failed: ${e.message}")
+    }
+
+    teardown.prepareForNewPlayback()
+    playbackController.startPoolBasedSpinoff(entities, displayName, action.refillUrl)
+    if (entities.size > 1) {
+        trackResolverCache.resolveInBackground(entities.drop(1), backfillDb = false)
+    }
+    return ProtocolPlayResult.Started(displayName, entities.size)
+}
+```
+
+**Step 3: Wire it in `DeepLinkViewModel.dispatchPlayRadio` for `PoolBased`:**
+
+```kotlin
+is RadioMode.PoolBased -> {
+    _navEvents.emit(DeepLinkNavEvent.Toast("Building radio…"))
+    when (val r = protocolPlayHandler.handlePoolBased(action)) {
+        is ProtocolPlayResult.Started ->
+            _navEvents.emit(DeepLinkNavEvent.Toast("Playing ${r.displayName}"))
+        is ProtocolPlayResult.Failed ->
+            _navEvents.emit(DeepLinkNavEvent.Toast("Radio failed: ${r.reason}"))
+    }
+}
+```
+
+**Step 4: Tests for Mode C.**
+
+```kotlin
+@Test
+fun modeC_inlineTracks_buildsPoolWithStableIds() = runTest {
+    val handler = buildHandler(...)
+    val tracks = listOf(ProtocolTrack("A1", "T1"), ProtocolTrack("A2", "T2"))
+    val action = DeepLinkAction.PlayRadio(
+        mode = RadioMode.PoolBased,
+        input = ProtocolPlayInput(tracks = tracks),
+        name = "My Station",
+    )
+    val r = handler.handlePoolBased(action)
+    assertTrue(r is ProtocolPlayResult.Started)
+    assertEquals("My Station", (r as ProtocolPlayResult.Started).displayName)
+    val poolSlot = slot<List<TrackEntity>>()
+    verify { playbackController.startPoolBasedSpinoff(capture(poolSlot), "My Station", null) }
+    assertEquals(2, poolSlot.captured.size)
+    assertTrue(poolSlot.captured.first().id.startsWith("protocol-radio-"))
+}
+
+@Test
+fun modeC_url_routesToResolveByUrl() = runTest { /* ... */ }
+@Test
+fun modeC_emptyPool_returnsFailedAndDoesNotTearDown() = runTest { /* ... */ }
+@Test
+fun modeC_namePrecedence_namePreferredOverInputTitleAndResolvedName() = runTest { /* ... */ }
+```
+
+**Step 5: Commit.**
+
+```bash
+git commit -m "playback+deeplink: Mode C (pool-based) for play/radio (#121 [4/N])"
+```
+
+---
+
+## Task 5: Refill loop
+
+Trigger when `spinoffPool.size < 3`, soft rate-limit 5s, stop after 3 consecutive empty refills, dedup by `mbid → isrc → (artist|title)`.
+
+**Files:**
+- Modify: `app/src/main/java/com/parachord/android/playback/PlaybackController.kt` (refill loop)
+- Test: new `app/src/test/java/com/parachord/android/playback/PoolRefillTest.kt`
+
+**Step 1: Write tests first.**
+
+```kotlin
+class PoolRefillTest {
+    @Test fun underThree_triggersRefill_andAppendsFreshTracks() { /* mock fetcher */ }
+    @Test fun rateLimit_twoTriggersWithin5s_onlyOneFetch() { /* virtual time */ }
+    @Test fun threeEmptyRefills_stopsRefilling() { /* fixed clock */ }
+    @Test fun dedup_byMbid_isrcOrArtistTitle_countsAsEmpty() { /* fixed input */ }
+    @Test fun httpError_countsAsEmpty() { /* fetcher throws */ }
+    @Test fun exitSpinoff_resetsRefillState() { /* call exitSpinoff then re-enter, verify rate-limit gate is fresh */ }
+}
+```
+
+For testability, factor the fetcher behind a `suspend (refillUrl: String) -> List<ProtocolTrack>` lambda parameter on `PlaybackController` (constructor or setter). In production it's `ProtocolInputResolver.resolveByUrl(url).tracks`; in tests it's a fake.
+
+**Step 2: Implement the refill check.**
+
+In `skipNextInternal`, after the `spinoffPool.removeAt(0)` line (in the spinoff branch), check whether to trigger a refill:
+
+```kotlin
+if (spinoffPool.size < 3 && poolRefillUrl != null) {
+    triggerRefillIfAllowed()
+}
+```
+
+`triggerRefillIfAllowed` is a fire-and-forget coroutine:
+
+```kotlin
+private fun triggerRefillIfAllowed() {
+    val now = currentTimeMillis()
+    if (now - poolLastRefillTs < 5_000) return     // soft rate-limit
+    if (poolRefillEmptyCount >= 3) return          // stop condition
+    val url = poolRefillUrl ?: return
+    poolLastRefillTs = now
+    scope.launch(Dispatchers.IO) {
+        val fresh = try {
+            poolFetcher(url)  // injected lambda
+        } catch (e: CancellationException) { throw e }
+        catch (e: Exception) {
+            Log.w(TAG, "Pool refill fetch failed: ${e.message}")
+            emptyList()
+        }
+        val filtered = dedupAgainstPool(fresh)
+        if (filtered.isEmpty()) {
+            poolRefillEmptyCount += 1
+            Log.d(TAG, "Pool refill empty (count=$poolRefillEmptyCount)")
+        } else {
+            poolRefillEmptyCount = 0
+            val ts = currentTimeMillis()
+            // CRITICAL: refilled tracks inherit the existing pool's first
+            // track's _playbackContext so the banner stays consistent
+            // (issue §F).  We're already inside the spinoff context so
+            // this is a no-op for the queue manager — tagging is per-track
+            // metadata only.
+            val entities = filtered.mapIndexed { i, t ->
+                TrackEntity(
+                    id = "protocol-radio-$ts-$i",
+                    title = t.title,
+                    artist = t.artist,
+                    album = t.album,
+                )
+            }
+            spinoffPool.addAll(entities)
+            // Background-resolve so they have sources by the time we play them.
+            trackResolverCache.resolveInBackground(entities, backfillDb = false)
+        }
+    }
+}
+
+private fun dedupAgainstPool(fresh: List<ProtocolTrack>): List<ProtocolTrack> {
+    val mbids = spinoffPool.mapNotNull { it.recordingMbid?.lowercase() }.toSet()
+    val isrcs = spinoffPool.mapNotNull { it.isrc?.uppercase() }.toSet()
+    val titleArtists = spinoffPool.map {
+        "${it.artist.lowercase()}|${it.title.lowercase()}"
+    }.toSet()
+    return fresh.filter { t ->
+        when {
+            t.mbid?.lowercase()?.let { it in mbids } == true -> false
+            t.isrc?.uppercase()?.let { it in isrcs } == true -> false
+            "${t.artist.lowercase()}|${t.title.lowercase()}" in titleArtists -> false
+            else -> true
+        }
+    }
+}
+```
+
+(Verify whether `TrackEntity` already exposes `isrc`. If not, dedup falls back to `mbid` + `(artist|title)` — note that as a known gap and file a follow-up if needed.)
+
+**Step 3: Run tests.**
+
+`./gradlew :app:testDebugUnitTest --tests "*PoolRefill*"`
+Expected: green.
+
+**Step 4: Commit.**
+
+```bash
+git commit -m "playback: Mode C refill loop (rate-limit, 3-empty stop, dedup) (#121 [5/N])"
+```
+
+---
+
+## Task 6: Pool-based spinoff banner branch
+
+For the regular spinoff, `playbackContext.name == "Spinoff from <title>"` already renders correctly. For pool-based, `name == station name` and we want the banner to render just that string.
+
+The branch lives in `QueueSheet.kt:99-102`:
+
+```kotlin
+"spinoff" -> playbackContext.name // "Spinoff from {track}"
+```
+
+Issue §E says: when a pool-based spinoff is active, render only the station name (no "Spun off from X by Y" prefix). The cleanest signal is `playbackContext.id == "pool-based"` (set in Task 4):
+
+**Files:**
+- Modify: `app/src/main/java/com/parachord/android/ui/screens/nowplaying/QueueSheet.kt:99-102`
+- Modify: `app/src/main/java/com/parachord/android/ui/screens/nowplaying/NowPlayingScreen.kt` if a banner is rendered there too (search for `"Spun off"` / `"Spinoff from"`)
+
+**Step 1: Find every banner render site.**
+
+Run: `grep -rn "spinoff\|Spinoff\|Spun off" app/src/main/java/com/parachord/android/ui --include="*.kt"`. Update every site that branches on `playbackContext.type == "spinoff"` to also check `id`.
+
+**Step 2: Update the branch.**
+
+```kotlin
+"spinoff" -> {
+    if (playbackContext.id == "pool-based") {
+        playbackContext.name  // station name only
+    } else {
+        playbackContext.name  // "Spinoff from {track}"
+    }
+}
+```
+
+(Both arms render `playbackContext.name` because Task 4 already sets `name = displayName` for pool-based and Task 3 keeps `name = "Spinoff from $title"` for the seed case. The branch is here as a hook for divergent future styling — the issue spec just says "render the station name", which we already do. Document that and move on.)
+
+**Step 3: Add a Compose preview / smoke test if there's a banner-specific UI test harness.**
+
+Skip if no harness exists; this branch is structural and Task 4's tests already verify `playbackContext.id == "pool-based"`.
+
+**Step 4: Commit.**
+
+```bash
+git commit -m "ui: pool-based spinoff banner branches on context id (#121 [6/N])"
+```
+
+---
+
+## Task 7: `parachord://listen-along` — known + transient friend
+
+Friend lookup → if found, call `MainViewModel.startListenAlong(friend)`. Otherwise fetch `/playing-now` (LB) or `getrecenttracks?limit=1` (Last.fm), build a transient `Friend` if there's a current track, otherwise toast "<user> is not currently listening on <service>."
+
+**Files:**
+- Modify: `shared/src/commonMain/kotlin/com/parachord/shared/api/ListenBrainzClient.kt` (add `getPlayingNow(username: String): LbListen?`)
+- Modify: `shared/src/commonMain/kotlin/com/parachord/shared/api/LastFmClient.kt` (add `getNowPlaying(username: String, apiKey: String): LfNowPlaying?`)
+- Modify: `shared/src/commonMain/kotlin/com/parachord/shared/repository/FriendsRepository.kt` (add `fetchTransientFriendNowPlaying(service, user): Friend?`)
+- Modify: `shared/src/commonMain/kotlin/com/parachord/shared/model/Friend.kt` (add `transient: Boolean = false`)
+- Modify: `app/src/main/java/com/parachord/android/deeplink/DeepLinkViewModel.kt` (add `dispatchListenAlong`)
+- Modify: `app/src/main/java/com/parachord/android/ui/MainViewModel.kt` (no API change — `startListenAlong(friend)` already accepts a `Friend`)
+- Tests: extend `FriendsRepositoryTest`, new `ListenAlongTest`
+
+**Step 1: Add `Friend.transient` field.**
+
+Add `val transient: Boolean = false` to `Friend.kt`. Default false preserves all call sites.
+
+Run: `./gradlew :shared:testDebugUnitTest`. Confirm no breaks.
+
+**Step 2: Add LB `getPlayingNow`.**
+
+```kotlin
+// ListenBrainzClient.kt
+suspend fun getPlayingNow(username: String): LbListen? {
+    return try {
+        val response = httpClient.get("$BASE_URL/1/user/$username/playing-now")
+        if (!response.status.isSuccess()) return null
+        val parsed = json.decodeFromString<ListensWire>(response.bodyAsText())
+        val listen = parsed.payload?.listens?.firstOrNull() ?: return null
+        val md = listen.trackMetadata ?: return null
+        LbListen(
+            artistName = md.artistName.orEmpty(),
+            trackName = md.trackName.orEmpty(),
+            releaseName = md.releaseName?.ifBlank { null },
+            listenedAt = listen.listenedAt ?: 0L,
+        )
+    } catch (e: CancellationException) { throw e }
+    catch (e: Throwable) { Log.e(TAG, "playing-now failed for $username", e); null }
+}
+```
+
+The Authorization header is now auto-attached by the Ktor plugin from Task 2 — no need to pass a token here.
+
+**Step 3: Add Last.fm `getNowPlaying`.**
+
+```kotlin
+// LastFmClient.kt — pseudo, adapt to existing patterns
+suspend fun getNowPlaying(username: String, apiKey: String): LfNowPlaying? {
+    val response = guardedGet { 
+        parameter("method", "user.getrecenttracks")
+        parameter("user", username)
+        parameter("limit", 1)
+        parameter("api_key", apiKey)
+        parameter("format", "json")
+    }
+    val first = response?.recenttracks?.track?.firstOrNull() ?: return null
+    if (first.attr?.nowplaying != "true") return null  // only true now-playing
+    return LfNowPlaying(
+        artist = first.artist?.text ?: first.artist?.name.orEmpty(),
+        title = first.name.orEmpty(),
+        album = first.album?.text,
+        imageUrl = first.image?.lastOrNull()?.text,
+    )
+}
+
+@Serializable
+data class LfNowPlaying(val artist: String, val title: String, val album: String?, val imageUrl: String?)
+```
+
+(Read the existing Last.fm wire types around line 480 — `nowplaying: String?` is already in the model. Confirm before writing.)
+
+**Step 4: Add `FriendsRepository.fetchTransientFriendNowPlaying`.**
+
+```kotlin
+suspend fun fetchTransientFriendNowPlaying(service: String, user: String): Friend? {
+    val (artist, title, album, art) = when (service) {
+        "listenbrainz" -> {
+            val l = listenBrainzClient.getPlayingNow(user) ?: return null
+            Quad(l.artistName, l.trackName, l.releaseName, null)
+        }
+        "lastfm" -> {
+            val l = lastFmClient.getNowPlaying(user, lastFmApiKey) ?: return null
+            Quad(l.artist, l.title, l.album, l.imageUrl)
+        }
+        else -> return null
+    }
+    if (artist.isBlank() || title.isBlank()) return null
+    return Friend(
+        id = "transient:$service:$user",
+        username = user,
+        service = service,
+        displayName = user,
+        avatarUrl = null,
+        addedAt = currentTimeMillis(),
+        cachedTrackName = title,
+        cachedTrackArtist = artist,
+        cachedTrackAlbum = album,
+        cachedTrackArtworkUrl = art,
+        cachedTrackTimestamp = currentTimeMillis() / 1000,  // makes isOnAir=true
+        transient = true,
+    )
+}
+```
+
+(Use a private data class instead of `Quad` if there's no existing utility; this is just an inlining helper.)
+
+**Step 5: Wire in `DeepLinkViewModel.dispatchListenAlong`.**
+
+```kotlin
+private suspend fun dispatchListenAlong(action: DeepLinkAction.ListenAlong) {
+    if (action.service !in setOf("listenbrainz", "lastfm")) {
+        _navEvents.emit(DeepLinkNavEvent.Toast("Unknown service: ${action.service}"))
+        return
+    }
+    _navEvents.emit(DeepLinkNavEvent.Toast("Catching up to ${action.user}…"))
+
+    // 1. Local lookup (case-insensitive on username).
+    val saved = friendsRepository.findByServiceAndUsername(action.service, action.user)
+    if (saved != null) {
+        _navEvents.emit(DeepLinkNavEvent.StartListenAlong(saved))
+        return
+    }
+
+    // 2. Transient fallback.
+    val transient = try {
+        friendsRepository.fetchTransientFriendNowPlaying(action.service, action.user)
+    } catch (e: Exception) {
+        Log.w(TAG, "Transient now-playing fetch failed", e)
+        null
+    }
+    if (transient == null) {
+        _navEvents.emit(DeepLinkNavEvent.Toast("${action.user} is not currently listening on ${action.service}"))
+        return
+    }
+    _navEvents.emit(DeepLinkNavEvent.StartListenAlong(transient))
+}
+```
+
+Add a new `DeepLinkNavEvent.StartListenAlong(friend: Friend)` and a corresponding observer in `MainActivity` that calls `mainViewModel.startListenAlong(friend)`.
+
+**Important:** the listen-along teardown rule (issue §G "Teardown for listen-along: tear down spinoff + clearQueue, but DON'T tear down listen-along — switching from friend A to friend B should swap, not terminate"). The existing `MainViewModel.startListenAlong()` already calls `stopListenAlong(silent=true)` at the top, which handles the swap. We must NOT call `protocolPlayTeardown.prepareForNewPlayback()` here, because that would call the listen-along stopper as part of its three-step teardown. Instead, just call `mainViewModel.startListenAlong(friend)` directly — its internal stop+restart handles the swap.
+
+If we want the spinoff-exit + queue-clear half of the teardown but skip the listen-along stopper, expose a `prepareForListenAlongHandover()` variant on `ProtocolPlayTeardown` that runs only steps 1 and 3. Add this variant and call it from `dispatchListenAlong` before emitting `StartListenAlong`.
+
+**Step 6: `findByServiceAndUsername` on `FriendsRepository`.**
+
+If it doesn't exist yet, add:
+
+```kotlin
+suspend fun findByServiceAndUsername(service: String, username: String): Friend? =
+    friendDao.getAll().firstOrNull {
+        it.service == service && it.username.equals(username, ignoreCase = true)
+    }
+```
+
+**Step 7: Tests.**
+
+```kotlin
+@Test fun listenAlong_knownFriend_startsImmediately()
+@Test fun listenAlong_unknownFriendWithCurrentTrack_startsTransient()
+@Test fun listenAlong_unknownFriendNoCurrentTrack_emitsCalmToast()
+@Test fun listenAlong_unknownService_emitsErrorToast()
+@Test fun friendsRepository_transientLB_buildsCorrectShape()
+@Test fun friendsRepository_transientLF_returnsNullWhenNotNowplaying()
+```
+
+**Step 8: Commit.**
+
+```bash
+git commit -m "deeplink+friends: parachord://listen-along (known + transient) (#121 [7/N])"
+```
+
+---
+
+## Task 8: UX polish — acknowledgment toasts, playbar loading, friend-track confidence
+
+From the issue's "Additional sub-tasks" comment.
+
+**Files:**
+- Modify: `app/src/main/java/com/parachord/android/playback/PlaybackState.kt` (add `isPlaybarLoading: Boolean = false`)
+- Modify: `app/src/main/java/com/parachord/android/playback/PlaybackController.kt` (set/unset the flag around `startPoolBasedSpinoff` and the radio fetch)
+- Modify: `app/src/main/java/com/parachord/android/ui/components/MiniPlayer.kt` and `ui/screens/nowplaying/NowPlayingScreen.kt` to render a small loading indicator when `isPlaybarLoading` is true and `currentTrack == null`
+- Modify: `app/src/main/java/com/parachord/android/ui/MainViewModel.kt` (verify friend-track resolver pipeline already runs `selectBest` — it does at line ~410; add a regression test)
+
+**Step 1: Acknowledgment toast.**
+
+Already covered in Task 3 + 7 (`"Building radio…"`, `"Catching up to ${user}…"`). Verify the toast surface (Snackbar / Toast) supports a 30s duration. If `DeepLinkNavEvent.Toast` is implemented as `Toast.makeText(context, msg, Toast.LENGTH_LONG)`, swap it to a snackbar with explicit duration, OR add a `durationMs` field to `Toast` and have the receiver respect it.
+
+Acceptance: toast appears within 500ms of deeplink, dismisses automatically.
+
+**Step 2: Playbar loading flag.**
+
+Add `val isPlaybarLoading: Boolean = false` to `PlaybackState`. Set it true inside `protocolPlayHandler.handlePoolBased` before the (potentially-slow) URL fetch; clear it true→false after `playbackController.startPoolBasedSpinoff` (or on failure). Render in `MiniPlayer` as a small `CircularProgressIndicator` overlaying the cover when `currentTrack == null && isPlaybarLoading`.
+
+For Mode B too (it's fast — sub-2s — but the spec says "Mode B and Mode C both apply").
+
+**Step 3: Friend-track confidence regression test.**
+
+```kotlin
+@Test
+fun listenAlong_resolvedFriendTrack_carriesConfidenceAboveThreshold() = runTest {
+    // Arrange: stub resolverManager to return a high-confidence Spotify source.
+    // Act: call playFriendCurrentTrack(friend, immediate=true)
+    // Assert: track passed to playbackController.playTrack has resolver != null
+    //         AND the source's confidence (from selectBest) >= MIN_CONFIDENCE_THRESHOLD.
+}
+```
+
+**Step 4: Commit.**
+
+```bash
+git commit -m "ux: ack toast + playbar loading + listen-along confidence test (#121 [8/N])"
+```
+
+---
+
+## Task 9: Manual on-device verification
+
+Run these in order on a connected device. Use the worktree-aware install path (`./gradlew installDebug` from the **branch checkout**, then force-stop the package). The branch lives in main repo (no worktree this time, per user preference) so plain `./gradlew installDebug` is fine.
+
+```bash
+adb shell am force-stop com.parachord.android.debug
+./gradlew installDebug
+
+# Mode B
+adb shell am start -W -a android.intent.action.VIEW -d "parachord://play/radio?artist=Slowdive"
+# Expect: "Building radio…" toast within 500ms; pool fills with Slowdive-similar
+# tracks; banner reads "Radio: Slowdive" or similar.
+
+# Mode C URL
+adb shell am start -W -a android.intent.action.VIEW \
+  -d "parachord://play/radio?url=https%3A%2F%2Fapi.listenbrainz.org%2F1%2Fexplore%2Flb-radio%3Fprompt%3Dtag%3Ashoegaze%26mode%3Deasy"
+# Expect: same toast; pool from JSPF; logcat shows Authorization: Token <…> on
+# the LB fetch (only when LB token is configured in Settings). Let pool drain
+# below 3 — verify exactly one refill fetch within the rate-limit window.
+
+# Mode C inline
+adb shell am start -W -a android.intent.action.VIEW \
+  -d "parachord://play/radio?tracks=W3sidGl0bGUiOiJSYWNpbmcgTGlrZSBhIFBybyIsImFydGlzdCI6Ik5hdGlvbmFsIn0sIHsidGl0bGUiOiJUcmFjayAyIiwiYXJ0aXN0IjoiQXJ0aXN0IDIifV0%3D&name=Inline%20Test"
+# Expect: 2 tracks from inline JSON; no refill (no ?refill=).
+
+# Listen-along — known friend (replace with an actual friend username from your friends list)
+adb shell am start -W -a android.intent.action.VIEW \
+  -d "parachord://listen-along?service=listenbrainz&user=mr_monkey"
+
+# Listen-along — unknown user with currently-playing track
+adb shell am start -W -a android.intent.action.VIEW \
+  -d "parachord://listen-along?service=listenbrainz&user=rob"
+
+# Listen-along — unknown user not currently listening
+adb shell am start -W -a android.intent.action.VIEW \
+  -d "parachord://listen-along?service=listenbrainz&user=someinactive_user"
+# Expect: calm toast, no crash, no playback change.
+```
+
+**Step 1: Run each. Verify expected outcomes via logcat (`adb logcat -s ProtocolPlayHandler PlaybackController DeepLinkViewModel FriendsRepository`).**
+
+**Step 2: Cross-check the issue acceptance criteria checkboxes.** Tick them in PR description.
+
+---
+
+## Task 10: Open the PR
+
+**Step 1:** Push branch:
+
+```bash
+git push -u origin feature/protocol-phase-3
+```
+
+**Step 2:** Open PR with title `Protocol play handlers — Phase 3 (#121)`. Body includes:
+- Bulleted summary of Mode B / Mode C / refill / listen-along / LB token plug.
+- Link to issue #121.
+- Manual verification checklist from Task 9 with each line checked.
+
+**Step 3:** Tag the issue with `closes #121` in the PR body.
+
+---
+
+## Risk notes
+
+- **`startSpinoff` refactor** (Task 3) touches a heavily-used method. Run the full `:app:testDebugUnitTest` suite after the refactor commit before adding Mode B logic on top.
+- **Last.fm Mode B with no `?title=`** may need `getSimilarArtists` instead of `getSimilarTracks`. Verify desktop's exact call before assuming `getSimilarTracks(artist, "")` works.
+- **HttpClient plugin in shared module** must compile clean for both `androidMain` and `iosMain` (KMP rule #6 — only `Default`/`Main` dispatchers in commonMain). The plugin uses `onRequest` which is suspend by design; no explicit dispatcher.
+- **Refill loop dedup** depends on `TrackEntity.isrc` existing — verify before relying on it. If absent, dedup is `mbid` + `(artist|title)` only (still better than nothing).
+- **Listen-along teardown asymmetry** (Task 7 Step 5) — DO NOT call the standard teardown. Use a half-teardown variant or skip teardown entirely.
+- **LB token may not be set** — every test that hits the auth plugin must work in both modes (token / no token). The plugin's `tokenProvider` returning `null` already covers the "no token" path.

--- a/shared/build.gradle.kts
+++ b/shared/build.gradle.kts
@@ -80,4 +80,11 @@ android {
         sourceCompatibility = JavaVersion.VERSION_17
         targetCompatibility = JavaVersion.VERSION_17
     }
+    testOptions {
+        // Return defaults for unmocked Android stubs (e.g. android.util.Log.*) so
+        // shared production code paths that log via the platform Log expect/actual
+        // don't throw "Method not mocked" RuntimeExceptions in JVM unit tests.
+        // Mirrors the same setting on :app — see CLAUDE.md "Common Mistakes".
+        unitTests.isReturnDefaultValues = true
+    }
 }

--- a/shared/src/androidMain/kotlin/com/parachord/shared/api/HttpClientFactory.android.kt
+++ b/shared/src/androidMain/kotlin/com/parachord/shared/api/HttpClientFactory.android.kt
@@ -13,8 +13,9 @@ actual fun createHttpClient(
     appConfig: AppConfig,
     authProvider: AuthTokenProvider,
     tokenRefresher: OAuthTokenRefresher,
+    lbTokenProvider: suspend () -> String?,
 ): HttpClient = HttpClient(OkHttp) {
-    installSharedPlugins(json, appConfig, authProvider, tokenRefresher)
+    installSharedPlugins(json, appConfig, authProvider, tokenRefresher, lbTokenProvider)
     engine {
         config {
             connectTimeout(15, TimeUnit.SECONDS)

--- a/shared/src/commonMain/kotlin/com/parachord/shared/api/HttpClientFactory.kt
+++ b/shared/src/commonMain/kotlin/com/parachord/shared/api/HttpClientFactory.kt
@@ -28,8 +28,10 @@ import kotlinx.serialization.json.Json
  *  2. Logging — early, sees behavior post-content-negotiation; sanitizes Authorization
  *  3. DefaultRequest — sets User-Agent + baseline headers; before auth so it applies on retries
  *  4. OAuthRefreshPlugin — 401 → refresh + retry, single-flight per realm
- *  5. ListenBrainzAuthPlugin — auto-attach `Authorization: Token <token>` for api.listenbrainz.org;
- *                              after OAuthRefreshPlugin so the LB token applies on retries too
+ *  5. ListenBrainzAuthPlugin — auto-attach `Authorization: Token <token>` for api.listenbrainz.org.
+ *                              Order vs. OAuthRefreshPlugin doesn't matter (no host overlap — LB
+ *                              tokens are static and never refreshed by OAuthRefreshPlugin), but
+ *                              kept after OAuth for visual grouping with auth-related plugins.
  *  6. HttpTimeout — last, wraps everything in 60s/15s/30s budget
  */
 expect fun createHttpClient(

--- a/shared/src/commonMain/kotlin/com/parachord/shared/api/HttpClientFactory.kt
+++ b/shared/src/commonMain/kotlin/com/parachord/shared/api/HttpClientFactory.kt
@@ -28,13 +28,16 @@ import kotlinx.serialization.json.Json
  *  2. Logging — early, sees behavior post-content-negotiation; sanitizes Authorization
  *  3. DefaultRequest — sets User-Agent + baseline headers; before auth so it applies on retries
  *  4. OAuthRefreshPlugin — 401 → refresh + retry, single-flight per realm
- *  5. HttpTimeout — last, wraps everything in 60s/15s/30s budget
+ *  5. ListenBrainzAuthPlugin — auto-attach `Authorization: Token <token>` for api.listenbrainz.org;
+ *                              after OAuthRefreshPlugin so the LB token applies on retries too
+ *  6. HttpTimeout — last, wraps everything in 60s/15s/30s budget
  */
 expect fun createHttpClient(
     json: Json,
     appConfig: AppConfig,
     authProvider: AuthTokenProvider,
     tokenRefresher: OAuthTokenRefresher,
+    lbTokenProvider: suspend () -> String?,
 ): HttpClient
 
 internal fun HttpClientConfig<*>.installSharedPlugins(
@@ -42,6 +45,7 @@ internal fun HttpClientConfig<*>.installSharedPlugins(
     appConfig: AppConfig,
     authProvider: AuthTokenProvider,
     tokenRefresher: OAuthTokenRefresher,
+    lbTokenProvider: suspend () -> String? = { null },
 ) {
     install(ContentNegotiation) { json(json) }
     install(Logging) {
@@ -59,6 +63,9 @@ internal fun HttpClientConfig<*>.installSharedPlugins(
             // SoundCloud added when its native client migrates from raw OkHttp
             // calls in a later 9E phase.
         )
+    }
+    install(ListenBrainzAuthPlugin) {
+        this.tokenProvider = lbTokenProvider
     }
     install(HttpTimeout) {
         requestTimeoutMillis = 60_000     // AI endpoints take 30–60s (CLAUDE.md "AI generation needs long timeouts")

--- a/shared/src/commonMain/kotlin/com/parachord/shared/api/ListenBrainzAuthPlugin.kt
+++ b/shared/src/commonMain/kotlin/com/parachord/shared/api/ListenBrainzAuthPlugin.kt
@@ -1,7 +1,10 @@
 package com.parachord.shared.api
 
+import com.parachord.shared.platform.Log
 import io.ktor.client.plugins.api.createClientPlugin
 import io.ktor.http.HttpHeaders
+
+private const val TAG = "ListenBrainzAuthPlugin"
 
 /**
  * Ktor plugin that auto-attaches `Authorization: Token <token>` to every request
@@ -46,7 +49,10 @@ val ListenBrainzAuthPlugin = createClientPlugin("ListenBrainzAuth", ::ListenBrai
             tokenProvider()
         } catch (e: Throwable) {
             // SettingsStore lookup should never throw, but defend anyway —
-            // a thrown exception here would kill every LB call.
+            // a thrown exception here would kill every LB call. Log so a
+            // misconfigured SettingsStore produces a diagnostic trail rather
+            // than a silent 401.
+            Log.w(TAG, "tokenProvider threw, omitting Authorization: ${e.message}")
             null
         }
         if (!token.isNullOrBlank()) {

--- a/shared/src/commonMain/kotlin/com/parachord/shared/api/ListenBrainzAuthPlugin.kt
+++ b/shared/src/commonMain/kotlin/com/parachord/shared/api/ListenBrainzAuthPlugin.kt
@@ -1,0 +1,56 @@
+package com.parachord.shared.api
+
+import io.ktor.client.plugins.api.createClientPlugin
+import io.ktor.http.HttpHeaders
+
+/**
+ * Ktor plugin that auto-attaches `Authorization: Token <token>` to every request
+ * targeting `api.listenbrainz.org` (or any subdomain thereof).
+ *
+ * The token is sourced lazily per-request via [ListenBrainzAuthConfig.tokenProvider]
+ * — typically a closure over [com.parachord.shared.settings.SettingsStore.getListenBrainzToken]
+ * — so runtime token changes (user pasting a new token in Settings) take effect
+ * without rebuilding the HttpClient.
+ *
+ * Behavior:
+ *  - Only matches host `api.listenbrainz.org` (case-insensitive) and subdomains.
+ *  - Does NOT clobber an existing `Authorization` header — call sites that set
+ *    their own header (e.g. [com.parachord.shared.api.ListenBrainzClient.submitRecordingFeedback])
+ *    keep their explicit token.
+ *  - If the token provider returns null/blank or throws, the request passes
+ *    through with no `Authorization` header. Callers see the natural 401 from
+ *    the server rather than a swallowed failure.
+ *
+ * Mirrors desktop commits 69116a4 / 31078cf. Used by Phase 3's protocol-play
+ * Mode C `?url=` initial pool fetch, refill loop fetches, and the listen-along
+ * `/playing-now` fetch.
+ */
+class ListenBrainzAuthConfig {
+    /**
+     * Looks up the user's ListenBrainz user-token. Called per-request; should
+     * be cheap (typically a [com.parachord.shared.store.SecureTokenStore.get]).
+     * Return null/blank when the user hasn't configured a token.
+     */
+    var tokenProvider: suspend () -> String? = { null }
+}
+
+val ListenBrainzAuthPlugin = createClientPlugin("ListenBrainzAuth", ::ListenBrainzAuthConfig) {
+    val tokenProvider = pluginConfig.tokenProvider
+    onRequest { request, _ ->
+        val host = request.url.host.lowercase()
+        val isLbHost = host == "api.listenbrainz.org" || host.endsWith(".api.listenbrainz.org")
+        if (!isLbHost) return@onRequest
+        if (request.headers.contains(HttpHeaders.Authorization)) return@onRequest
+
+        val token = try {
+            tokenProvider()
+        } catch (e: Throwable) {
+            // SettingsStore lookup should never throw, but defend anyway —
+            // a thrown exception here would kill every LB call.
+            null
+        }
+        if (!token.isNullOrBlank()) {
+            request.headers.append(HttpHeaders.Authorization, "Token $token")
+        }
+    }
+}

--- a/shared/src/commonMain/kotlin/com/parachord/shared/api/ListenBrainzClient.kt
+++ b/shared/src/commonMain/kotlin/com/parachord/shared/api/ListenBrainzClient.kt
@@ -198,6 +198,50 @@ class ListenBrainzClient(private val httpClient: HttpClient) {
         }
     }
 
+    /**
+     * Fetch a user's currently-playing track (if any).
+     *
+     * Endpoint: `GET /1/user/{name}/playing-now`. The response shape is
+     * identical to `/listens` but capped to at most one entry — reuse
+     * [ListensWire] and pluck `listens.firstOrNull()`. Returns `null`
+     * when the user isn't currently scrobbling, when track metadata is
+     * blank, or on any HTTP error.
+     *
+     * Auth required as of mid-2026; the [ListenBrainzAuthPlugin] (Phase
+     * 3 Task 2) auto-attaches the configured token, so this method
+     * doesn't need a token parameter. If no token is configured the
+     * request will 401 and we return null.
+     *
+     * Used by the `parachord://listen-along` transient-friend fallback
+     * when the target user isn't in the local friends list.
+     */
+    suspend fun getPlayingNow(username: String): LbListen? {
+        return try {
+            val response = httpClient.get("$BASE_URL/1/user/$username/playing-now")
+            if (!response.status.isSuccess()) {
+                Log.w(TAG, "playing-now returned ${response.status.value} for $username")
+                return null
+            }
+            val parsed = json.decodeFromString<ListensWire>(response.bodyAsText())
+            val listen = parsed.payload?.listens?.firstOrNull() ?: return null
+            val md = listen.trackMetadata ?: return null
+            val artist = md.artistName.orEmpty()
+            val title = md.trackName.orEmpty()
+            if (artist.isBlank() || title.isBlank()) return null
+            LbListen(
+                artistName = artist,
+                trackName = title,
+                releaseName = md.releaseName?.ifBlank { null },
+                listenedAt = listen.listenedAt ?: 0L,
+            )
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Throwable) {
+            Log.w(TAG, "playing-now failed for $username", e)
+            null
+        }
+    }
+
     /** Fetch user's top artists. range: week, month, quarter, half_yearly, year, all_time. */
     suspend fun getUserTopArtists(
         username: String,

--- a/shared/src/commonMain/kotlin/com/parachord/shared/api/MusicBrainzClient.kt
+++ b/shared/src/commonMain/kotlin/com/parachord/shared/api/MusicBrainzClient.kt
@@ -111,6 +111,33 @@ class MusicBrainzClient(private val httpClient: HttpClient) {
     ): MbReleaseDetail =
         guardedGet("$BASE_URL/release/$releaseId") { parameter("inc", inc) }
 
+    /**
+     * Browse releases that belong to a given release-group, including
+     * media + recordings + artist-credits so the caller can map tracks
+     * directly without a follow-up release lookup.
+     *
+     * Sorted by release date (oldest first per MB default). Caller picks
+     * the first release as a canonical pick — usually adequate since most
+     * release-groups have one or a few editions of the same tracklist.
+     *
+     * Endpoint: GET /ws/2/release?release-group={rgMbid}&inc=...&limit=...
+     *
+     * Used by the protocol deeplink resolver to handle the common case
+     * where an external tool (e.g. Achordion) emits a release-group MBID
+     * as the canonical "album" identifier — `/ws/2/release/{rgMbid}` 404s
+     * for those, so we fall through to this browse endpoint.
+     */
+    suspend fun browseReleasesByReleaseGroup(
+        releaseGroupMbid: String,
+        inc: String = "recordings+artist-credits",
+        limit: Int = 1,
+    ): MbReleaseBrowseResponse =
+        guardedGet("$BASE_URL/release") {
+            parameter("release-group", releaseGroupMbid)
+            parameter("inc", inc)
+            parameter("limit", limit)
+        }
+
     suspend fun browseReleaseGroups(
         artistId: String,
         limit: Int = 100,
@@ -218,6 +245,21 @@ data class MbReleaseDetail(
     val artistName: String get() = artistCredit.joinToString(", ") { it.name }
     val year: Int? get() = date?.take(4)?.toIntOrNull()
 }
+
+/**
+ * Response for `GET /ws/2/release?release-group={rgMbid}&inc=...`.
+ *
+ * The browsed release entries carry the same shape as [MbReleaseDetail]
+ * (id + title + artist-credit + media[]+tracks[]) when the request
+ * includes `inc=recordings+artist-credits`, so we reuse that type for
+ * the items rather than introducing a parallel response model.
+ */
+@Serializable
+data class MbReleaseBrowseResponse(
+    @SerialName("release-offset") val releaseOffset: Int = 0,
+    @SerialName("release-count") val releaseCount: Int = 0,
+    val releases: List<MbReleaseDetail> = emptyList(),
+)
 
 @Serializable
 data class MbMedia(

--- a/shared/src/commonMain/kotlin/com/parachord/shared/db/dao/FriendDao.kt
+++ b/shared/src/commonMain/kotlin/com/parachord/shared/db/dao/FriendDao.kt
@@ -55,6 +55,16 @@ class FriendDao(private val db: ParachordDb) {
         queries.getById(id).executeAsOneOrNull()?.toFriend()
     }
 
+    /**
+     * Look up a saved friend by `(service, username)` with a
+     * case-insensitive username match. One-shot query — does NOT
+     * round-trip through the live Flow used by [getAllFriends].
+     */
+    suspend fun findByServiceAndUsername(service: String, username: String): Friend? =
+        withContext(Dispatchers.Default) {
+            queries.findByServiceAndUsername(service, username).executeAsOneOrNull()?.toFriend()
+        }
+
     /* ---- Writes ---- */
 
     suspend fun upsert(friend: Friend): Unit = withContext(Dispatchers.Default) {

--- a/shared/src/commonMain/kotlin/com/parachord/shared/deeplink/DeepLinkAction.kt
+++ b/shared/src/commonMain/kotlin/com/parachord/shared/deeplink/DeepLinkAction.kt
@@ -30,10 +30,11 @@ sealed class DeepLinkAction {
     ) : DeepLinkAction()
 
     /**
-     * `parachord://play/radio` — start a radio context. [refillUrl] is the
-     * URL the radio engine polls for fresh tracks (Mode A). [input]
-     * supplies the initial pool / seed; [mode] selects Mode B (artist seed)
-     * or Mode C (pool-based) for non-URL modes.
+     * `parachord://play/radio` — start a radio context. [input] supplies the
+     * initial pool / seed; [mode] selects Mode B (artist seed) or Mode C
+     * (pool-based). [refillUrl] is the URL used for subsequent refills only
+     * — the initial pool is sourced from `input.url` or `input.tracks`,
+     * decoupled from refill sourcing.
      */
     data class PlayRadio(
         val mode: RadioMode,

--- a/shared/src/commonMain/kotlin/com/parachord/shared/deeplink/ProtocolPlayModels.kt
+++ b/shared/src/commonMain/kotlin/com/parachord/shared/deeplink/ProtocolPlayModels.kt
@@ -58,16 +58,19 @@ data class ProtocolTrack(
 /**
  * Radio mode for `parachord://play/radio`.
  *
- * Mirrors desktop's three-mode model:
- * - Mode A (URL-fed) — handled via `PlayRadio.refillUrl` + initial
- *   `tracks` payload; no enum variant needed because the radio engine
- *   just polls the URL on each refill.
+ * Two variants after the Phase 3 parser reshape (commit `81e32dc`):
  * - [ArtistSeed] — Mode B. Server / client builds the queue from one
  *   seed artist (and optional song hint); refills are computed from
  *   the same seed.
- * - [PoolBased] — Mode C. Initial pool of tracks supplied inline
- *   (or via [ProtocolPlayInput.tracks]); subsequent refills draw from
- *   that pool. No external seed.
+ * - [PoolBased] — Mode C. Initial pool of tracks supplied via
+ *   [ProtocolPlayInput.url] (a hosted XSPF/JSPF/M3U/JSON tracklist) or
+ *   [ProtocolPlayInput.tracks] (inline base64 JSON). No external seed.
+ *
+ * Note: there is no separate "Mode A" variant — the optional
+ * [PlayRadio.refillUrl] is what subsequent refills draw from, and is
+ * decoupled from initial pool sourcing. A radio with `?url=` for the
+ * initial pool plus `?refill=` for subsequent refills is just Mode C
+ * with a refill URL set.
  */
 sealed class RadioMode {
     /** Mode B — single seed artist (and optional song title hint). */

--- a/shared/src/commonMain/kotlin/com/parachord/shared/deeplink/ProtocolPlayTeardown.kt
+++ b/shared/src/commonMain/kotlin/com/parachord/shared/deeplink/ProtocolPlayTeardown.kt
@@ -35,4 +35,21 @@ interface ProtocolPlayTeardown {
      * for the queue clear to settle before submitting new tracks.
      */
     suspend fun prepareForNewPlayback()
+
+    /**
+     * Half-teardown for `parachord://listen-along` friend-A → friend-B
+     * handover. Runs steps **(1) exit spinoff** and **(3) clear queue**,
+     * but DELIBERATELY SKIPS step (2) "stop listen-along".
+     *
+     * The reason: `MainViewModel.startListenAlong(friend)` already calls
+     * `stopListenAlong(silent = true)` at its top, so the swap is atomic.
+     * Calling [prepareForNewPlayback] here would tear down the very
+     * listen-along loop we're about to replace — a stop+start race that
+     * occasionally lets the dying loop's last poll tick clobber the new
+     * friend's track right after `startListenAlong` set it.
+     *
+     * Use this method, NOT [prepareForNewPlayback], from any code path
+     * that's about to call `MainViewModel.startListenAlong`.
+     */
+    suspend fun prepareForListenAlongHandover()
 }

--- a/shared/src/commonMain/kotlin/com/parachord/shared/deeplink/PublicHttpsUrl.kt
+++ b/shared/src/commonMain/kotlin/com/parachord/shared/deeplink/PublicHttpsUrl.kt
@@ -2,7 +2,7 @@ package com.parachord.shared.deeplink
 
 /**
  * SSRF guard for protocol-fetched URLs (Phase 2 `play/playlist?url=`,
- * Phase 3 `play/radio?refillUrl=`, etc.).
+ * Phase 3 `play/radio?url=` / `play/radio?refill=`, etc.).
  *
  * Mirrors desktop's `isPublicHttpUrl` exactly. Rejects:
  *

--- a/shared/src/commonMain/kotlin/com/parachord/shared/di/SharedModule.kt
+++ b/shared/src/commonMain/kotlin/com/parachord/shared/di/SharedModule.kt
@@ -11,6 +11,7 @@ import com.parachord.shared.api.SmartLinksClient
 import com.parachord.shared.api.SpotifyClient
 import com.parachord.shared.api.TicketmasterClient
 import com.parachord.shared.api.createHttpClient
+import com.parachord.shared.settings.SettingsStore
 import com.parachord.shared.store.KvStore
 import kotlinx.serialization.json.Json
 import org.koin.core.module.dsl.singleOf
@@ -36,7 +37,23 @@ val sharedModule = module {
     }
 
     // HTTP Client (platform engine via expect/actual)
-    single { createHttpClient(get(), get(), get(), get()) }
+    //
+    // The lbTokenProvider closure captures SettingsStore so every request to
+    // api.listenbrainz.org auto-attaches `Authorization: Token <token>`. Looked
+    // up per-request — runtime token changes (Settings UI) take effect without
+    // a client rebuild. SettingsStore is registered by the platform-side module
+    // (AndroidModule / iOS module); Koin resolves it lazily on first HttpClient
+    // injection so module load order doesn't matter.
+    single {
+        val settings: SettingsStore = get()
+        createHttpClient(
+            get(),
+            get(),
+            get(),
+            get(),
+            lbTokenProvider = { settings.getListenBrainzToken() },
+        )
+    }
 
     // API Clients (Ktor, cross-platform)
     // SpotifyClient: per-API auth via AuthTokenProvider for AuthRealm.Spotify.

--- a/shared/src/commonMain/kotlin/com/parachord/shared/model/Friend.kt
+++ b/shared/src/commonMain/kotlin/com/parachord/shared/model/Friend.kt
@@ -15,6 +15,17 @@ data class Friend(
     val cachedTrackArtworkUrl: String? = null,
     val pinnedToSidebar: Boolean = false,
     val autoPinned: Boolean = false,
+    /**
+     * `true` for synthetic Friend records minted on the fly by the
+     * `parachord://listen-along?service=…&user=…` deeplink for users who
+     * are not in the local friends DB. Transient friends are NEVER
+     * persisted via [com.parachord.shared.db.dao.FriendDao] (the DAO's
+     * `upsert` doesn't read this field, and the listen-along path goes
+     * directly to `MainViewModel.startListenAlong(friend)` without
+     * touching Room). Default `false` keeps every existing call site
+     * — DB hydration, sync, friend-add — untouched.
+     */
+    val transient: Boolean = false,
 ) {
     /** Friend is "on air" if their cached track was played within the last 10 minutes. */
     val isOnAir: Boolean

--- a/shared/src/commonMain/kotlin/com/parachord/shared/repository/FriendsRepository.kt
+++ b/shared/src/commonMain/kotlin/com/parachord/shared/repository/FriendsRepository.kt
@@ -20,7 +20,6 @@ import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
@@ -67,9 +66,7 @@ class FriendsRepository(
      */
     suspend fun findByServiceAndUsername(service: String, username: String): Friend? =
         withContext(Dispatchers.Default) {
-            getAllFriends().first().firstOrNull {
-                it.service == service && it.username.equals(username, ignoreCase = true)
-            }
+            friendDao.findByServiceAndUsername(service, username)
         }
 
     /**

--- a/shared/src/commonMain/kotlin/com/parachord/shared/repository/FriendsRepository.kt
+++ b/shared/src/commonMain/kotlin/com/parachord/shared/repository/FriendsRepository.kt
@@ -20,6 +20,7 @@ import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
@@ -53,6 +54,120 @@ class FriendsRepository(
 
     /** Get a single friend by ID. */
     suspend fun getFriendById(id: String): Friend? = friendDao.getFriendById(id)
+
+    /**
+     * Look up a saved friend by `(service, username)`. Case-insensitive
+     * on the username so the deeplink user `?user=mrmonkey` finds a
+     * stored "MrMonkey".
+     *
+     * Used by the `parachord://listen-along` dispatcher to decide
+     * between calling [MainViewModel.startListenAlong] with a stored
+     * Friend (this returns non-null) versus minting a transient one
+     * via [fetchTransientFriendNowPlaying] (this returns null).
+     */
+    suspend fun findByServiceAndUsername(service: String, username: String): Friend? =
+        withContext(Dispatchers.Default) {
+            getAllFriends().first().firstOrNull {
+                it.service == service && it.username.equals(username, ignoreCase = true)
+            }
+        }
+
+    /**
+     * Fetch the target user's currently-playing track and build a
+     * synthetic, NON-PERSISTED [Friend] record for the
+     * `parachord://listen-along` deeplink path. Returns `null` when:
+     *
+     *  - LB user has no `playing-now` entry, OR
+     *  - Last.fm response's first track has `@attr.nowplaying != "true"`,
+     *    OR
+     *  - the API call fails (calm UX — caller surfaces a "not currently
+     *    listening" toast rather than an error).
+     *
+     * The returned Friend's id is `transient:{service}:{user}` and its
+     * `transient` flag is `true`. Callers pass it directly to
+     * `MainViewModel.startListenAlong(friend)` — that VM only reads
+     * cachedTrack* fields + id/displayName/service, none of which need
+     * a Room row to exist. `cachedTrackTimestamp` is stamped at "now"
+     * (seconds since epoch) so [Friend.isOnAir] returns true.
+     */
+    suspend fun fetchTransientFriendNowPlaying(service: String, user: String): Friend? =
+        withContext(Dispatchers.Default) {
+            try {
+                when (service) {
+                    "listenbrainz" -> {
+                        val listen = listenBrainzClient.getPlayingNow(user) ?: return@withContext null
+                        buildTransientFriend(
+                            service = service,
+                            user = user,
+                            trackName = listen.trackName,
+                            trackArtist = listen.artistName,
+                            trackAlbum = listen.releaseName,
+                            artworkUrl = null,
+                        )
+                    }
+                    "lastfm" -> {
+                        val response = lastFmClient.getUserRecentTracks(
+                            user = user,
+                            apiKey = lastFmApiKey,
+                            limit = 1,
+                        )
+                        val first = response.recenttracks?.track?.firstOrNull() ?: return@withContext null
+                        // Only treat the row as "now playing" when Last.fm
+                        // explicitly flags it. Unlike refreshLastFmActivity()
+                        // we don't sanity-check against a recent scrobble
+                        // here — the deeplink path is one-shot and the user
+                        // is already opting in by sharing the link; even a
+                        // slightly stale flag is acceptable, and the polling
+                        // loop will recover on the next tick.
+                        if (first.attr?.nowplaying != "true") return@withContext null
+                        val artist = first.artist?.name?.takeIf { it.isNotBlank() }
+                            ?: return@withContext null
+                        val title = first.name.takeIf { it.isNotBlank() }
+                            ?: return@withContext null
+                        buildTransientFriend(
+                            service = service,
+                            user = user,
+                            trackName = title,
+                            trackArtist = artist,
+                            trackAlbum = first.album?.name?.takeIf { it.isNotBlank() },
+                            artworkUrl = first.image.bestImageUrl(),
+                        )
+                    }
+                    else -> null
+                }
+            } catch (e: Exception) {
+                Log.w(TAG, "fetchTransientFriendNowPlaying failed for $service:$user", e)
+                null
+            }
+        }
+
+    private fun buildTransientFriend(
+        service: String,
+        user: String,
+        trackName: String,
+        trackArtist: String,
+        trackAlbum: String?,
+        artworkUrl: String?,
+    ): Friend = Friend(
+        id = "transient:$service:$user",
+        username = user,
+        service = service,
+        displayName = user,
+        avatarUrl = null,
+        addedAt = currentTimeMillis(),
+        lastFetchedAt = currentTimeMillis(),
+        cachedTrackName = trackName,
+        cachedTrackArtist = trackArtist,
+        cachedTrackAlbum = trackAlbum,
+        cachedTrackArtworkUrl = artworkUrl,
+        // Seconds since epoch — matches the timestamp scale used by
+        // refreshLastFmActivity and refreshListenBrainzActivity, so
+        // Friend.isOnAir's 10-min window evaluates correctly.
+        cachedTrackTimestamp = currentTimeMillis() / 1000,
+        pinnedToSidebar = false,
+        autoPinned = false,
+        transient = true,
+    )
 
     /** Remove a friend locally and unfollow on the service. */
     suspend fun removeFriend(friendId: String) = withContext(Dispatchers.Default) {

--- a/shared/src/commonMain/sqldelight/com/parachord/shared/db/Friend.sq
+++ b/shared/src/commonMain/sqldelight/com/parachord/shared/db/Friend.sq
@@ -24,6 +24,9 @@ SELECT * FROM friends WHERE pinnedToSidebar = 1 ORDER BY cachedTrackTimestamp DE
 getById:
 SELECT * FROM friends WHERE id = ?;
 
+findByServiceAndUsername:
+SELECT * FROM friends WHERE service = ? AND lower(username) = lower(?) LIMIT 1;
+
 upsert:
 INSERT OR REPLACE INTO friends (id, username, service, displayName, avatarUrl, addedAt, lastFetchedAt, cachedTrackName, cachedTrackArtist, cachedTrackAlbum, cachedTrackTimestamp, cachedTrackArtworkUrl, pinnedToSidebar, autoPinned)
 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?);

--- a/shared/src/commonTest/kotlin/com/parachord/shared/api/ListenBrainzAuthPluginTest.kt
+++ b/shared/src/commonTest/kotlin/com/parachord/shared/api/ListenBrainzAuthPluginTest.kt
@@ -81,6 +81,9 @@ class ListenBrainzAuthPluginTest {
 
     @Test
     fun providerThrows_passesThroughWithoutAuthHeader() = runTest {
+        // We deliberately don't propagate the throwable — a thrown exception
+        // here would kill every LB call. The plugin logs the failure (Log.w)
+        // and falls through; callers see the natural 401 from the server.
         var seenAuth: String? = null
         val engine = MockEngine { req ->
             seenAuth = req.headers["Authorization"]

--- a/shared/src/commonTest/kotlin/com/parachord/shared/api/ListenBrainzAuthPluginTest.kt
+++ b/shared/src/commonTest/kotlin/com/parachord/shared/api/ListenBrainzAuthPluginTest.kt
@@ -1,0 +1,97 @@
+package com.parachord.shared.api
+
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.mock.MockEngine
+import io.ktor.client.engine.mock.respond
+import io.ktor.client.request.get
+import io.ktor.client.request.headers
+import io.ktor.http.HttpStatusCode
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+/**
+ * MockEngine tests for [ListenBrainzAuthPlugin].
+ *
+ * The MockEngine handler captures the outbound request's `Authorization`
+ * header at the engine boundary — i.e. AFTER the plugin pipeline has run.
+ * That's exactly what we need to verify: did the plugin attach (or pass
+ * through, or preserve) the header correctly?
+ */
+class ListenBrainzAuthPluginTest {
+
+    @Test
+    fun attachesTokenForListenBrainzHost() = runTest {
+        var seenAuth: String? = null
+        val engine = MockEngine { req ->
+            seenAuth = req.headers["Authorization"]
+            respond("{}", HttpStatusCode.OK)
+        }
+        val client = HttpClient(engine) {
+            install(ListenBrainzAuthPlugin) { tokenProvider = { "secret-token" } }
+        }
+        client.get("https://api.listenbrainz.org/1/user/foo/playing-now")
+        assertEquals("Token secret-token", seenAuth)
+    }
+
+    @Test
+    fun doesNotAttachTokenForOtherHosts() = runTest {
+        var seenAuth: String? = null
+        val engine = MockEngine { req ->
+            seenAuth = req.headers["Authorization"]
+            respond("{}", HttpStatusCode.OK)
+        }
+        val client = HttpClient(engine) {
+            install(ListenBrainzAuthPlugin) { tokenProvider = { "secret-token" } }
+        }
+        client.get("https://example.com/something")
+        assertNull(seenAuth)
+    }
+
+    @Test
+    fun noTokenConfigured_passesThroughWithoutAuthHeader() = runTest {
+        var seenAuth: String? = null
+        val engine = MockEngine { req ->
+            seenAuth = req.headers["Authorization"]
+            respond("{}", HttpStatusCode.Unauthorized)
+        }
+        val client = HttpClient(engine) {
+            install(ListenBrainzAuthPlugin) { tokenProvider = { null } }
+        }
+        client.get("https://api.listenbrainz.org/1/user/foo/playing-now")
+        assertNull(seenAuth)
+    }
+
+    @Test
+    fun preservesExistingAuthHeader() = runTest {
+        var seenAuth: String? = null
+        val engine = MockEngine { req ->
+            seenAuth = req.headers["Authorization"]
+            respond("{}", HttpStatusCode.OK)
+        }
+        val client = HttpClient(engine) {
+            install(ListenBrainzAuthPlugin) { tokenProvider = { "plugin-token" } }
+        }
+        client.get("https://api.listenbrainz.org/1/user/foo/playing-now") {
+            headers { append("Authorization", "Token explicit-token") }
+        }
+        assertEquals("Token explicit-token", seenAuth)
+    }
+
+    @Test
+    fun providerThrows_passesThroughWithoutAuthHeader() = runTest {
+        var seenAuth: String? = null
+        val engine = MockEngine { req ->
+            seenAuth = req.headers["Authorization"]
+            respond("{}", HttpStatusCode.OK)
+        }
+        val client = HttpClient(engine) {
+            install(ListenBrainzAuthPlugin) {
+                tokenProvider = { error("boom") }
+            }
+        }
+        client.get("https://api.listenbrainz.org/1/user/foo/playing-now")
+        assertNull(seenAuth)
+    }
+}

--- a/shared/src/commonTest/kotlin/com/parachord/shared/api/ListenBrainzPlayingNowTest.kt
+++ b/shared/src/commonTest/kotlin/com/parachord/shared/api/ListenBrainzPlayingNowTest.kt
@@ -1,0 +1,167 @@
+package com.parachord.shared.api
+
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.mock.MockEngine
+import io.ktor.client.engine.mock.respond
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.headersOf
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+
+/**
+ * MockEngine tests for [ListenBrainzClient.getPlayingNow]. Added as
+ * part of the `parachord://listen-along` transient-friend fallback
+ * (issue #121, Phase 3 Task 7).
+ *
+ * The endpoint shape mirrors `/listens` — the same `payload.listens[]`
+ * envelope — so we reuse the [ListensWire] decoder. These tests exercise
+ * the boundary cases where reuse can mask bugs:
+ *  - empty payload → null (user not currently scrobbling)
+ *  - blank artist OR title → null (ListenBrainz sometimes emits
+ *    placeholders; we treat those as "not playing")
+ *  - HTTP 4xx/5xx → null (calm UX — listen-along caller surfaces a
+ *    "not currently listening" toast rather than an error)
+ *  - happy path → populated [LbListen]
+ */
+class ListenBrainzPlayingNowTest {
+
+    private fun client(engine: MockEngine) = ListenBrainzClient(HttpClient(engine))
+
+    private val jsonHeaders = headersOf("Content-Type", "application/json")
+
+    @Test
+    fun happyPath_returnsLbListenWithMetadata() = runTest {
+        val body = """
+            {
+              "payload": {
+                "listens": [
+                  {
+                    "listened_at": 1700000000,
+                    "track_metadata": {
+                      "artist_name": "Slowdive",
+                      "track_name": "Sugar For The Pill",
+                      "release_name": "Slowdive (2017)"
+                    }
+                  }
+                ]
+              }
+            }
+        """.trimIndent()
+        val engine = MockEngine { _ ->
+            respond(body, HttpStatusCode.OK, jsonHeaders)
+        }
+
+        val listen = client(engine).getPlayingNow("rob")
+        assertNotNull(listen)
+        assertEquals("Slowdive", listen.artistName)
+        assertEquals("Sugar For The Pill", listen.trackName)
+        assertEquals("Slowdive (2017)", listen.releaseName)
+        assertEquals(1700000000L, listen.listenedAt)
+    }
+
+    @Test
+    fun emptyPayload_returnsNull() = runTest {
+        // User reachable but not currently playing anything.
+        val body = """{"payload":{"listens":[]}}"""
+        val engine = MockEngine { _ ->
+            respond(body, HttpStatusCode.OK, jsonHeaders)
+        }
+        assertNull(client(engine).getPlayingNow("rob"))
+    }
+
+    @Test
+    fun missingTrackMetadata_returnsNull() = runTest {
+        val body = """
+            {
+              "payload": {
+                "listens": [
+                  { "listened_at": 1700000000 }
+                ]
+              }
+            }
+        """.trimIndent()
+        val engine = MockEngine { _ ->
+            respond(body, HttpStatusCode.OK, jsonHeaders)
+        }
+        assertNull(client(engine).getPlayingNow("rob"))
+    }
+
+    @Test
+    fun blankArtist_returnsNull() = runTest {
+        val body = """
+            {
+              "payload": {
+                "listens": [
+                  {
+                    "track_metadata": {
+                      "artist_name": "",
+                      "track_name": "Sugar For The Pill"
+                    }
+                  }
+                ]
+              }
+            }
+        """.trimIndent()
+        val engine = MockEngine { _ ->
+            respond(body, HttpStatusCode.OK, jsonHeaders)
+        }
+        assertNull(client(engine).getPlayingNow("rob"))
+    }
+
+    @Test
+    fun blankTitle_returnsNull() = runTest {
+        val body = """
+            {
+              "payload": {
+                "listens": [
+                  {
+                    "track_metadata": {
+                      "artist_name": "Slowdive",
+                      "track_name": ""
+                    }
+                  }
+                ]
+              }
+            }
+        """.trimIndent()
+        val engine = MockEngine { _ ->
+            respond(body, HttpStatusCode.OK, jsonHeaders)
+        }
+        assertNull(client(engine).getPlayingNow("rob"))
+    }
+
+    @Test
+    fun http401_returnsNullCalmly() = runTest {
+        // Auth not configured, or token expired. Listen-along caller
+        // converts this into a calm "not currently listening" toast.
+        val engine = MockEngine { _ ->
+            respond("Unauthorized", HttpStatusCode.Unauthorized)
+        }
+        assertNull(client(engine).getPlayingNow("rob"))
+    }
+
+    @Test
+    fun http500_returnsNullCalmly() = runTest {
+        val engine = MockEngine { _ ->
+            respond("Internal Server Error", HttpStatusCode.InternalServerError)
+        }
+        assertNull(client(engine).getPlayingNow("rob"))
+    }
+
+    @Test
+    fun urlIncludesUsername() = runTest {
+        var seenUrl: String? = null
+        val engine = MockEngine { req ->
+            seenUrl = req.url.toString()
+            respond("""{"payload":{"listens":[]}}""", HttpStatusCode.OK, jsonHeaders)
+        }
+        client(engine).getPlayingNow("MrMonkey")
+        assertEquals(
+            "https://api.listenbrainz.org/1/user/MrMonkey/playing-now",
+            seenUrl,
+        )
+    }
+}

--- a/shared/src/iosMain/kotlin/com/parachord/shared/api/HttpClientFactory.ios.kt
+++ b/shared/src/iosMain/kotlin/com/parachord/shared/api/HttpClientFactory.ios.kt
@@ -12,8 +12,9 @@ actual fun createHttpClient(
     appConfig: AppConfig,
     authProvider: AuthTokenProvider,
     tokenRefresher: OAuthTokenRefresher,
+    lbTokenProvider: suspend () -> String?,
 ): HttpClient = HttpClient(Darwin) {
-    installSharedPlugins(json, appConfig, authProvider, tokenRefresher)
+    installSharedPlugins(json, appConfig, authProvider, tokenRefresher, lbTokenProvider)
     engine {
         configureRequest {
             setAllowsCellularAccess(true)


### PR DESCRIPTION
Closes #121. Implements `parachord://play/radio` (artist-seed Mode B + pool-based Mode C with refill loop) and `parachord://listen-along` (known + transient-friend paths). Depends on #119 (Phase 1) + #120 (Phase 2).

## Summary

- **Mode B (`?artist=`)** — splits on whether `?title=` is present:
  - **With title** (`?artist=X&title=Y`) → Last.fm `track.getsimilar` (the existing in-app spinoff backend), via `startSpinoffWithSeed`. Per-track spinoff via deeplink.
  - **Without title** (`?artist=X`) → ListenBrainz LB Radio (`/1/explore/lb-radio?prompt=artist:(X)&mode=easy`), routed through the **same Mode C pool path** (synthetic `PlayRadio(mode=PoolBased, url, refillUrl)`). The lb-radio URL doubles as the refill URL so the radio keeps generating tracks across pool drains. Token auto-attach (below) supplies auth automatically.
- **Mode C (`?url=`/`?tracks=`/`?refill=`)** — `startPoolBasedSpinoff` flow. Initial pool from URL fetch (JSPF/XSPF/M3U via the existing `ProtocolInputResolver` cascade) or inline base64 JSON. `PoolRefiller` handles refills: rate-limit 5s, 3-consecutive-empty stop, dedup by mbid → (artist|title) lowercase.
- **LB token auto-attach** — Ktor `ListenBrainzAuthPlugin` matches `api.listenbrainz.org` and subdomains; token sourced lazily per-request from `SettingsStore.getListenBrainzToken()`. Doesn't clobber pre-set `Authorization` headers (e.g. `submitRecordingFeedback`'s explicit token).
- **Listen-along** — `FriendsRepository.fetchTransientFriendNowPlaying` for users not in the local friends DB; transient `Friend.transient = true` in-memory only (never persisted to Room). `MainViewModel.startListenAlong`'s poll loop branches on `friend.transient` so transient friends refresh via re-fetch instead of `friendDao.getFriendById` (which would return null for synthetic IDs and break the loop). `prepareForListenAlongHandover` (steps 1+3 of teardown, NOT step 2) avoids the stop+start race when swapping friends.
- **UX polish** — ack toasts on entry (`Building radio…`, `Catching up to <user>…`, ~3.5s via `LENGTH_LONG`); `PlaybackState.isPlaybarLoading` flag with mini-player spinner overlay during pool fetch; listen-along resolver-confidence already enforced via `ResolverScoring.selectBest` (anchored with a comment for future maintainers).

## Parser shift (note for reviewers)

Phase 2's `parsePlayRadio` dispatched Mode A on `?refillUrl=` presence. The desktop contract (per #121) treats `?url=` as the **initial pool URL** and `?refill=` as the **refill-only URL**. This PR's first commit reshapes the parser to match. `?refillUrl=` is kept as a legacy alias for back-compat with anything generated against the Phase 2 build.

## Test plan

- [x] All unit tests pass: 598 tests, 0 failures (`:shared:testDebugUnitTest :app:testDebugUnitTest`).
- [x] Manual on-device — Mode B artist-only routes through LB Radio:
      `adb shell am start -W -a android.intent.action.VIEW -d "parachord://play/radio?artist=Slowdive"`
- [x] Manual on-device — Mode B title-bearing falls through to Last.fm spinoff:
      `adb shell am start -W -a android.intent.action.VIEW -d "parachord://play/radio?artist=Slowdive&title=Sugar%20For%20The%20Pill"`
- [x] Manual on-device — Mode C inline pool with name precedence works.

## Known limitations

- **Toast duration** — desktop's 30s ack toast is approximated as `Toast.LENGTH_LONG` (~3.5s). Android Toast can't do arbitrary durations or programmatic dismiss-on-event. Future polish: convert to a Compose Snackbar with explicit duration + clear-on-track-change.
- **Refill ISRC dedup** — `TrackEntity` has no `isrc` column; dedup falls back to `mbid → (artist|title)`. Documented in `PoolRefiller` KDoc.
- **Mode B artist-only requires an LB token** — the lb-radio endpoint needs auth. Configured via Settings; plugin attaches automatically. Without a token the call returns 401 and the toast surfaces "Radio failed: …".

## Plan

[docs/plans/2026-05-10-phase-3-protocol-radio-listen-along.md](docs/plans/2026-05-10-phase-3-protocol-radio-listen-along.md)

🤖 Generated with [Claude Code](https://claude.com/claude-code)