### PR TITLE
share: migrate track / album / artist sharing to Achordion entity links

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -42,6 +42,7 @@ jobs:
       - name: Create local.properties
         run: |
           cat <<EOF > local.properties
+          ACHORDION_BEARER_TOKEN=${{ secrets.ACHORDION_BEARER_TOKEN }}
           LASTFM_API_KEY=${{ secrets.LASTFM_API_KEY }}
           LASTFM_SHARED_SECRET=${{ secrets.LASTFM_SHARED_SECRET }}
           SPOTIFY_CLIENT_ID=${{ secrets.SPOTIFY_CLIENT_ID }}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -343,19 +343,43 @@ Importing a playlist from an XSPF URL (as opposed to an uploaded `.xspf` file or
 
 **Key files:** `playlist/HostedPlaylistPoller.kt`, `playlist/HostedPlaylistScheduler.kt`, `playlist/HostedPlaylistWorker.kt`, `playlist/XspfHashing.kt` (shared SSRF + SHA-256 helpers), `playlist/PlaylistImportManager.kt` (persists `sourceUrl` + hash), `sync/SyncEngine.kt` (hosted skip-pull + include-in-push), `ui/components/HostedBadge.kt`
 
-### Outbound Sharing (Smart Links)
+### Outbound Sharing (Achordion + Smart Links)
 
-Long-press / overflow → Share fires the Android share sheet with a `https://go.parachord.com/<id>` smart-link minted by desktop's Cloudflare Pages backend (same `/api/create` endpoint, same payload shape, same short URLs that desktop produces). Recipients on Slack / Discord / iMessage get a rich Open Graph preview with title, art, and per-service "Listen on Spotify/Apple Music/SoundCloud" buttons.
+Long-press / overflow → Share fires the Android share sheet. Post-migration (v0.6.x+) the share URL depends on the entity type:
 
-**Base URL trap.** The smart-links README documents `links.parachord.app` as the "optional custom domain" and the Cloudflare Pages default `parachord-links.pages.dev` as the canonical deploy. Neither matches what desktop actually uses — production short URLs land on `go.parachord.com`. Always use `https://go.parachord.com/` as the Retrofit base URL so Android shares stay brand-consistent with desktop. (`links.parachord.app` doesn't even resolve.)
+- **Track / album / artist** → Achordion entity URL (`https://achordion.xyz/<type>/<mbid>`) via `AchordionClient`. Mirrors desktop's `publishSmartLink` / `publishAlbumSmartLink` / `publishArtistSmartLink` in `parachord-desktop/app.js`.
+- **Playlist** → `https://go.parachord.com/<id>` via `SmartLinksClient`. Retained for playlists because Achordion has no playlist entity page yet.
 
-**Fallback chain order matters.** If smart-link creation fails (timeout / 5xx / no metadata), fall through to the `https://parachord.com/go?uri=parachord://...` deeplink wrapper — never to a raw source URL like `open.spotify.com/playlist/<id>`. Even synced playlists should keep Parachord branding on the share; recipients can still get to Spotify via the smart-link page's per-service buttons when the API is reachable. The wrapper at `parachord.com/go` is a separate static GitHub Pages redirect — different service from the smart-link backend at `go.parachord.com`.
+Recipients on Slack / Discord / iMessage get a rich Open Graph preview either way — Achordion renders per-service "Listen on Spotify/Apple Music/SoundCloud" buttons after server-side link resolution; smart-links serve the existing feature.fm-style landing page.
+
+**Track shares pre-warm Achordion's cache** via `POST /api/track-links/submit` so recipients see fully-resolved per-service links instead of an empty page on first load. Submit gates (all must hold):
+1. `recordingMbid` is non-null.
+2. At least one streaming source ID (`spotifyId`, `appleMusicId`, `soundcloudId`) is non-blank.
+3. Per-session dedup by lowercase MBID — repeat shares of the same track don't re-submit.
+4. Auth-failed kill-switch on 401 — flips off for the session so a bad bearer token doesn't spam the backend.
+
+Album and artist shares call entity-link only — **no submit** (matches desktop; submits are recording-keyed).
+
+**Fallback when MBID is missing or the entity-link API errors:** Achordion lookup URL patterns do server-side MusicBrainz search and 302 to the canonical entity page:
+- Tracks: `https://achordion.xyz/recording/lookup?artist=&title=`
+- Albums: `https://achordion.xyz/release-group/lookup?artist=&title=`
+- Artists: `https://achordion.xyz/artist/lookup?name=`
+
+Playlist shares fall back to the `https://parachord.com/go?uri=parachord://...` deeplink wrapper when smart-link creation fails — never to a raw source URL like `open.spotify.com/playlist/<id>`. The wrapper at `parachord.com/go` is a separate static GitHub Pages redirect — different service from the smart-link backend at `go.parachord.com`.
+
+**Bearer token** for Achordion comes from `AppConfig.achordionBearerToken` (BuildConfig field, sourced from `local.properties` or CI secret). Empty token short-circuits cleanly to lookup URLs without calling the API.
+
+**Smart-link payload requirements (playlist path, from `smart-links/functions/api/create.js`):** `title` is required; `tracks` array must be non-empty for `type=playlist`. Build the payload defensively — if there's nothing to send, skip the API and go straight to the deeplink wrapper rather than POSTing a guaranteed 400.
 
 **Wiring:** `TrackContextMenuHost` auto-wires share for tracks (every screen that uses the host gets it for free). Album / Artist / Playlist context menus take an optional `onShare: (() -> Unit)?` parameter — every callsite passes it explicitly via `rememberShareAlbumLite`, `rememberShareArtist`, `rememberSharePlaylist`, or `rememberSharePlaylistById`. The "lite" variants skip the per-track URL map (deeplink fallback only) for screens like the artist discography where tracks aren't in scope; the rich variant is used on detail screens (`PlaylistDetailScreen`) where the full tracklist is available.
 
-**Smart-link payload requirements (from `smart-links/functions/api/create.js`):** `title` is required; `tracks` array must be non-empty for `type=album|playlist`; `urls` map must be non-empty for `type=track`. Build the payload defensively — if there are no per-service URLs at all, skip the API and go straight to the deeplink wrapper rather than POSTing a guaranteed 400.
-
-**Key files:** `share/SmartLinkApi.kt` (Retrofit interface), `share/ShareManager.kt` (orchestration + fallback), `share/ShareSheet.kt` (`openShareSheet` + `rememberShareXxx` Composable helpers), `ui/components/{Track,Album,Artist}ContextMenu.kt`, `ui/screens/playlists/PlaylistsScreen.kt` (PlaylistContextMenu)
+**Key files:**
+- `shared/.../api/AchordionClient.kt` — Ktor client (entity-link + submit)
+- `shared/.../api/SmartLinksClient.kt` — playlist-only Ktor client
+- `app/.../share/ShareManager.kt` — caller, parallel `coroutineScope` for track shares (entity-link + submit fire concurrently)
+- `app/.../share/ShareSheet.kt` — `openShareSheet` + `rememberShareXxx` Composable helpers
+- `app/.../ui/components/{Track,Album,Artist}ContextMenu.kt`, `app/.../ui/screens/playlists/PlaylistsScreen.kt` (PlaylistContextMenu)
+- `parachord-desktop/plugins/achordion.axe` — reference implementation
 
 ### ListenBrainz Weekly Playlists
 

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -30,6 +30,7 @@ android {
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
 
         // API keys — loaded from local.properties or environment variables
+        buildConfigField("String", "ACHORDION_BEARER_TOKEN", "\"${localProp("ACHORDION_BEARER_TOKEN")}\"")
         buildConfigField("String", "LASTFM_API_KEY", "\"${localProp("LASTFM_API_KEY")}\"")
         buildConfigField("String", "LASTFM_SHARED_SECRET", "\"${localProp("LASTFM_SHARED_SECRET")}\"")
         buildConfigField("String", "SPOTIFY_CLIENT_ID", "\"${localProp("SPOTIFY_CLIENT_ID")}\"")

--- a/app/src/main/java/com/parachord/android/di/AndroidModule.kt
+++ b/app/src/main/java/com/parachord/android/di/AndroidModule.kt
@@ -144,6 +144,7 @@ val androidModule = module {
 
     single {
         com.parachord.shared.config.AppConfig(
+            achordionBearerToken = com.parachord.android.BuildConfig.ACHORDION_BEARER_TOKEN,
             lastFmApiKey = com.parachord.android.BuildConfig.LASTFM_API_KEY,
             lastFmSharedSecret = com.parachord.android.BuildConfig.LASTFM_SHARED_SECRET,
             spotifyClientId = com.parachord.android.BuildConfig.SPOTIFY_CLIENT_ID,

--- a/app/src/main/java/com/parachord/android/di/AndroidModule.kt
+++ b/app/src/main/java/com/parachord/android/di/AndroidModule.kt
@@ -264,7 +264,7 @@ val androidModule = module {
     // `sharedModule`; per-platform `OkHttp`/`Darwin` Ktor engines + global
     // User-Agent + sanitized Authorization-stripping logging come for free
     // through the shared `HttpClientFactory`.
-    single { com.parachord.android.share.ShareManager(get(), get(), get()) }
+    single { com.parachord.android.share.ShareManager(get(), get(), get(), get()) }
 
     // Spotify Web API — migrated to shared Ktor client (SpotifyClient) in
     // Phase 9E.1.8. Binding lives in sharedModule; per-request auth via

--- a/app/src/main/java/com/parachord/android/share/ShareManager.kt
+++ b/app/src/main/java/com/parachord/android/share/ShareManager.kt
@@ -174,17 +174,19 @@ class ShareManager constructor(
     }
 
     /**
-     * Artists don't have a smart-link shape on desktop yet (per
-     * `TODO-album-smart-links.md` in Parachord/parachord — even albums are
-     * partial), so always fall back to the deeplink wrapper. Recipients with
-     * Parachord installed jump straight into the Artist screen; everyone else
-     * lands on the redirect page that explains what Parachord is.
+     * Shares an artist via the Achordion artist entity page when we have an
+     * MBID, falling back to the `/artist/lookup?name=` route otherwise.
+     * Matches desktop's behavior — no smart-link submit since artists don't
+     * have track-link payloads.
      */
-    fun shareArtist(name: String, imageUrl: String? = null): ShareResult {
-        val subject = name
-        val url = deepLinkWrapper("artist", "/${enc(name)}", isPath = true)
-        return ShareResult(url, subject, isSmartLink = false)
+    suspend fun shareArtist(name: String, artistMbid: String? = null): ShareResult {
+        val entityUrl = tryFetchEntityLink(EntityType.Artist, artistMbid)
+        val url = entityUrl ?: artistLookupUrl(name)
+        return ShareResult(url, name, isSmartLink = entityUrl != null)
     }
+
+    private fun artistLookupUrl(name: String): String =
+        "https://achordion.xyz/artist/lookup?name=${enc(name)}"
 
     private suspend fun tryCreateSmartLink(request: SmartLinkCreateRequest): String? {
         return try {

--- a/app/src/main/java/com/parachord/android/share/ShareManager.kt
+++ b/app/src/main/java/com/parachord/android/share/ShareManager.kt
@@ -22,18 +22,22 @@ import kotlinx.coroutines.withTimeout
 /**
  * Builds shareable URLs for tracks, albums, playlists, and artists.
  *
- * Primary path: POST to the desktop Smart Links backend (`links.parachord.app`)
- * to mint a rich landing page — same infra desktop uses. The recipient gets
- * Open Graph previews + per-service "Play on Spotify/SoundCloud/Bandcamp"
- * buttons on every major platform that unfurls links.
+ * - **Tracks / albums / artists** resolve to Achordion entity pages
+ *   (`achordion.xyz/{recording,release-group,artist}/...`) via
+ *   [AchordionClient]. Track shares additionally pre-warm Achordion's
+ *   match cache via `POST /api/track-links/submit` so recipients land
+ *   on a fully-populated entity page on first click. Mirrors desktop's
+ *   `publishSmartLink` / `publishAlbumSmartLink` / `publishArtistSmartLink`.
+ * - **Playlists** continue to use [SmartLinksClient] →
+ *   `go.parachord.com/<id>` smart-links. Achordion has no playlist
+ *   entity page yet.
+ * - When the MBID is missing or the API fails/times out, all four paths
+ *   fall through to lookup URLs (`achordion.xyz/<type>/lookup?...` for
+ *   the migrated types, the existing `parachord.com/go?uri=...` wrapper
+ *   for playlists), so a share always produces a usable URL.
  *
- * Fallback path: a `https://parachord.com/go?uri=parachord://...` redirect
- * (matches desktop's chat-share format) so the link always opens in Parachord
- * even if the smart-link API is down or we don't have enough metadata to
- * make a useful smart link (e.g. artists, which aren't smart-link-shaped).
- *
- * Network calls are bounded by [SMART_LINK_TIMEOUT_MS] so a slow API can't
- * hold up the share sheet — we silently fall back to the deeplink wrapper.
+ * Network calls are bounded by a 4 s timeout so a slow API can't hold
+ * up the share sheet.
  */
 class ShareManager constructor(
     private val smartLinksClient: SmartLinksClient,

--- a/app/src/main/java/com/parachord/android/share/ShareManager.kt
+++ b/app/src/main/java/com/parachord/android/share/ShareManager.kt
@@ -6,11 +6,17 @@ import com.parachord.android.data.db.dao.PlaylistTrackDao
 import com.parachord.android.data.db.entity.PlaylistEntity
 import com.parachord.android.data.db.entity.PlaylistTrackEntity
 import com.parachord.android.data.db.entity.TrackEntity
+import com.parachord.shared.api.AchordionClient
+import com.parachord.shared.api.EntityType
 import com.parachord.shared.api.SmartLinkCreateRequest
 import com.parachord.shared.api.SmartLinkTrack
 import com.parachord.shared.api.SmartLinksClient
+import com.parachord.shared.api.SubmitTrackLinksRequest
+import com.parachord.shared.api.TrackLink
 import com.parachord.shared.platform.Log
 import kotlinx.coroutines.TimeoutCancellationException
+import kotlinx.coroutines.async
+import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.withTimeout
 
 /**
@@ -31,6 +37,7 @@ import kotlinx.coroutines.withTimeout
  */
 class ShareManager constructor(
     private val smartLinksClient: SmartLinksClient,
+    private val achordionClient: AchordionClient,
     private val playlistDao: PlaylistDao,
     private val playlistTrackDao: PlaylistTrackDao,
 ) {
@@ -47,27 +54,72 @@ class ShareManager constructor(
         val isSmartLink: Boolean,
     )
 
-    suspend fun shareTrack(track: TrackEntity): ShareResult {
+    suspend fun shareTrack(track: TrackEntity): ShareResult = coroutineScope {
         val subject = "${track.artist} – ${track.title}"
-        val urls = buildMap<String, String> {
-            track.spotifyId?.let { put("spotify", "https://open.spotify.com/track/$it") }
-            track.appleMusicId?.let { put("applemusic", "https://music.apple.com/song/$it") }
-            track.soundcloudId?.let { put("soundcloud", "https://soundcloud.com/$it") }
-        }
-        val smart = if (urls.isNotEmpty()) {
-            tryCreateSmartLink(
-                SmartLinkCreateRequest(
-                    title = track.title,
-                    artist = track.artist,
-                    albumArt = track.artworkUrl,
-                    type = "track",
-                    urls = urls,
-                )
-            )
-        } else null
-        val url = smart ?: deepLinkWrapper("play", "artist=${enc(track.artist)}&title=${enc(track.title)}")
-        return ShareResult(url, subject, smart != null)
+        val mbid = track.recordingMbid
+
+        // Fire entity-link + submit in parallel. Both AWAITED so the recipient's
+        // first click sees a fully-warmed Achordion page. Matches desktop's
+        // publishSmartLink behavior (parachord-desktop/app.js:13380+).
+        val entityLinkJob = async { tryFetchEntityLink(EntityType.Track, mbid) }
+        val submitJob = async { trySubmitForTrack(track, mbid) }
+        val entityUrl = entityLinkJob.await()
+        submitJob.await()
+
+        val url = entityUrl ?: trackLookupUrl(track.artist, track.title)
+        ShareResult(url, subject, isSmartLink = entityUrl != null)
     }
+
+    private suspend fun tryFetchEntityLink(type: EntityType, mbid: String?): String? {
+        if (mbid.isNullOrBlank()) return null
+        return try {
+            withTimeout(SMART_LINK_TIMEOUT_MS) {
+                achordionClient.fetchEntityLink(type, mbid)?.url
+            }
+        } catch (e: TimeoutCancellationException) {
+            Log.w(TAG, "fetchEntityLink timed out for $type mbid=$mbid")
+            null
+        } catch (e: Exception) {
+            Log.w(TAG, "fetchEntityLink failed for $type mbid=$mbid: ${e.message}")
+            null
+        }
+    }
+
+    private suspend fun trySubmitForTrack(track: TrackEntity, mbid: String?) {
+        if (mbid.isNullOrBlank()) return
+        val links = buildList {
+            track.spotifyId?.takeIf { it.isNotBlank() }?.let {
+                add(TrackLink(url = "https://open.spotify.com/track/$it", host = "spotify.com", label = "Spotify"))
+            }
+            track.appleMusicId?.takeIf { it.isNotBlank() }?.let {
+                add(TrackLink(url = "https://music.apple.com/song/$it", host = "music.apple.com", label = "Apple Music"))
+            }
+            track.soundcloudId?.takeIf { it.isNotBlank() }?.let {
+                add(TrackLink(url = "https://soundcloud.com/$it", host = "soundcloud.com", label = "SoundCloud"))
+            }
+        }
+        if (links.isEmpty()) return
+        try {
+            withTimeout(SMART_LINK_TIMEOUT_MS) {
+                achordionClient.submitTrackLinks(
+                    SubmitTrackLinksRequest(
+                        mbid = mbid,
+                        links = links,
+                        trackName = track.title,
+                        artistName = track.artist,
+                        albumName = track.album,
+                    )
+                )
+            }
+        } catch (e: TimeoutCancellationException) {
+            Log.w(TAG, "submitTrackLinks timed out for mbid=$mbid")
+        } catch (e: Exception) {
+            Log.w(TAG, "submitTrackLinks failed for mbid=$mbid: ${e.message}")
+        }
+    }
+
+    private fun trackLookupUrl(artist: String, title: String): String =
+        "https://achordion.xyz/recording/lookup?artist=${enc(artist)}&title=${enc(title)}"
 
     suspend fun shareAlbum(
         title: String,

--- a/app/src/main/java/com/parachord/android/share/ShareManager.kt
+++ b/app/src/main/java/com/parachord/android/share/ShareManager.kt
@@ -124,35 +124,17 @@ class ShareManager constructor(
     suspend fun shareAlbum(
         title: String,
         artist: String,
-        artworkUrl: String?,
-        tracks: List<PlaylistTrackEntity>,
-        spotifyAlbumId: String? = null,
+        @Suppress("UNUSED_PARAMETER") artworkUrl: String?, // kept for caller compat; unused after Achordion migration
+        releaseGroupMbid: String?,
     ): ShareResult {
         val subject = "$artist – $title"
-        val albumUrls = buildMap<String, String> {
-            spotifyAlbumId?.let { put("spotify", "https://open.spotify.com/album/$it") }
-        }
-        val smartTracks = tracks.map { it.toSmartLinkTrack() }
-        val smart = if (smartTracks.isNotEmpty() || albumUrls.isNotEmpty()) {
-            tryCreateSmartLink(
-                SmartLinkCreateRequest(
-                    title = title,
-                    artist = artist,
-                    albumArt = artworkUrl,
-                    type = "album",
-                    urls = albumUrls.takeIf { it.isNotEmpty() },
-                    tracks = smartTracks.ifEmpty { null },
-                )
-            )
-        } else null
-        val url = smart ?: deepLinkWrapper(
-            host = "album",
-            // Path segments: album/{artist}/{title}; both URL-encoded.
-            pathOrQuery = "/${enc(artist)}/${enc(title)}",
-            isPath = true,
-        )
-        return ShareResult(url, subject, smart != null)
+        val entityUrl = tryFetchEntityLink(EntityType.ReleaseGroup, releaseGroupMbid)
+        val url = entityUrl ?: releaseGroupLookupUrl(artist, title)
+        return ShareResult(url, subject, isSmartLink = entityUrl != null)
     }
+
+    private fun releaseGroupLookupUrl(artist: String, title: String): String =
+        "https://achordion.xyz/release-group/lookup?artist=${enc(artist)}&title=${enc(title)}"
 
     /**
      * Convenience for callsites that have a [playlistId] but no in-memory

--- a/app/src/main/java/com/parachord/android/share/ShareSheet.kt
+++ b/app/src/main/java/com/parachord/android/share/ShareSheet.kt
@@ -136,13 +136,17 @@ fun rememberSharePlaylistById(): (String) -> Unit {
 @Composable
 fun rememberShareArtist(): (name: String, imageUrl: String?) -> Unit {
     val context = LocalContext.current
+    val scope = rememberCoroutineScope()
     val shareManager: ShareManager = koinInject()
     return remember(context, shareManager) {
-        { name, imageUrl ->
-            // Artists go straight to the deeplink wrapper — no smart-link
-            // shape exists on desktop yet, so no network call is needed.
-            val result = shareManager.shareArtist(name, imageUrl)
-            openShareSheet(context, result.url, result.subject)
+        { name, _ ->
+            // imageUrl is no longer used — Achordion serves the artist page
+            // from name (or MBID, when plumbed through callers in a follow-up).
+            scope.launch {
+                val result = shareManager.shareArtist(name, artistMbid = null)
+                openShareSheet(context, result.url, result.subject)
+            }
+            Unit
         }
     }
 }

--- a/app/src/main/java/com/parachord/android/share/ShareSheet.kt
+++ b/app/src/main/java/com/parachord/android/share/ShareSheet.kt
@@ -33,10 +33,10 @@ fun openShareSheet(context: Context, url: String, subject: String) {
 }
 
 /**
- * Returns a callback that asynchronously builds a smart-link (or fallback
- * deeplink) for [track] and opens the system share sheet. Network call is
- * bounded by [ShareManager.SMART_LINK_TIMEOUT_MS] so the share-sheet delay
- * is at most a few seconds.
+ * Returns a callback that asynchronously builds a share URL (Achordion
+ * entity link with submit pre-warm — falling back to a lookup URL when
+ * the MBID is absent or the API times out) for [track] and opens the
+ * system share sheet. Internal 4 s timeout caps share-sheet delay.
  */
 @Composable
 fun rememberShareTrack(): (TrackEntity) -> Unit {

--- a/app/src/main/java/com/parachord/android/share/ShareSheet.kt
+++ b/app/src/main/java/com/parachord/android/share/ShareSheet.kt
@@ -66,9 +66,12 @@ fun rememberShareAlbum(): (
     val scope = rememberCoroutineScope()
     val shareManager: ShareManager = koinInject()
     return remember(context) {
-        { title, artist, artworkUrl, tracks, spotifyAlbumId ->
+        { title, artist, artworkUrl, _, _ ->
             scope.launch {
-                val result = shareManager.shareAlbum(title, artist, artworkUrl, tracks, spotifyAlbumId)
+                // releaseGroupMbid is not yet plumbed through callers — future follow-up
+                // to surface it from MetadataService results so Achordion serves the
+                // entity page directly instead of the lookup fallback.
+                val result = shareManager.shareAlbum(title, artist, artworkUrl, releaseGroupMbid = null)
                 openShareSheet(context, result.url, result.subject)
             }
             Unit

--- a/app/src/test/java/com/parachord/android/share/ShareManagerTest.kt
+++ b/app/src/test/java/com/parachord/android/share/ShareManagerTest.kt
@@ -132,6 +132,27 @@ class ShareManagerTest {
     }
 
     @Test
+    fun shareArtist_withMbid_callsEntityLinkOnly_noSubmit() = runTest {
+        val achordion = mockk<AchordionClient>()
+        coEvery { achordion.fetchEntityLink(EntityType.Artist, "artist-mbid-1", any()) } returns
+            EntityLink(url = "https://achordion.xyz/artist/slowdive")
+        val mgr = buildManager(achordion = achordion)
+        val result = mgr.shareArtist("Slowdive", artistMbid = "artist-mbid-1")
+        assertEquals("https://achordion.xyz/artist/slowdive", result.url)
+        assertTrue(result.isSmartLink)
+        coVerify(exactly = 0) { achordion.submitTrackLinks(any()) }
+    }
+
+    @Test
+    fun shareArtist_noMbid_returnsLookupFallback() = runTest {
+        val achordion = mockk<AchordionClient>(relaxed = true)
+        val mgr = buildManager(achordion = achordion)
+        val result = mgr.shareArtist("Slowdive", artistMbid = null)
+        assertEquals("https://achordion.xyz/artist/lookup?name=Slowdive", result.url)
+        assertFalse(result.isSmartLink)
+    }
+
+    @Test
     fun shareAlbum_withMbid_callsEntityLinkOnly_noSubmit() = runTest {
         val achordion = mockk<AchordionClient>()
         coEvery { achordion.fetchEntityLink(EntityType.ReleaseGroup, "rg-mbid-1", any()) } returns

--- a/app/src/test/java/com/parachord/android/share/ShareManagerTest.kt
+++ b/app/src/test/java/com/parachord/android/share/ShareManagerTest.kt
@@ -211,4 +211,36 @@ class ShareManagerTest {
         // ShareManager filters source-list at build time and skips submit when empty.
         coVerify(exactly = 0) { achordion.submitTrackLinks(any()) }
     }
+
+    @Test
+    fun sharePlaylist_unchanged_stillUsesSmartLinksClient_notAchordion() = runTest {
+        val achordion = mockk<AchordionClient>(relaxed = true)
+        val smartLinks = mockk<SmartLinksClient>(relaxed = true)
+        coEvery { smartLinks.create(any()) } returns com.parachord.shared.api.SmartLinkCreateResponse(
+            id = "abc123",
+            url = "https://go.parachord.com/abc123",
+        )
+
+        val playlistDao = mockk<PlaylistDao>()
+        val playlistTrackDao = mockk<PlaylistTrackDao>()
+        coEvery { playlistDao.getById("p1") } returns com.parachord.android.data.db.entity.PlaylistEntity(
+            id = "p1",
+            name = "My Playlist",
+            ownerName = "me",
+        )
+        coEvery { playlistTrackDao.getByPlaylistIdSync("p1") } returns emptyList()
+
+        val mgr = ShareManager(
+            smartLinksClient = smartLinks,
+            achordionClient = achordion,
+            playlistDao = playlistDao,
+            playlistTrackDao = playlistTrackDao,
+        )
+
+        val result = mgr.sharePlaylist("p1")
+        assertEquals("https://go.parachord.com/abc123", result?.url)
+        coVerify(exactly = 0) { achordion.fetchEntityLink(any(), any(), any()) }
+        coVerify(exactly = 0) { achordion.submitTrackLinks(any()) }
+        coVerify(exactly = 1) { smartLinks.create(any()) }
+    }
 }

--- a/app/src/test/java/com/parachord/android/share/ShareManagerTest.kt
+++ b/app/src/test/java/com/parachord/android/share/ShareManagerTest.kt
@@ -1,0 +1,145 @@
+package com.parachord.android.share
+
+import com.parachord.android.data.db.dao.PlaylistDao
+import com.parachord.android.data.db.dao.PlaylistTrackDao
+import com.parachord.android.data.db.entity.TrackEntity
+import com.parachord.shared.api.AchordionClient
+import com.parachord.shared.api.EntityLink
+import com.parachord.shared.api.EntityType
+import com.parachord.shared.api.SmartLinksClient
+import com.parachord.shared.api.SubmitResult
+import com.parachord.shared.api.SubmitTrackLinksRequest
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.mockk
+import io.mockk.slot
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import android.app.Application
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+@RunWith(RobolectricTestRunner::class)
+@Config(application = Application::class)
+class ShareManagerTest {
+
+    private fun buildManager(
+        achordion: AchordionClient = mockk(relaxed = true),
+        smartLinks: SmartLinksClient = mockk(relaxed = true),
+    ): ShareManager = ShareManager(
+        smartLinksClient = smartLinks,
+        achordionClient = achordion,
+        playlistDao = mockk(relaxed = true),
+        playlistTrackDao = mockk(relaxed = true),
+    )
+
+    private fun sampleTrack(
+        recordingMbid: String? = "550e8400-e29b-41d4-a716-446655440000",
+        spotifyId: String? = "SP123",
+        appleMusicId: String? = "AM456",
+        soundcloudId: String? = "user/track",
+    ) = TrackEntity(
+        id = "t1",
+        title = "Sugar For The Pill",
+        artist = "Slowdive",
+        album = "Slowdive",
+        recordingMbid = recordingMbid,
+        spotifyId = spotifyId,
+        appleMusicId = appleMusicId,
+        soundcloudId = soundcloudId,
+    )
+
+    @Test
+    fun shareTrack_withMbid_callsBothEntityLinkAndSubmit() = runTest {
+        val achordion = mockk<AchordionClient>()
+        coEvery { achordion.fetchEntityLink(EntityType.Track, "550e8400-e29b-41d4-a716-446655440000", any()) } returns
+            EntityLink(url = "https://achordion.xyz/recording/slowdive-sugar")
+        coEvery { achordion.submitTrackLinks(any()) } returns SubmitResult.Ok
+
+        val mgr = buildManager(achordion = achordion)
+        val result = mgr.shareTrack(sampleTrack())
+
+        assertEquals("https://achordion.xyz/recording/slowdive-sugar", result.url)
+        assertTrue(result.isSmartLink)
+        coVerify(exactly = 1) { achordion.fetchEntityLink(EntityType.Track, any(), any()) }
+        coVerify(exactly = 1) { achordion.submitTrackLinks(any()) }
+    }
+
+    @Test
+    fun shareTrack_withoutMbid_callsNeitherApi_returnsLookupFallback() = runTest {
+        val achordion = mockk<AchordionClient>(relaxed = true)
+        val mgr = buildManager(achordion = achordion)
+        val result = mgr.shareTrack(sampleTrack(recordingMbid = null))
+
+        assertEquals(
+            "https://achordion.xyz/recording/lookup?artist=Slowdive&title=Sugar%20For%20The%20Pill",
+            result.url,
+        )
+        assertFalse(result.isSmartLink)
+        coVerify(exactly = 0) { achordion.fetchEntityLink(any(), any(), any()) }
+        coVerify(exactly = 0) { achordion.submitTrackLinks(any()) }
+    }
+
+    @Test
+    fun shareTrack_entityLinkReturnsNull_returnsLookupFallback_butStillSubmits() = runTest {
+        val achordion = mockk<AchordionClient>()
+        coEvery { achordion.fetchEntityLink(any(), any(), any()) } returns null
+        coEvery { achordion.submitTrackLinks(any()) } returns SubmitResult.Ok
+
+        val mgr = buildManager(achordion = achordion)
+        val result = mgr.shareTrack(sampleTrack())
+
+        assertTrue(result.url.startsWith("https://achordion.xyz/recording/lookup?"))
+        assertFalse(result.isSmartLink)
+        coVerify(exactly = 1) { achordion.submitTrackLinks(any()) }
+    }
+
+    @Test
+    fun shareTrack_submitPayloadIncludesAllAvailableSourceUrls() = runTest {
+        val achordion = mockk<AchordionClient>()
+        coEvery { achordion.fetchEntityLink(any(), any(), any()) } returns null
+        val payloadSlot = slot<SubmitTrackLinksRequest>()
+        coEvery { achordion.submitTrackLinks(capture(payloadSlot)) } returns SubmitResult.Ok
+
+        val mgr = buildManager(achordion = achordion)
+        mgr.shareTrack(sampleTrack())
+
+        val payload = payloadSlot.captured
+        assertEquals("550e8400-e29b-41d4-a716-446655440000", payload.mbid)
+        assertEquals("Sugar For The Pill", payload.trackName)
+        assertEquals("Slowdive", payload.artistName)
+        assertEquals("Slowdive", payload.albumName)
+        val hosts = payload.links.map { it.host }.toSet()
+        assertEquals(setOf("spotify.com", "music.apple.com", "soundcloud.com"), hosts)
+    }
+
+    @Test
+    fun shareTrack_skipsSourceUrlsWithBlankIds() = runTest {
+        val achordion = mockk<AchordionClient>()
+        coEvery { achordion.fetchEntityLink(any(), any(), any()) } returns null
+        val payloadSlot = slot<SubmitTrackLinksRequest>()
+        coEvery { achordion.submitTrackLinks(capture(payloadSlot)) } returns SubmitResult.Ok
+
+        val mgr = buildManager(achordion = achordion)
+        mgr.shareTrack(sampleTrack(spotifyId = "SP", appleMusicId = "", soundcloudId = null))
+
+        val hosts = payloadSlot.captured.links.map { it.host }
+        assertEquals(listOf("spotify.com"), hosts)
+    }
+
+    @Test
+    fun shareTrack_noSourceIds_doesNotCallSubmit() = runTest {
+        val achordion = mockk<AchordionClient>()
+        coEvery { achordion.fetchEntityLink(any(), any(), any()) } returns null
+
+        val mgr = buildManager(achordion = achordion)
+        mgr.shareTrack(sampleTrack(spotifyId = null, appleMusicId = null, soundcloudId = null))
+
+        // ShareManager filters source-list at build time and skips submit when empty.
+        coVerify(exactly = 0) { achordion.submitTrackLinks(any()) }
+    }
+}

--- a/app/src/test/java/com/parachord/android/share/ShareManagerTest.kt
+++ b/app/src/test/java/com/parachord/android/share/ShareManagerTest.kt
@@ -132,6 +132,54 @@ class ShareManagerTest {
     }
 
     @Test
+    fun shareAlbum_withMbid_callsEntityLinkOnly_noSubmit() = runTest {
+        val achordion = mockk<AchordionClient>()
+        coEvery { achordion.fetchEntityLink(EntityType.ReleaseGroup, "rg-mbid-1", any()) } returns
+            EntityLink(url = "https://achordion.xyz/release-group/death-cab-tower")
+
+        val mgr = buildManager(achordion = achordion)
+        val result = mgr.shareAlbum(
+            title = "I Built You a Tower",
+            artist = "Death Cab for Cutie",
+            artworkUrl = null,
+            releaseGroupMbid = "rg-mbid-1",
+        )
+
+        assertEquals("https://achordion.xyz/release-group/death-cab-tower", result.url)
+        assertTrue(result.isSmartLink)
+        coVerify(exactly = 1) { achordion.fetchEntityLink(EntityType.ReleaseGroup, "rg-mbid-1", any()) }
+        coVerify(exactly = 0) { achordion.submitTrackLinks(any()) }
+    }
+
+    @Test
+    fun shareAlbum_noMbid_returnsLookupFallback() = runTest {
+        val achordion = mockk<AchordionClient>(relaxed = true)
+        val mgr = buildManager(achordion = achordion)
+        val result = mgr.shareAlbum(
+            title = "I Built You a Tower",
+            artist = "Death Cab for Cutie",
+            artworkUrl = null,
+            releaseGroupMbid = null,
+        )
+        assertEquals(
+            "https://achordion.xyz/release-group/lookup?artist=Death%20Cab%20for%20Cutie&title=I%20Built%20You%20a%20Tower",
+            result.url,
+        )
+        assertFalse(result.isSmartLink)
+        coVerify(exactly = 0) { achordion.fetchEntityLink(any(), any(), any()) }
+    }
+
+    @Test
+    fun shareAlbum_entityLinkFails_returnsLookupFallback() = runTest {
+        val achordion = mockk<AchordionClient>()
+        coEvery { achordion.fetchEntityLink(any(), any(), any()) } returns null
+        val mgr = buildManager(achordion = achordion)
+        val result = mgr.shareAlbum("Tower", "Death Cab", null, "rg-mbid-1")
+        assertTrue(result.url.contains("/release-group/lookup?"))
+        assertFalse(result.isSmartLink)
+    }
+
+    @Test
     fun shareTrack_noSourceIds_doesNotCallSubmit() = runTest {
         val achordion = mockk<AchordionClient>()
         coEvery { achordion.fetchEntityLink(any(), any(), any()) } returns null

--- a/docs/plans/2026-05-10-achordion-share-links-design.md
+++ b/docs/plans/2026-05-10-achordion-share-links-design.md
@@ -1,0 +1,308 @@
+# Achordion share links — design
+
+**Goal:** Migrate outbound Parachord-Android share URLs from `go.parachord.com/<id>` smart-links to Achordion entity pages (`achordion.xyz/<type>/<mbid>`), matching desktop's behavior in `parachord-desktop/app.js`'s `publishSmartLink` / `publishAlbumSmartLink` / `publishArtistSmartLink`. Track shares also pre-warm Achordion's cache via the `/api/track-links/submit` endpoint so recipients land on a fully-resolved entity page.
+
+**Architecture:** New shared `AchordionClient` (Ktor) wraps two HTTP endpoints. `ShareManager` (`:app`) drops its `SmartLinksClient` calls for track/album/artist and routes them through the new client. Playlists keep `SmartLinksClient` since Achordion has no playlist entity. Bearer token sourced from `AppConfig.achordionBearerToken` (BuildConfig field, sourced from `local.properties` + CI secret).
+
+**Tech stack:** Kotlin Multiplatform (`AchordionClient` in `shared/commonMain`, Ktor HTTP), Koin, mockk for tests, MockEngine for Ktor client tests.
+
+## Scope
+
+### In
+
+- New shared `AchordionClient` with `fetchEntityLink(type, mbid)` + `submitTrackLinks(payload)`.
+- `ShareManager.shareTrack` / `shareAlbum` / `shareArtist` rewritten to call `AchordionClient`.
+- Bearer token threaded through `AppConfig`.
+- Per-session dedup of submits + `authFailed` kill-switch (matches desktop plugin).
+- Tests: `AchordionClientTest` (shared, MockEngine), `ShareManagerTest` (`:app`, mockk).
+
+### Out
+
+- Playlist shares — stay on `SmartLinksClient` / `go.parachord.com`.
+- UI changes to share affordances — `ShareResult` shape unchanged.
+- Token rotation infra — the token is semi-public (desktop publishes it in `.axe` plugin); rotation when it happens is a manual coordinated bump across desktop / android / ios repos.
+- `fetchEmbedCode` (desktop has it; Android doesn't surface embeds yet).
+
+## Sections
+
+### 1. `AchordionClient` (shared, Ktor)
+
+**File:** `shared/src/commonMain/kotlin/com/parachord/shared/api/AchordionClient.kt`
+
+Two endpoints, both Bearer-token authenticated:
+
+- `GET https://achordion.xyz/api/entity-link?type={track|release-group|artist}&mbid={mbid}` (optional `&include=names`). Returns `{ url, embed_url?, name?, artist_name?, album_name? }`.
+- `POST https://achordion.xyz/api/track-links/submit` body `{ mbid, links: [{url, host, label?}], trackName?, artistName?, albumName? }`. Returns 200 on accept, 401 on bad token.
+
+Public surface:
+
+```kotlin
+class AchordionClient(
+    private val httpClient: HttpClient,
+    private val bearerToken: String,
+) {
+    suspend fun fetchEntityLink(
+        type: EntityType,
+        mbid: String,
+        includeNames: Boolean = false,
+    ): EntityLink?
+
+    suspend fun submitTrackLinks(payload: SubmitTrackLinksRequest): SubmitResult
+}
+
+enum class EntityType(val wireValue: String) {
+    Track("track"),
+    ReleaseGroup("release-group"),
+    Artist("artist");
+}
+
+@Serializable
+data class EntityLink(
+    val url: String,
+    @SerialName("embed_url") val embedUrl: String? = null,
+    val name: String? = null,
+    @SerialName("artist_name") val artistName: String? = null,
+    @SerialName("album_name") val albumName: String? = null,
+)
+
+@Serializable
+data class SubmitTrackLinksRequest(
+    val mbid: String,
+    val links: List<TrackLink>,
+    val trackName: String? = null,
+    val artistName: String? = null,
+    val albumName: String? = null,
+)
+
+@Serializable
+data class TrackLink(
+    val url: String,
+    val host: String,
+    val label: String? = null,
+)
+
+sealed class SubmitResult {
+    object Ok : SubmitResult()
+    object NoLinks : SubmitResult()
+    object AlreadySubmitted : SubmitResult()
+    object NoMbid : SubmitResult()
+    data class HttpError(val status: Int) : SubmitResult()
+    object AuthFailed : SubmitResult()
+    data class NetworkError(val message: String) : SubmitResult()
+}
+```
+
+Internal state:
+
+- `submittedThisSession: MutableSet<String>` — keyed by lowercased MBID. Prevents re-submitting the same recording within a single app lifetime. Mutex-protected (KMP rule: no `ConcurrentHashMap`).
+- `authFailed: AtomicBoolean` (using `kotlin.concurrent.atomics` or a plain `@Volatile Boolean`). Set on first 401 from either endpoint. Once set, all subsequent calls short-circuit returning `AuthFailed` without hitting the network.
+
+Both reset only on process restart. Matches desktop plugin's per-session model.
+
+### 2. `ShareManager` rewrite (`:app`)
+
+**File:** `app/src/main/java/com/parachord/android/share/ShareManager.kt`
+
+Replace the three Achordion-eligible methods. `sharePlaylist(...)` stays unchanged.
+
+```kotlin
+class ShareManager(
+    private val smartLinksClient: SmartLinksClient,   // playlists only
+    private val achordionClient: AchordionClient,     // NEW
+    private val playlistDao: PlaylistDao,
+    private val playlistTrackDao: PlaylistTrackDao,
+) {
+
+    suspend fun shareTrack(track: TrackEntity): ShareResult = coroutineScope {
+        val subject = "${track.artist} – ${track.title}"
+        val mbid = track.recordingMbid
+        // Fire entity-link + submit in parallel. Both awaited so the
+        // recipient's first click sees a fully-warmed Achordion page.
+        val entityLinkJob = async { tryFetchEntityLink(EntityType.Track, mbid) }
+        val submitJob = async { trySubmitForTrack(track, mbid) }
+        val entityUrl = entityLinkJob.await()
+        submitJob.await()
+        val url = entityUrl ?: trackLookupUrl(track.artist, track.title)
+        ShareResult(url, subject, isSmartLink = entityUrl != null)
+    }
+
+    suspend fun shareAlbum(
+        title: String,
+        artist: String,
+        artworkUrl: String?,  // unused now, kept for caller compat
+        releaseGroupMbid: String?,
+    ): ShareResult {
+        val entityUrl = tryFetchEntityLink(EntityType.ReleaseGroup, releaseGroupMbid)
+        val url = entityUrl ?: releaseGroupLookupUrl(artist, title)
+        return ShareResult(url, "$artist – $title", isSmartLink = entityUrl != null)
+    }
+
+    fun shareArtist(name: String, artistMbid: String? = null): ShareResult {
+        // No suspend wrapper — entity-link API is async but artist share
+        // is fire-and-forget on the API side; let the caller decide
+        // whether to await. Actually, since callers always go through
+        // suspend context, just make it suspend too:
+    }
+
+    suspend fun shareArtist(name: String, artistMbid: String? = null): ShareResult {
+        val entityUrl = tryFetchEntityLink(EntityType.Artist, artistMbid)
+        val url = entityUrl ?: artistLookupUrl(name)
+        return ShareResult(url, name, isSmartLink = entityUrl != null)
+    }
+
+    // sharePlaylist unchanged
+}
+```
+
+**Internal helpers:**
+
+```kotlin
+private suspend fun tryFetchEntityLink(type: EntityType, mbid: String?): String? {
+    if (mbid.isNullOrBlank()) return null
+    return try {
+        withTimeout(SMART_LINK_TIMEOUT_MS) {
+            achordionClient.fetchEntityLink(type, mbid)?.url
+        }
+    } catch (e: TimeoutCancellationException) {
+        Log.w(TAG, "fetchEntityLink timed out for $type mbid=$mbid")
+        null
+    } catch (e: Exception) {
+        Log.w(TAG, "fetchEntityLink failed for $type mbid=$mbid: ${e.message}")
+        null
+    }
+}
+
+private suspend fun trySubmitForTrack(track: TrackEntity, mbid: String?) {
+    if (mbid.isNullOrBlank()) return   // Section 3 gate: no MBID → no submit
+    val links = buildList {
+        track.spotifyId?.takeIf { it.isNotBlank() }?.let {
+            add(TrackLink(url = "https://open.spotify.com/track/$it", host = "spotify.com", label = "Spotify"))
+        }
+        track.appleMusicId?.takeIf { it.isNotBlank() }?.let {
+            add(TrackLink(url = "https://music.apple.com/song/$it", host = "music.apple.com", label = "Apple Music"))
+        }
+        track.soundcloudId?.takeIf { it.isNotBlank() }?.let {
+            add(TrackLink(url = "https://soundcloud.com/$it", host = "soundcloud.com", label = "SoundCloud"))
+        }
+    }
+    if (links.isEmpty()) return
+    try {
+        withTimeout(SMART_LINK_TIMEOUT_MS) {
+            achordionClient.submitTrackLinks(
+                SubmitTrackLinksRequest(
+                    mbid = mbid,
+                    links = links,
+                    trackName = track.title,
+                    artistName = track.artist,
+                    albumName = track.album,
+                )
+            )
+        }
+    } catch (e: TimeoutCancellationException) {
+        Log.w(TAG, "submitTrackLinks timed out for mbid=$mbid")
+    } catch (e: Exception) {
+        Log.w(TAG, "submitTrackLinks failed for mbid=$mbid: ${e.message}")
+    }
+}
+
+private fun trackLookupUrl(artist: String, title: String): String =
+    "https://achordion.xyz/recording/lookup?artist=${enc(artist)}&title=${enc(title)}"
+
+private fun releaseGroupLookupUrl(artist: String, title: String): String =
+    "https://achordion.xyz/release-group/lookup?artist=${enc(artist)}&title=${enc(title)}"
+
+private fun artistLookupUrl(name: String): String =
+    "https://achordion.xyz/artist/lookup?name=${enc(name)}"
+```
+
+### 3. Confidence gate (Section 3 decision)
+
+Submit fires when `track.recordingMbid` is non-null AND at least one streaming ID is non-blank. No per-source confidence threading — the MBID presence is the proxy gate.
+
+Rationale: `MbidEnrichmentService` only stamps `recordingMbid` when the ListenBrainz mapper returns a confident match, which correlates strongly with the per-resolver IDs being correct. Wrong-song submits are theoretically possible but low-probability; if they appear in practice, follow-up issue threads `TrackResolverCache` confidence into the gate.
+
+### 4. Bearer token via `AppConfig`
+
+**Files modified:**
+
+- `shared/src/commonMain/kotlin/com/parachord/shared/config/AppConfig.kt` — add `val achordionBearerToken: String`.
+- `app/build.gradle.kts` — add `buildConfigField("String", "ACHORDION_BEARER_TOKEN", "\"${localProp("ACHORDION_BEARER_TOKEN")}\"")`. Default to empty string when absent.
+- `app/src/main/java/com/parachord/android/di/AndroidModule.kt` — populate `AppConfig.achordionBearerToken = BuildConfig.ACHORDION_BEARER_TOKEN` in the `AppConfig` factory.
+- `shared/src/commonMain/kotlin/com/parachord/shared/di/SharedModule.kt` — wire `AchordionClient` Koin binding with `bearerToken = get<AppConfig>().achordionBearerToken`.
+- `.github/workflows/build.yml` — surface `ACHORDION_BEARER_TOKEN` from CI secret to `local.properties` (same pattern as `LASTFM_API_KEY`).
+- `local.properties` — local developers add `ACHORDION_BEARER_TOKEN=parachord_…` if they want submit/entity-link to work in dev builds. Without the line, the token is empty and `AchordionClient` no-ops (returns null entity links, returns `AuthFailed` from `submitTrackLinks` — Section 1 short-circuit). Falls through cleanly to lookup URLs; share still works, just without pre-warm or canonical-slug URLs.
+
+The published token (matching desktop's `.axe` plugin): `parachord_rgOgj2trN2KeIovar9DYA-yOCRkxgO6KlSyAo_jHtgg`.
+
+### 5. `SmartLinksClient` disposition
+
+Keep `SmartLinksClient` as-is. Update its class kdoc to: "Playlist shares only — track/album/artist migrated to Achordion as of 0.6.x; this client is retained for playlists since Achordion has no playlist entity page." No Koin removal, no test changes.
+
+### 6. Tests
+
+#### `AchordionClientTest` (shared, MockEngine)
+
+```kotlin
+class AchordionClientTest {
+    @Test fun fetchEntityLink_returnsCanonicalUrl_whenApiReturns200() = runTest { … }
+    @Test fun fetchEntityLink_returnsNull_on404() = runTest { … }
+    @Test fun fetchEntityLink_returnsNull_onMalformedResponse() = runTest { … }
+    @Test fun fetchEntityLink_sendsBearerTokenInAuthHeader() = runTest { … }
+    @Test fun fetchEntityLink_encodesMbidInQueryString() = runTest { … }
+    @Test fun submitTrackLinks_returnsOk_whenApiReturns200() = runTest { … }
+    @Test fun submitTrackLinks_returnsAlreadySubmitted_onSecondCallSameMbid() = runTest { … }
+    @Test fun submitTrackLinks_dedupKeyIsLowercaseMbid() = runTest { … }
+    @Test fun submitTrackLinks_returnsAuthFailed_on401() = runTest { … }
+    @Test fun submitTrackLinks_authFailedShortCircuitsSubsequentCalls() = runTest { … }
+    @Test fun submitTrackLinks_returnsNoLinks_whenLinksListIsEmpty() = runTest { … }
+    @Test fun submitTrackLinks_sendsBearerTokenAndJsonBody() = runTest { … }
+}
+```
+
+#### `ShareManagerTest` (`:app`, mockk)
+
+```kotlin
+class ShareManagerTest {
+    @Test fun shareTrack_withMbid_callsBothEntityLinkAndSubmit_inParallel() = runTest { … }
+    @Test fun shareTrack_withoutMbid_callsNeitherApi_returnsLookupFallback() = runTest { … }
+    @Test fun shareTrack_entityLinkFails_returnsLookupFallback_butStillCallsSubmit() = runTest { … }
+    @Test fun shareTrack_submitFails_doesNotBlockReturn() = runTest { … }
+    @Test fun shareTrack_awaitsBothBeforeReturning_orderCheck() = runTest { … }
+    @Test fun shareAlbum_callsEntityLinkOnly_noSubmit() = runTest { … }
+    @Test fun shareAlbum_noMbid_returnsLookupFallback() = runTest { … }
+    @Test fun shareArtist_callsEntityLinkOnly_noSubmit() = runTest { … }
+    @Test fun shareArtist_noMbid_returnsLookupFallback() = runTest { … }
+    @Test fun sharePlaylist_unchanged_stillUsesSmartLinksClient() = runTest { … }
+}
+```
+
+### 7. UI / surface
+
+No UI changes. `ShareResult(url, subject, isSmartLink)` shape unchanged. All callsites (`TrackContextMenuHost`, `rememberShareTrack`, `rememberShareAlbumLite`, `rememberShareArtist`, `rememberSharePlaylist`, `rememberSharePlaylistById`) keep working unchanged. The `isSmartLink` boolean is computed differently now (true when the Achordion entity-link API returned a canonical URL; false when we fell through to the lookup URL) but its semantic stays "did we get the nice URL or the fallback".
+
+### 8. Callsite updates
+
+Search for callers passing the old shape to `ShareManager.shareAlbum` (currently takes `tracks: List<PlaylistTrackEntity>, spotifyAlbumId: String?`) and update to the new signature. Expected callers per CLAUDE.md "Outbound Sharing (Smart Links)":
+
+- `ui/components/AlbumContextMenu.kt` (via `rememberShareAlbumLite` / rich variant)
+- `ui/screens/album/AlbumDetailScreen.kt`
+- Any other album-share entry point
+
+The `tracks` and `spotifyAlbumId` parameters get dropped from `shareAlbum`'s signature; callers that pass them today need updating. `releaseGroupMbid: String?` is added. Most album entities should already carry an MBID via `AlbumEntity.mbid` — confirm at implementation time which field holds it.
+
+Same drill for `shareArtist` — currently `(name: String, imageUrl: String? = null)`, becomes `(name: String, artistMbid: String? = null)`. `imageUrl` was unused in the existing `shareArtist` body anyway.
+
+## Risk notes
+
+- **Token leakage in CI logs.** Workflow must mask the secret. Use `${{ secrets.ACHORDION_BEARER_TOKEN }}` and don't `echo` it. Same pattern as `LASTFM_API_KEY`.
+- **API drift.** Achordion's `/api/entity-link` response shape is what desktop plugin parses today. If Achordion changes it, both desktop and android need updating. Worth filing a cross-repo "API contract" note in achordion's AGENTS.md.
+- **Submit gate too lax.** Section 3's MBID-only gate may submit wrong-song matches occasionally. Mitigation: file a follow-up to thread `TrackResolverCache` confidence into the gate if Achordion's match cache shows drift.
+- **Timeout budget.** Share sheet must open within ~500ms of tap to feel responsive. The 4s `SMART_LINK_TIMEOUT_MS` is a worst case for entity-link + submit. Recipient experience is better with the wait, but consider showing a "Copying…" ack toast during the wait (we already have `DeepLinkNavEvent.Toast.longDuration` from Phase 3 polish — reusable here).
+
+## Cross-refs
+
+- Parachord-Android #137 — Compose Snackbar (overlap if we add a "Copying…" ack)
+- jherskowitz/achordion#54 — unrelated share concern (Mode C-inline shrink)
+- Achordion AGENTS.md § "Track-links submission" — the submit endpoint contract this design depends on
+- `parachord-desktop/plugins/achordion.axe` — reference implementation for the submit + entity-link client
+- `parachord-desktop/app.js` lines 13367–13635 — `publishSmartLink` / `publishAlbumSmartLink` / `publishArtistSmartLink` (desktop parity reference)

--- a/docs/plans/2026-05-10-achordion-share-links.md
+++ b/docs/plans/2026-05-10-achordion-share-links.md
@@ -1,0 +1,1561 @@
+# Achordion share-links Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Migrate outbound share URLs (track/album/artist) from `go.parachord.com` smart-links to Achordion entity pages, with track-share submit pre-warm matching desktop's `publishSmartLink`.
+
+**Architecture:** New shared `AchordionClient` (Ktor) wraps `/api/entity-link` + `/api/track-links/submit`. `ShareManager` calls it instead of `SmartLinksClient` for the three migrated types. Playlists keep the existing smart-link path. Bearer token threads through `AppConfig` from a new `ACHORDION_BEARER_TOKEN` BuildConfig field.
+
+**Tech Stack:** Kotlin Multiplatform (commonMain), Ktor, kotlinx.serialization, kotlinx.coroutines (Mutex), Koin, mockk, Ktor MockEngine. Per CLAUDE.md "KMP rules": no `Dispatchers.IO` / `java.*` in commonMain; use `kotlinx.coroutines.sync.Mutex` for shared mutable state instead of `ConcurrentHashMap`/`@Volatile` for compound writes.
+
+**Design doc:** [`docs/plans/2026-05-10-achordion-share-links-design.md`](2026-05-10-achordion-share-links-design.md) — read first for context (URL shapes, submit gate, token rationale, risk notes).
+
+---
+
+## Task 0: Baseline + scoping reads
+
+**Step 1:** Confirm branch is `feature/achordion-share-links` off main.
+
+Run: `git status && git log --oneline -1`
+Expected: `On branch feature/achordion-share-links` / first line shows the design-doc commit `e13af49`.
+
+**Step 2:** Confirm baseline tests pass.
+
+Run: `./gradlew :app:testDebugUnitTest :shared:testDebugUnitTest`
+Expected: BUILD SUCCESSFUL.
+
+**Step 3:** Read three reference files cold so the rest of the plan refers to them by line number:
+
+- [`shared/src/commonMain/kotlin/com/parachord/shared/api/MusicBrainzClient.kt`](shared/src/commonMain/kotlin/com/parachord/shared/api/MusicBrainzClient.kt) — shape reference for the new `AchordionClient` (same Ktor client patterns).
+- [`shared/src/commonTest/kotlin/com/parachord/shared/api/MusicBrainzClientTest.kt`](shared/src/commonTest/kotlin/com/parachord/shared/api/MusicBrainzClientTest.kt) — MockEngine test pattern.
+- [`parachord-desktop/plugins/achordion.axe`](../../../parachord-desktop/plugins/achordion.axe) (if you have desktop checked out at `~/Development/parachord/parachord-desktop/`) — reference implementation. The plugin's `submit`, `fetchEntityLink`, and the dedup/auth-failed kill-switch semantics are what we're porting.
+
+No commit; this is read-only orientation.
+
+---
+
+## Task 1: `AchordionClient` — types + skeleton
+
+**Files:**
+- Create: `shared/src/commonMain/kotlin/com/parachord/shared/api/AchordionClient.kt`
+
+This commit lands ONLY the types + a skeleton client (constructor + companion + empty methods returning placeholder values). Tests + behavior follow in subsequent tasks.
+
+**Step 1:** Create the file with types + skeleton.
+
+```kotlin
+// shared/src/commonMain/kotlin/com/parachord/shared/api/AchordionClient.kt
+package com.parachord.shared.api
+
+import com.parachord.shared.platform.Log
+import io.ktor.client.HttpClient
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.Json
+
+/**
+ * Client for the Achordion entity-link + submit-track-links APIs.
+ *
+ * Two endpoints, both Bearer-token authenticated:
+ *
+ *  - `GET /api/entity-link?type={track|release-group|artist}&mbid={mbid}` —
+ *    returns the canonical Achordion entity URL (possibly a slug-based
+ *    redirect target) plus optional names. Used to mint share URLs.
+ *  - `POST /api/track-links/submit` — pre-warms Achordion's match cache
+ *    with the sharer's resolved per-service URLs (Spotify/Apple/SoundCloud)
+ *    so the recipient lands on a fully-populated entity page on first click.
+ *
+ * Per-session dedup: an MBID submitted once won't re-submit until the
+ * process restarts. Matches desktop's `submittedThisSession` in
+ * `plugins/achordion.axe`.
+ *
+ * `authFailed` kill-switch: once any call returns 401, subsequent calls
+ * short-circuit without hitting the network until process restart.
+ *
+ * KMP-clean (commonMain). Token is sourced from [com.parachord.shared.config.AppConfig.achordionBearerToken]
+ * which carries an empty string when not configured — empty-token calls
+ * short-circuit as [SubmitResult.AuthFailed] / null entity links.
+ */
+class AchordionClient(
+    private val httpClient: HttpClient,
+    private val bearerToken: String,
+) {
+    companion object {
+        private const val TAG = "AchordionClient"
+        private const val ENTITY_LINK_ENDPOINT = "https://achordion.xyz/api/entity-link"
+        private const val SUBMIT_ENDPOINT = "https://achordion.xyz/api/track-links/submit"
+        private val json = Json { ignoreUnknownKeys = true; encodeDefaults = false }
+    }
+
+    private val dedupMutex = Mutex()
+    private val submittedThisSession: MutableSet<String> = mutableSetOf()
+    @Volatile private var authFailed: Boolean = false
+
+    suspend fun fetchEntityLink(
+        type: EntityType,
+        mbid: String,
+        includeNames: Boolean = false,
+    ): EntityLink? {
+        TODO("Task 2")
+    }
+
+    suspend fun submitTrackLinks(payload: SubmitTrackLinksRequest): SubmitResult {
+        TODO("Task 3")
+    }
+}
+
+enum class EntityType(val wireValue: String) {
+    Track("track"),
+    ReleaseGroup("release-group"),
+    Artist("artist"),
+}
+
+@Serializable
+data class EntityLink(
+    val url: String,
+    @SerialName("embed_url") val embedUrl: String? = null,
+    val name: String? = null,
+    @SerialName("artist_name") val artistName: String? = null,
+    @SerialName("album_name") val albumName: String? = null,
+)
+
+@Serializable
+data class SubmitTrackLinksRequest(
+    val mbid: String,
+    val links: List<TrackLink>,
+    val trackName: String? = null,
+    val artistName: String? = null,
+    val albumName: String? = null,
+)
+
+@Serializable
+data class TrackLink(
+    val url: String,
+    val host: String,
+    val label: String? = null,
+)
+
+sealed class SubmitResult {
+    object Ok : SubmitResult()
+    object NoLinks : SubmitResult()
+    object AlreadySubmitted : SubmitResult()
+    object NoMbid : SubmitResult()
+    data class HttpError(val status: Int) : SubmitResult()
+    object AuthFailed : SubmitResult()
+    data class NetworkError(val message: String) : SubmitResult()
+}
+```
+
+**Step 2:** Compile.
+
+Run: `./gradlew :shared:compileDebugKotlinAndroid :shared:compileKotlinIosArm64 :shared:compileKotlinIosSimulatorArm64`
+Expected: BUILD SUCCESSFUL. (TODO bodies compile; they just throw at runtime — Tasks 2+3 replace them.)
+
+**Step 3:** Commit.
+
+```bash
+git add shared/src/commonMain/kotlin/com/parachord/shared/api/AchordionClient.kt
+git commit -m "$(cat <<'EOF'
+api: AchordionClient skeleton — types + empty methods (#share-links)
+
+Lays the public surface (EntityType, EntityLink, SubmitTrackLinksRequest,
+TrackLink, SubmitResult) and the constructor. Methods are TODO bodies;
+behavior follows in subsequent commits.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 2: `fetchEntityLink` implementation + tests
+
+**Files:**
+- Create: `shared/src/commonTest/kotlin/com/parachord/shared/api/AchordionClientTest.kt`
+- Modify: `shared/src/commonMain/kotlin/com/parachord/shared/api/AchordionClient.kt`
+
+TDD: tests first, then implementation.
+
+**Step 1: Write the failing tests.**
+
+```kotlin
+// shared/src/commonTest/kotlin/com/parachord/shared/api/AchordionClientTest.kt
+package com.parachord.shared.api
+
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.mock.MockEngine
+import io.ktor.client.engine.mock.respond
+import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.headersOf
+import io.ktor.serialization.kotlinx.json.json
+import kotlinx.coroutines.test.runTest
+import kotlinx.serialization.json.Json
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+class AchordionClientTest {
+
+    private val json = Json { ignoreUnknownKeys = true }
+
+    private fun buildClient(engine: MockEngine, token: String = "test-token"): AchordionClient {
+        val httpClient = HttpClient(engine) {
+            install(ContentNegotiation) { json(json) }
+        }
+        return AchordionClient(httpClient, token)
+    }
+
+    // ── fetchEntityLink ─────────────────────────────────────────────
+
+    @Test
+    fun fetchEntityLink_returnsCanonicalUrl_whenApiReturns200() = runTest {
+        val engine = MockEngine { _ ->
+            respond(
+                content = """{"url":"https://achordion.xyz/recording/slowdive-sugar","name":"Sugar For The Pill"}""",
+                status = HttpStatusCode.OK,
+                headers = headersOf("Content-Type", "application/json"),
+            )
+        }
+        val client = buildClient(engine)
+        val result = client.fetchEntityLink(EntityType.Track, "abc-mbid")
+        assertEquals("https://achordion.xyz/recording/slowdive-sugar", result?.url)
+        assertEquals("Sugar For The Pill", result?.name)
+    }
+
+    @Test
+    fun fetchEntityLink_returnsNull_on404() = runTest {
+        val engine = MockEngine { _ ->
+            respond(content = """{"error":"Not Found"}""", status = HttpStatusCode.NotFound)
+        }
+        val client = buildClient(engine)
+        assertNull(client.fetchEntityLink(EntityType.Track, "abc-mbid"))
+    }
+
+    @Test
+    fun fetchEntityLink_returnsNull_onMalformedResponse() = runTest {
+        val engine = MockEngine { _ ->
+            respond(content = """{"unexpected":"shape"}""", status = HttpStatusCode.OK,
+                    headers = headersOf("Content-Type", "application/json"))
+        }
+        val client = buildClient(engine)
+        // SerializationException on missing required `url` field → swallowed → null.
+        assertNull(client.fetchEntityLink(EntityType.Track, "abc-mbid"))
+    }
+
+    @Test
+    fun fetchEntityLink_sendsBearerTokenInAuthHeader() = runTest {
+        var seenAuth: String? = null
+        val engine = MockEngine { req ->
+            seenAuth = req.headers["Authorization"]
+            respond("""{"url":"https://achordion.xyz/recording/x"}""", HttpStatusCode.OK,
+                    headersOf("Content-Type", "application/json"))
+        }
+        val client = buildClient(engine, token = "secret-bearer")
+        client.fetchEntityLink(EntityType.Track, "abc-mbid")
+        assertEquals("Bearer secret-bearer", seenAuth)
+    }
+
+    @Test
+    fun fetchEntityLink_encodesMbidAndTypeInQueryString() = runTest {
+        var seenUrl: String? = null
+        val engine = MockEngine { req ->
+            seenUrl = req.url.toString()
+            respond("""{"url":"https://achordion.xyz/release-group/x"}""", HttpStatusCode.OK,
+                    headersOf("Content-Type", "application/json"))
+        }
+        val client = buildClient(engine)
+        client.fetchEntityLink(EntityType.ReleaseGroup, "554b417d-8885-41e6-86c7-ae935e62d571")
+        val url = checkNotNull(seenUrl)
+        assertEquals(true, url.startsWith("https://achordion.xyz/api/entity-link?"))
+        assertEquals(true, url.contains("type=release-group"))
+        assertEquals(true, url.contains("mbid=554b417d-8885-41e6-86c7-ae935e62d571"))
+    }
+
+    @Test
+    fun fetchEntityLink_includeNamesAddsQueryParam() = runTest {
+        var seenUrl: String? = null
+        val engine = MockEngine { req ->
+            seenUrl = req.url.toString()
+            respond("""{"url":"https://achordion.xyz/x"}""", HttpStatusCode.OK,
+                    headersOf("Content-Type", "application/json"))
+        }
+        val client = buildClient(engine)
+        client.fetchEntityLink(EntityType.Track, "abc", includeNames = true)
+        assertEquals(true, seenUrl?.contains("include=names"))
+    }
+
+    @Test
+    fun fetchEntityLink_emptyToken_returnsNull_doesNotHitNetwork() = runTest {
+        var calls = 0
+        val engine = MockEngine { _ ->
+            calls += 1
+            respond("""{"url":"x"}""", HttpStatusCode.OK)
+        }
+        val client = buildClient(engine, token = "")
+        assertNull(client.fetchEntityLink(EntityType.Track, "abc"))
+        assertEquals(0, calls)
+    }
+
+    @Test
+    fun fetchEntityLink_after401_subsequentCallsShortCircuit() = runTest {
+        var calls = 0
+        val engine = MockEngine { _ ->
+            calls += 1
+            respond(content = "", status = HttpStatusCode.Unauthorized)
+        }
+        val client = buildClient(engine)
+        assertNull(client.fetchEntityLink(EntityType.Track, "first"))
+        assertNull(client.fetchEntityLink(EntityType.Track, "second"))
+        assertNull(client.fetchEntityLink(EntityType.Track, "third"))
+        assertEquals(1, calls)   // only the first call hits the network
+    }
+}
+```
+
+**Step 2: Run the tests to confirm they fail.**
+
+Run: `./gradlew :shared:testDebugUnitTest --tests "*AchordionClient*"`
+Expected: FAIL — all eight tests fail with `NotImplementedError` (from the `TODO()` body).
+
+**Step 3: Implement `fetchEntityLink`.**
+
+Replace the `TODO("Task 2")` body in `AchordionClient.kt` with:
+
+```kotlin
+suspend fun fetchEntityLink(
+    type: EntityType,
+    mbid: String,
+    includeNames: Boolean = false,
+): EntityLink? {
+    if (bearerToken.isBlank()) return null
+    if (authFailed) return null
+    return try {
+        val response = httpClient.get(ENTITY_LINK_ENDPOINT) {
+            parameter("type", type.wireValue)
+            parameter("mbid", mbid)
+            if (includeNames) parameter("include", "names")
+            header(HttpHeaders.Authorization, "Bearer $bearerToken")
+            accept(ContentType.Application.Json)
+        }
+        when (response.status) {
+            HttpStatusCode.Unauthorized -> {
+                authFailed = true
+                Log.w(TAG, "entity-link returned 401 — suppressing further calls this session")
+                null
+            }
+            HttpStatusCode.OK -> {
+                val body = response.bodyAsText()
+                json.decodeFromString<EntityLink>(body)
+            }
+            else -> {
+                Log.w(TAG, "entity-link returned HTTP ${response.status.value} for $type mbid=$mbid")
+                null
+            }
+        }
+    } catch (e: kotlinx.coroutines.CancellationException) {
+        throw e
+    } catch (e: Throwable) {
+        Log.w(TAG, "entity-link failed for $type mbid=$mbid: ${e.message}")
+        null
+    }
+}
+```
+
+Add imports:
+
+```kotlin
+import io.ktor.client.request.accept
+import io.ktor.client.request.get
+import io.ktor.client.request.header
+import io.ktor.client.request.parameter
+import io.ktor.client.statement.bodyAsText
+import io.ktor.http.ContentType
+import io.ktor.http.HttpHeaders
+import io.ktor.http.HttpStatusCode
+```
+
+**Step 4: Run the tests, confirm green.**
+
+Run: `./gradlew :shared:testDebugUnitTest --tests "*AchordionClient*"`
+Expected: PASS — 8/8.
+
+**Step 5: Commit.**
+
+```bash
+git add shared/src/commonMain/kotlin/com/parachord/shared/api/AchordionClient.kt \
+        shared/src/commonTest/kotlin/com/parachord/shared/api/AchordionClientTest.kt
+git commit -m "$(cat <<'EOF'
+api: AchordionClient.fetchEntityLink + 8 MockEngine tests (#share-links)
+
+Resolves a Bearer-authenticated GET against /api/entity-link to the
+canonical Achordion entity URL. Empty token short-circuits without
+hitting the network (covers debug builds without local.properties).
+First 401 trips an authFailed kill-switch so subsequent calls
+short-circuit too — matches desktop plugin's per-session model.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 3: `submitTrackLinks` implementation + tests
+
+**Files:**
+- Modify: `shared/src/commonTest/kotlin/com/parachord/shared/api/AchordionClientTest.kt`
+- Modify: `shared/src/commonMain/kotlin/com/parachord/shared/api/AchordionClient.kt`
+
+**Step 1: Add tests below the existing fetchEntityLink block.**
+
+```kotlin
+// ── submitTrackLinks ────────────────────────────────────────────
+
+private val sampleRequest = SubmitTrackLinksRequest(
+    mbid = "abc-mbid-123",
+    links = listOf(
+        TrackLink(url = "https://open.spotify.com/track/X", host = "spotify.com", label = "Spotify"),
+    ),
+    trackName = "Song",
+    artistName = "Artist",
+    albumName = "Album",
+)
+
+@Test
+fun submitTrackLinks_returnsOk_whenApiReturns200() = runTest {
+    val engine = MockEngine { _ -> respond("", HttpStatusCode.OK) }
+    val client = buildClient(engine)
+    assertEquals(SubmitResult.Ok, client.submitTrackLinks(sampleRequest))
+}
+
+@Test
+fun submitTrackLinks_returnsNoLinks_whenLinksListIsEmpty() = runTest {
+    val engine = MockEngine { _ -> error("should not be called") }
+    val client = buildClient(engine)
+    val result = client.submitTrackLinks(sampleRequest.copy(links = emptyList()))
+    assertEquals(SubmitResult.NoLinks, result)
+}
+
+@Test
+fun submitTrackLinks_returnsNoMbid_whenMbidIsBlank() = runTest {
+    val engine = MockEngine { _ -> error("should not be called") }
+    val client = buildClient(engine)
+    val result = client.submitTrackLinks(sampleRequest.copy(mbid = ""))
+    assertEquals(SubmitResult.NoMbid, result)
+}
+
+@Test
+fun submitTrackLinks_returnsAlreadySubmitted_onSecondCallSameMbid() = runTest {
+    val engine = MockEngine { _ -> respond("", HttpStatusCode.OK) }
+    val client = buildClient(engine)
+    assertEquals(SubmitResult.Ok, client.submitTrackLinks(sampleRequest))
+    assertEquals(SubmitResult.AlreadySubmitted, client.submitTrackLinks(sampleRequest))
+}
+
+@Test
+fun submitTrackLinks_dedupKeyIsLowercaseMbid() = runTest {
+    val engine = MockEngine { _ -> respond("", HttpStatusCode.OK) }
+    val client = buildClient(engine)
+    client.submitTrackLinks(sampleRequest.copy(mbid = "ABC-MBID-123"))
+    val second = client.submitTrackLinks(sampleRequest.copy(mbid = "abc-mbid-123"))
+    assertEquals(SubmitResult.AlreadySubmitted, second)
+}
+
+@Test
+fun submitTrackLinks_returnsAuthFailed_on401() = runTest {
+    val engine = MockEngine { _ -> respond("", HttpStatusCode.Unauthorized) }
+    val client = buildClient(engine)
+    assertEquals(SubmitResult.AuthFailed, client.submitTrackLinks(sampleRequest))
+}
+
+@Test
+fun submitTrackLinks_authFailedShortCircuitsSubsequentCalls() = runTest {
+    var calls = 0
+    val engine = MockEngine { _ ->
+        calls += 1
+        respond("", HttpStatusCode.Unauthorized)
+    }
+    val client = buildClient(engine)
+    client.submitTrackLinks(sampleRequest)
+    val again = client.submitTrackLinks(sampleRequest.copy(mbid = "different-mbid"))
+    assertEquals(SubmitResult.AuthFailed, again)
+    assertEquals(1, calls)   // only the first call hits the network
+}
+
+@Test
+fun submitTrackLinks_returnsHttpError_onOther4xx() = runTest {
+    val engine = MockEngine { _ -> respond("", HttpStatusCode.UnprocessableEntity) }
+    val client = buildClient(engine)
+    val result = client.submitTrackLinks(sampleRequest)
+    assertEquals(SubmitResult.HttpError(422), result)
+}
+
+@Test
+fun submitTrackLinks_sendsBearerTokenAndJsonBody() = runTest {
+    var seenAuth: String? = null
+    var seenContentType: String? = null
+    val engine = MockEngine { req ->
+        seenAuth = req.headers["Authorization"]
+        seenContentType = req.headers["Content-Type"]
+        respond("", HttpStatusCode.OK)
+    }
+    val client = buildClient(engine, token = "tok-xyz")
+    client.submitTrackLinks(sampleRequest)
+    assertEquals("Bearer tok-xyz", seenAuth)
+    assertEquals(true, seenContentType?.startsWith("application/json"))
+}
+
+@Test
+fun submitTrackLinks_emptyToken_returnsAuthFailed_doesNotHitNetwork() = runTest {
+    var calls = 0
+    val engine = MockEngine { _ -> calls += 1; respond("", HttpStatusCode.OK) }
+    val client = buildClient(engine, token = "")
+    assertEquals(SubmitResult.AuthFailed, client.submitTrackLinks(sampleRequest))
+    assertEquals(0, calls)
+}
+```
+
+**Step 2: Run, confirm failure.**
+
+Run: `./gradlew :shared:testDebugUnitTest --tests "*AchordionClient*"`
+Expected: 8 from Task 2 pass, 10 new fail with `NotImplementedError`.
+
+**Step 3: Implement `submitTrackLinks`.**
+
+Replace `TODO("Task 3")`:
+
+```kotlin
+suspend fun submitTrackLinks(payload: SubmitTrackLinksRequest): SubmitResult {
+    if (bearerToken.isBlank()) return SubmitResult.AuthFailed
+    if (authFailed) return SubmitResult.AuthFailed
+    if (payload.mbid.isBlank()) return SubmitResult.NoMbid
+    if (payload.links.isEmpty()) return SubmitResult.NoLinks
+
+    val mbidKey = payload.mbid.lowercase()
+    val alreadySubmitted = dedupMutex.withLock {
+        if (mbidKey in submittedThisSession) true
+        else { submittedThisSession.add(mbidKey); false }
+    }
+    if (alreadySubmitted) return SubmitResult.AlreadySubmitted
+
+    return try {
+        val response = httpClient.post(SUBMIT_ENDPOINT) {
+            header(HttpHeaders.Authorization, "Bearer $bearerToken")
+            contentType(ContentType.Application.Json)
+            setBody(payload)
+        }
+        when (response.status) {
+            HttpStatusCode.OK, HttpStatusCode.Created, HttpStatusCode.Accepted -> SubmitResult.Ok
+            HttpStatusCode.Unauthorized -> {
+                authFailed = true
+                Log.w(TAG, "submit returned 401 — suppressing further calls this session")
+                SubmitResult.AuthFailed
+            }
+            else -> {
+                // Roll back the dedup entry so a transient 5xx doesn't
+                // permanently mark this mbid as "submitted" for the
+                // rest of the session.
+                dedupMutex.withLock { submittedThisSession.remove(mbidKey) }
+                Log.w(TAG, "submit returned HTTP ${response.status.value} for mbid=${payload.mbid}")
+                SubmitResult.HttpError(response.status.value)
+            }
+        }
+    } catch (e: kotlinx.coroutines.CancellationException) {
+        throw e
+    } catch (e: Throwable) {
+        dedupMutex.withLock { submittedThisSession.remove(mbidKey) }
+        Log.w(TAG, "submit failed for mbid=${payload.mbid}: ${e.message}")
+        SubmitResult.NetworkError(e.message ?: "unknown")
+    }
+}
+```
+
+Add imports:
+
+```kotlin
+import io.ktor.client.plugins.contentnegotiation.ContentNegotiation  // already may be present
+import io.ktor.client.request.post
+import io.ktor.client.request.setBody
+import io.ktor.http.contentType
+import kotlinx.coroutines.sync.withLock
+```
+
+**Step 4: Run, confirm green.**
+
+Run: `./gradlew :shared:testDebugUnitTest --tests "*AchordionClient*"`
+Expected: 18/18 PASS.
+
+**Step 5: Commit.**
+
+```bash
+git add shared/src/commonMain/kotlin/com/parachord/shared/api/AchordionClient.kt \
+        shared/src/commonTest/kotlin/com/parachord/shared/api/AchordionClientTest.kt
+git commit -m "$(cat <<'EOF'
+api: AchordionClient.submitTrackLinks + 10 MockEngine tests (#share-links)
+
+POSTs the sharer's resolved per-service URLs to Achordion's match
+cache. Gates in order: empty token, authFailed kill-switch, blank MBID,
+empty links, per-session dedup (lowercase MBID key under a coroutine
+Mutex — KMP-safe). HTTP errors roll back the dedup entry so a transient
+5xx doesn't permanently mark the MBID as submitted.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 4: `AppConfig.achordionBearerToken` + BuildConfig
+
+**Files:**
+- Modify: `shared/src/commonMain/kotlin/com/parachord/shared/config/AppConfig.kt`
+- Modify: `app/build.gradle.kts:33-39ish` (the `buildConfigField` block)
+- Modify: `app/src/main/java/com/parachord/android/di/AndroidModule.kt` (search for the `AppConfig` factory)
+
+**Step 1: Add field to AppConfig.**
+
+In `AppConfig.kt` data class, add (alphabetically placed; the file already has fields like `lastFmApiKey`, `userAgent`, `isDebug`):
+
+```kotlin
+data class AppConfig(
+    val lastFmApiKey: String = "",
+    // ... existing fields ...
+    val achordionBearerToken: String = "",
+    val userAgent: String = "",
+    val isDebug: Boolean = false,
+)
+```
+
+Place `achordionBearerToken` between the existing API-key fields and `userAgent` — match the existing alphabetical or grouping convention by reading the file first.
+
+**Step 2: Add BuildConfig field.**
+
+In `app/build.gradle.kts` near line 33-39 where other `buildConfigField` calls live, add:
+
+```kotlin
+buildConfigField("String", "ACHORDION_BEARER_TOKEN", "\"${localProp("ACHORDION_BEARER_TOKEN")}\"")
+```
+
+Place it alphabetically among the other tokens.
+
+**Step 3: Wire it into the AppConfig Koin factory.**
+
+Search: `grep -n "AppConfig(" app/src/main/java/com/parachord/android/di/AndroidModule.kt`
+
+Find the `single<AppConfig> { ... }` (or `factory<AppConfig> { ... }`) block. It should look like:
+
+```kotlin
+single {
+    AppConfig(
+        lastFmApiKey = BuildConfig.LASTFM_API_KEY,
+        userAgent = "Parachord/${BuildConfig.VERSION_NAME} (Android; https://parachord.app)",
+        isDebug = BuildConfig.DEBUG,
+        // ... etc
+    )
+}
+```
+
+Add the new field:
+
+```kotlin
+achordionBearerToken = BuildConfig.ACHORDION_BEARER_TOKEN,
+```
+
+**Step 4: Compile.**
+
+Run: `./gradlew :app:compileDebugKotlin :shared:compileKotlinIosArm64`
+Expected: BUILD SUCCESSFUL on both targets.
+
+**Step 5: Quick test to confirm AppConfig now carries the token.**
+
+Add to `shared/src/commonTest/kotlin/com/parachord/shared/config/AppConfigTest.kt` (create if absent — single test):
+
+```kotlin
+package com.parachord.shared.config
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class AppConfigTest {
+    @Test
+    fun achordionBearerToken_defaultIsEmpty() {
+        assertEquals("", AppConfig().achordionBearerToken)
+    }
+}
+```
+
+Run: `./gradlew :shared:testDebugUnitTest --tests "*AppConfig*"`
+Expected: PASS.
+
+**Step 6: Commit.**
+
+```bash
+git add shared/src/commonMain/kotlin/com/parachord/shared/config/AppConfig.kt \
+        app/build.gradle.kts \
+        app/src/main/java/com/parachord/android/di/AndroidModule.kt \
+        shared/src/commonTest/kotlin/com/parachord/shared/config/AppConfigTest.kt
+git commit -m "$(cat <<'EOF'
+config: AppConfig.achordionBearerToken + BuildConfig wire (#share-links)
+
+Threads the Bearer token through AppConfig from a new
+ACHORDION_BEARER_TOKEN BuildConfig field. Sourced from local.properties
+or the CI secret of the same name. Empty default means devs without the
+token in local.properties get a clean fall-through to lookup URLs
+without API errors — AchordionClient short-circuits on empty tokens.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 5: CI secret + workflow wire
+
+**Files:**
+- Modify: `.github/workflows/build.yml` (the `Create local.properties` step around line 42-50)
+
+**Step 1: Add the secret to the CI `local.properties` write block.**
+
+Find the `cat <<EOF > local.properties` heredoc and add a line:
+
+```yaml
+ACHORDION_BEARER_TOKEN=${{ secrets.ACHORDION_BEARER_TOKEN }}
+```
+
+Place alphabetically among the other secrets.
+
+**Step 2: Add the secret to the repo on GitHub.**
+
+This is a manual / out-of-band step the controller should flag to the user:
+
+> Add a new repo secret named `ACHORDION_BEARER_TOKEN` with value `parachord_rgOgj2trN2KeIovar9DYA-yOCRkxgO6KlSyAo_jHtgg` (the published value from desktop's `parachord-desktop/plugins/achordion.axe`) via Settings → Secrets and variables → Actions → New repository secret. Without this secret, release builds will compile and ship but Achordion submits will silently no-op until the token is configured.
+
+The implementer should NOT try to set this themselves — flag it in the report.
+
+**Step 3: Commit the workflow change.**
+
+```bash
+git add .github/workflows/build.yml
+git commit -m "$(cat <<'EOF'
+ci: wire ACHORDION_BEARER_TOKEN into local.properties (#share-links)
+
+Release builds need the Achordion Bearer token surfaced into
+local.properties so the BuildConfig field carries it. Empty value
+when the repo secret isn't set is fine — AchordionClient short-circuits
+gracefully.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 6: Koin binding for `AchordionClient`
+
+**Files:**
+- Modify: `shared/src/commonMain/kotlin/com/parachord/shared/di/SharedModule.kt` — add binding adjacent to `SmartLinksClient` (line 91)
+
+**Step 1: Add the Koin binding.**
+
+After line 91 (`single { SmartLinksClient(get()) }`), add:
+
+```kotlin
+single {
+    AchordionClient(
+        httpClient = get(),
+        bearerToken = get<AppConfig>().achordionBearerToken,
+    )
+}
+```
+
+Verify the imports are right (`AchordionClient`, `AppConfig`). Add if missing.
+
+**Step 2: Compile.**
+
+Run: `./gradlew :app:compileDebugKotlin`
+Expected: BUILD SUCCESSFUL.
+
+**Step 3: Commit.**
+
+```bash
+git add shared/src/commonMain/kotlin/com/parachord/shared/di/SharedModule.kt
+git commit -m "$(cat <<'EOF'
+di: wire AchordionClient as a Koin singleton (#share-links)
+
+Sources the Bearer token from AppConfig.achordionBearerToken at
+construction time. Ready for ShareManager to inject in the next commit.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 7: `ShareManager` — rewrite `shareTrack`
+
+**Files:**
+- Modify: `app/src/main/java/com/parachord/android/share/ShareManager.kt`
+- Create: `app/src/test/java/com/parachord/android/share/ShareManagerTest.kt`
+
+**Step 1: Add AchordionClient to ShareManager constructor.**
+
+```kotlin
+class ShareManager constructor(
+    private val smartLinksClient: SmartLinksClient,
+    private val achordionClient: AchordionClient,    // NEW
+    private val playlistDao: PlaylistDao,
+    private val playlistTrackDao: PlaylistTrackDao,
+) { ... }
+```
+
+Update the Koin binding in `AndroidModule.kt` to pass `achordionClient = get()`.
+
+**Step 2: Write failing tests for `shareTrack`.**
+
+```kotlin
+// app/src/test/java/com/parachord/android/share/ShareManagerTest.kt
+package com.parachord.android.share
+
+import com.parachord.android.data.db.dao.PlaylistDao
+import com.parachord.android.data.db.dao.PlaylistTrackDao
+import com.parachord.android.data.db.entity.TrackEntity
+import com.parachord.shared.api.AchordionClient
+import com.parachord.shared.api.EntityLink
+import com.parachord.shared.api.EntityType
+import com.parachord.shared.api.SmartLinksClient
+import com.parachord.shared.api.SubmitResult
+import com.parachord.shared.api.SubmitTrackLinksRequest
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.mockk
+import io.mockk.slot
+import kotlinx.coroutines.test.runTest
+import org.junit.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class ShareManagerTest {
+
+    private fun buildManager(
+        achordion: AchordionClient = mockk(relaxed = true),
+        smartLinks: SmartLinksClient = mockk(relaxed = true),
+    ): ShareManager = ShareManager(
+        smartLinksClient = smartLinks,
+        achordionClient = achordion,
+        playlistDao = mockk(relaxed = true),
+        playlistTrackDao = mockk(relaxed = true),
+    )
+
+    private fun sampleTrack(
+        recordingMbid: String? = "550e8400-e29b-41d4-a716-446655440000",
+        spotifyId: String? = "SP123",
+        appleMusicId: String? = "AM456",
+        soundcloudId: String? = "user/track",
+    ) = TrackEntity(
+        id = "t1",
+        title = "Sugar For The Pill",
+        artist = "Slowdive",
+        album = "Slowdive",
+        recordingMbid = recordingMbid,
+        spotifyId = spotifyId,
+        appleMusicId = appleMusicId,
+        soundcloudId = soundcloudId,
+    )
+
+    @Test
+    fun shareTrack_withMbid_callsBothEntityLinkAndSubmit() = runTest {
+        val achordion = mockk<AchordionClient>()
+        coEvery { achordion.fetchEntityLink(EntityType.Track, "550e8400-e29b-41d4-a716-446655440000", any()) } returns
+            EntityLink(url = "https://achordion.xyz/recording/slowdive-sugar")
+        coEvery { achordion.submitTrackLinks(any()) } returns SubmitResult.Ok
+
+        val mgr = buildManager(achordion = achordion)
+        val result = mgr.shareTrack(sampleTrack())
+
+        assertEquals("https://achordion.xyz/recording/slowdive-sugar", result.url)
+        assertTrue(result.isSmartLink)
+        coVerify(exactly = 1) { achordion.fetchEntityLink(EntityType.Track, any(), any()) }
+        coVerify(exactly = 1) { achordion.submitTrackLinks(any()) }
+    }
+
+    @Test
+    fun shareTrack_withoutMbid_callsNeitherApi_returnsLookupFallback() = runTest {
+        val achordion = mockk<AchordionClient>(relaxed = true)
+        val mgr = buildManager(achordion = achordion)
+        val result = mgr.shareTrack(sampleTrack(recordingMbid = null))
+
+        assertEquals(
+            "https://achordion.xyz/recording/lookup?artist=Slowdive&title=Sugar%20For%20The%20Pill",
+            result.url,
+        )
+        assertFalse(result.isSmartLink)
+        coVerify(exactly = 0) { achordion.fetchEntityLink(any(), any(), any()) }
+        coVerify(exactly = 0) { achordion.submitTrackLinks(any()) }
+    }
+
+    @Test
+    fun shareTrack_entityLinkReturnsNull_returnsLookupFallback_butStillSubmits() = runTest {
+        val achordion = mockk<AchordionClient>()
+        coEvery { achordion.fetchEntityLink(any(), any(), any()) } returns null
+        coEvery { achordion.submitTrackLinks(any()) } returns SubmitResult.Ok
+
+        val mgr = buildManager(achordion = achordion)
+        val result = mgr.shareTrack(sampleTrack())
+
+        assertTrue(result.url.startsWith("https://achordion.xyz/recording/lookup?"))
+        assertFalse(result.isSmartLink)
+        coVerify(exactly = 1) { achordion.submitTrackLinks(any()) }
+    }
+
+    @Test
+    fun shareTrack_submitPayloadIncludesAllAvailableSourceUrls() = runTest {
+        val achordion = mockk<AchordionClient>()
+        coEvery { achordion.fetchEntityLink(any(), any(), any()) } returns null
+        val payloadSlot = slot<SubmitTrackLinksRequest>()
+        coEvery { achordion.submitTrackLinks(capture(payloadSlot)) } returns SubmitResult.Ok
+
+        val mgr = buildManager(achordion = achordion)
+        mgr.shareTrack(sampleTrack())
+
+        val payload = payloadSlot.captured
+        assertEquals("550e8400-e29b-41d4-a716-446655440000", payload.mbid)
+        assertEquals("Sugar For The Pill", payload.trackName)
+        assertEquals("Slowdive", payload.artistName)
+        assertEquals("Slowdive", payload.albumName)
+        val hosts = payload.links.map { it.host }.toSet()
+        assertEquals(setOf("spotify.com", "music.apple.com", "soundcloud.com"), hosts)
+    }
+
+    @Test
+    fun shareTrack_skipsSourceUrlsWithBlankIds() = runTest {
+        val achordion = mockk<AchordionClient>()
+        coEvery { achordion.fetchEntityLink(any(), any(), any()) } returns null
+        val payloadSlot = slot<SubmitTrackLinksRequest>()
+        coEvery { achordion.submitTrackLinks(capture(payloadSlot)) } returns SubmitResult.Ok
+
+        val mgr = buildManager(achordion = achordion)
+        mgr.shareTrack(sampleTrack(spotifyId = "SP", appleMusicId = "", soundcloudId = null))
+
+        val hosts = payloadSlot.captured.links.map { it.host }
+        assertEquals(listOf("spotify.com"), hosts)
+    }
+
+    @Test
+    fun shareTrack_noSourceIds_doesNotCallSubmit() = runTest {
+        val achordion = mockk<AchordionClient>()
+        coEvery { achordion.fetchEntityLink(any(), any(), any()) } returns null
+        coEvery { achordion.submitTrackLinks(any()) } returns SubmitResult.NoLinks
+
+        val mgr = buildManager(achordion = achordion)
+        mgr.shareTrack(sampleTrack(spotifyId = null, appleMusicId = null, soundcloudId = null))
+
+        // ShareManager filters source-list at build time and skips submit when empty.
+        coVerify(exactly = 0) { achordion.submitTrackLinks(any()) }
+    }
+}
+```
+
+**Step 3: Run, confirm failure.**
+
+Run: `./gradlew :app:testDebugUnitTest --tests "*ShareManagerTest*"`
+Expected: FAIL — old signature doesn't have `achordionClient`, and `shareTrack` body still calls `smartLinksClient`.
+
+**Step 4: Replace `shareTrack` body and helpers.**
+
+Open `app/src/main/java/com/parachord/android/share/ShareManager.kt` and replace `shareTrack`:
+
+```kotlin
+suspend fun shareTrack(track: TrackEntity): ShareResult = coroutineScope {
+    val subject = "${track.artist} – ${track.title}"
+    val mbid = track.recordingMbid
+
+    // Fire entity-link + submit in parallel. Both AWAITED so the recipient's
+    // first click sees a fully-warmed Achordion page. Matches desktop's
+    // publishSmartLink behavior (parachord-desktop/app.js:13380+).
+    val entityLinkJob = async { tryFetchEntityLink(EntityType.Track, mbid) }
+    val submitJob = async { trySubmitForTrack(track, mbid) }
+    val entityUrl = entityLinkJob.await()
+    submitJob.await()
+
+    val url = entityUrl ?: trackLookupUrl(track.artist, track.title)
+    ShareResult(url, subject, isSmartLink = entityUrl != null)
+}
+
+private suspend fun tryFetchEntityLink(type: EntityType, mbid: String?): String? {
+    if (mbid.isNullOrBlank()) return null
+    return try {
+        withTimeout(SMART_LINK_TIMEOUT_MS) {
+            achordionClient.fetchEntityLink(type, mbid)?.url
+        }
+    } catch (e: TimeoutCancellationException) {
+        Log.w(TAG, "fetchEntityLink timed out for $type mbid=$mbid")
+        null
+    } catch (e: Exception) {
+        Log.w(TAG, "fetchEntityLink failed for $type mbid=$mbid: ${e.message}")
+        null
+    }
+}
+
+private suspend fun trySubmitForTrack(track: TrackEntity, mbid: String?) {
+    if (mbid.isNullOrBlank()) return
+    val links = buildList {
+        track.spotifyId?.takeIf { it.isNotBlank() }?.let {
+            add(TrackLink(url = "https://open.spotify.com/track/$it", host = "spotify.com", label = "Spotify"))
+        }
+        track.appleMusicId?.takeIf { it.isNotBlank() }?.let {
+            add(TrackLink(url = "https://music.apple.com/song/$it", host = "music.apple.com", label = "Apple Music"))
+        }
+        track.soundcloudId?.takeIf { it.isNotBlank() }?.let {
+            add(TrackLink(url = "https://soundcloud.com/$it", host = "soundcloud.com", label = "SoundCloud"))
+        }
+    }
+    if (links.isEmpty()) return
+    try {
+        withTimeout(SMART_LINK_TIMEOUT_MS) {
+            achordionClient.submitTrackLinks(
+                SubmitTrackLinksRequest(
+                    mbid = mbid,
+                    links = links,
+                    trackName = track.title,
+                    artistName = track.artist,
+                    albumName = track.album,
+                )
+            )
+        }
+    } catch (e: TimeoutCancellationException) {
+        Log.w(TAG, "submitTrackLinks timed out for mbid=$mbid")
+    } catch (e: Exception) {
+        Log.w(TAG, "submitTrackLinks failed for mbid=$mbid: ${e.message}")
+    }
+}
+
+private fun trackLookupUrl(artist: String, title: String): String =
+    "https://achordion.xyz/recording/lookup?artist=${enc(artist)}&title=${enc(title)}"
+```
+
+Add imports:
+
+```kotlin
+import com.parachord.shared.api.AchordionClient
+import com.parachord.shared.api.EntityType
+import com.parachord.shared.api.SubmitTrackLinksRequest
+import com.parachord.shared.api.TrackLink
+import kotlinx.coroutines.async
+import kotlinx.coroutines.coroutineScope
+```
+
+Don't remove `SmartLinksClient` / `SmartLinkCreateRequest` imports — playlist still uses them.
+
+**Step 5: Run, confirm green.**
+
+Run: `./gradlew :app:testDebugUnitTest --tests "*ShareManagerTest*"`
+Expected: 6/6 new tests PASS.
+
+**Step 6: Commit.**
+
+```bash
+git add app/src/main/java/com/parachord/android/share/ShareManager.kt \
+        app/src/main/java/com/parachord/android/di/AndroidModule.kt \
+        app/src/test/java/com/parachord/android/share/ShareManagerTest.kt
+git commit -m "$(cat <<'EOF'
+share: rewrite shareTrack to use AchordionClient + 6 mockk tests (#share-links)
+
+Drops the SmartLinksClient call for tracks. Now calls entity-link +
+submit in parallel via coroutineScope+async, awaits both before
+returning. Lookup URL fallback when MBID is missing. Submit gates
+internally on links.isNotEmpty so tracks without resolved sources
+skip the POST cleanly.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 8: `ShareManager` — rewrite `shareAlbum`
+
+**Files:**
+- Modify: `app/src/main/java/com/parachord/android/share/ShareManager.kt` (shareAlbum body, around line 72-103)
+- Modify: `app/src/test/java/com/parachord/android/share/ShareManagerTest.kt` (add tests)
+- Modify: `app/src/main/java/com/parachord/android/share/ShareSheet.kt` (caller at line 71 + `rememberShareAlbum` signature at line 58)
+
+**Step 1: Write the failing tests.**
+
+Add to ShareManagerTest:
+
+```kotlin
+@Test
+fun shareAlbum_withMbid_callsEntityLinkOnly_noSubmit() = runTest {
+    val achordion = mockk<AchordionClient>()
+    coEvery { achordion.fetchEntityLink(EntityType.ReleaseGroup, "rg-mbid-1", any()) } returns
+        EntityLink(url = "https://achordion.xyz/release-group/death-cab-tower")
+
+    val mgr = buildManager(achordion = achordion)
+    val result = mgr.shareAlbum(
+        title = "I Built You a Tower",
+        artist = "Death Cab for Cutie",
+        artworkUrl = null,
+        releaseGroupMbid = "rg-mbid-1",
+    )
+
+    assertEquals("https://achordion.xyz/release-group/death-cab-tower", result.url)
+    assertTrue(result.isSmartLink)
+    coVerify(exactly = 1) { achordion.fetchEntityLink(EntityType.ReleaseGroup, "rg-mbid-1", any()) }
+    coVerify(exactly = 0) { achordion.submitTrackLinks(any()) }
+}
+
+@Test
+fun shareAlbum_noMbid_returnsLookupFallback() = runTest {
+    val achordion = mockk<AchordionClient>(relaxed = true)
+    val mgr = buildManager(achordion = achordion)
+    val result = mgr.shareAlbum(
+        title = "I Built You a Tower",
+        artist = "Death Cab for Cutie",
+        artworkUrl = null,
+        releaseGroupMbid = null,
+    )
+    assertEquals(
+        "https://achordion.xyz/release-group/lookup?artist=Death%20Cab%20for%20Cutie&title=I%20Built%20You%20a%20Tower",
+        result.url,
+    )
+    assertFalse(result.isSmartLink)
+    coVerify(exactly = 0) { achordion.fetchEntityLink(any(), any(), any()) }
+}
+
+@Test
+fun shareAlbum_entityLinkFails_returnsLookupFallback() = runTest {
+    val achordion = mockk<AchordionClient>()
+    coEvery { achordion.fetchEntityLink(any(), any(), any()) } returns null
+    val mgr = buildManager(achordion = achordion)
+    val result = mgr.shareAlbum("Tower", "Death Cab", null, "rg-mbid-1")
+    assertTrue(result.url.contains("/release-group/lookup?"))
+    assertFalse(result.isSmartLink)
+}
+```
+
+**Step 2: Run, confirm failure.**
+
+Run: `./gradlew :app:testDebugUnitTest --tests "*ShareManagerTest.shareAlbum*"`
+Expected: compile error — `shareAlbum` doesn't have the new signature.
+
+**Step 3: Update `shareAlbum` body.**
+
+Replace the existing `shareAlbum` method body:
+
+```kotlin
+suspend fun shareAlbum(
+    title: String,
+    artist: String,
+    artworkUrl: String?,         // kept for caller compat; unused after migration
+    releaseGroupMbid: String?,
+): ShareResult {
+    val subject = "$artist – $title"
+    val entityUrl = tryFetchEntityLink(EntityType.ReleaseGroup, releaseGroupMbid)
+    val url = entityUrl ?: releaseGroupLookupUrl(artist, title)
+    return ShareResult(url, subject, isSmartLink = entityUrl != null)
+}
+
+private fun releaseGroupLookupUrl(artist: String, title: String): String =
+    "https://achordion.xyz/release-group/lookup?artist=${enc(artist)}&title=${enc(title)}"
+```
+
+Note: the old `shareAlbum` took `(title, artist, artworkUrl, tracks, spotifyAlbumId)`. We're dropping `tracks` + `spotifyAlbumId` from the API. Callers must be updated.
+
+**Step 4: Update caller sites in `ShareSheet.kt`.**
+
+In `ShareSheet.kt`, the `rememberShareAlbum` helper (line 58+) and `rememberShareAlbumLite` (line 88+) currently produce a lambda that takes `(title, artist, artworkUrl, tracks, spotifyAlbumId)`. Two paths:
+
+1. **Reduce the lambda signature** to `(title, artist, artworkUrl, releaseGroupMbid)`. Update all call sites that pass `tracks` / `spotifyAlbumId` to drop those args and pass `releaseGroupMbid` (null if not known yet).
+
+2. **Keep the existing lambda signature, drop `tracks` / `spotifyAlbumId` from the lambda body's call to `shareManager.shareAlbum`, add `releaseGroupMbid = null` always.** Most callers don't have an MBID anyway, so this just removes the dead args without forcing callers to thread MBID through yet.
+
+Use **#2 for now** — minimal churn. File a follow-up to plumb release-group MBID from `AlbumEntity` once the entity carries one. Update `ShareSheet.kt:71`:
+
+```kotlin
+val result = shareManager.shareAlbum(title, artist, artworkUrl, releaseGroupMbid = null)
+```
+
+(Drop the `tracks` and `spotifyAlbumId` args.)
+
+And line 92 (the Lite variant):
+
+```kotlin
+shareAlbum(title, artist, artworkUrl)
+```
+
+…assuming the Lite signature already doesn't accept tracks/spotifyAlbumId. Verify by reading the existing helper body.
+
+**Step 5: Run, confirm green.**
+
+Run: `./gradlew :app:testDebugUnitTest --tests "*ShareManagerTest*"`
+Expected: all tests PASS (Task 7's 6 + Task 8's 3 = 9).
+
+Run: `./gradlew :app:compileDebugKotlin`
+Expected: BUILD SUCCESSFUL.
+
+**Step 6: Commit.**
+
+```bash
+git add app/src/main/java/com/parachord/android/share/ShareManager.kt \
+        app/src/main/java/com/parachord/android/share/ShareSheet.kt \
+        app/src/test/java/com/parachord/android/share/ShareManagerTest.kt
+git commit -m "$(cat <<'EOF'
+share: rewrite shareAlbum to use AchordionClient + 3 tests (#share-links)
+
+Drops the smart-link payload (tracks list, spotifyAlbumId) — they're
+no longer needed since Achordion serves the album entity page from
+just the release-group MBID. Callers pass releaseGroupMbid (currently
+always null since AlbumEntity doesn't carry one yet; future follow-up
+to plumb it).
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 9: `ShareManager` — rewrite `shareArtist`
+
+**Files:**
+- Modify: `app/src/main/java/com/parachord/android/share/ShareManager.kt:149-153`
+- Modify: `app/src/test/java/com/parachord/android/share/ShareManagerTest.kt`
+- Modify: `app/src/main/java/com/parachord/android/share/ShareSheet.kt:134-141` (`rememberShareArtist`)
+
+**Step 1: Write tests.**
+
+```kotlin
+@Test
+fun shareArtist_withMbid_callsEntityLinkOnly_noSubmit() = runTest {
+    val achordion = mockk<AchordionClient>()
+    coEvery { achordion.fetchEntityLink(EntityType.Artist, "artist-mbid-1", any()) } returns
+        EntityLink(url = "https://achordion.xyz/artist/slowdive")
+    val mgr = buildManager(achordion = achordion)
+    val result = mgr.shareArtist("Slowdive", artistMbid = "artist-mbid-1")
+    assertEquals("https://achordion.xyz/artist/slowdive", result.url)
+    assertTrue(result.isSmartLink)
+    coVerify(exactly = 0) { achordion.submitTrackLinks(any()) }
+}
+
+@Test
+fun shareArtist_noMbid_returnsLookupFallback() = runTest {
+    val achordion = mockk<AchordionClient>(relaxed = true)
+    val mgr = buildManager(achordion = achordion)
+    val result = mgr.shareArtist("Slowdive", artistMbid = null)
+    assertEquals("https://achordion.xyz/artist/lookup?name=Slowdive", result.url)
+    assertFalse(result.isSmartLink)
+}
+```
+
+**Step 2: Run, confirm failure.**
+
+Run: `./gradlew :app:testDebugUnitTest --tests "*ShareManagerTest.shareArtist*"`
+Expected: compile or assertion error.
+
+**Step 3: Update `shareArtist`.**
+
+```kotlin
+suspend fun shareArtist(name: String, artistMbid: String? = null): ShareResult {
+    val entityUrl = tryFetchEntityLink(EntityType.Artist, artistMbid)
+    val url = entityUrl ?: artistLookupUrl(name)
+    return ShareResult(url, name, isSmartLink = entityUrl != null)
+}
+
+private fun artistLookupUrl(name: String): String =
+    "https://achordion.xyz/artist/lookup?name=${enc(name)}"
+```
+
+Note: changed from `fun` (sync) to `suspend fun`. Caller `rememberShareArtist` already runs in `coroutineScope`, so the change is safe. Update its caller too.
+
+**Step 4: Update `ShareSheet.rememberShareArtist`.**
+
+In `ShareSheet.kt` around line 141, current call is `shareManager.shareArtist(name, imageUrl)`. The `imageUrl` parameter was unused in the old body anyway. Change to:
+
+```kotlin
+val result = shareManager.shareArtist(name, artistMbid = null)
+```
+
+(Future improvement: when Achordion has a public artist-MBID lookup endpoint, or when `Artist` carries an MBID via metadata service, thread it here. For now, lookup URL handles the no-MBID case.)
+
+The `rememberShareArtist` lambda signature can stay `(name: String, imageUrl: String?) -> Unit` if other call sites pass `imageUrl`; the helper just discards it. Or simplify to `(name: String) -> Unit` if call sites are simple to update. Use judgment based on caller count.
+
+**Step 5: Run, confirm green.**
+
+Run: `./gradlew :app:testDebugUnitTest --tests "*ShareManagerTest*"`
+Expected: 11/11 PASS.
+
+Run: `./gradlew :app:compileDebugKotlin`
+Expected: BUILD SUCCESSFUL.
+
+**Step 6: Commit.**
+
+```bash
+git add app/src/main/java/com/parachord/android/share/ShareManager.kt \
+        app/src/main/java/com/parachord/android/share/ShareSheet.kt \
+        app/src/test/java/com/parachord/android/share/ShareManagerTest.kt
+git commit -m "$(cat <<'EOF'
+share: rewrite shareArtist to use AchordionClient + 2 tests (#share-links)
+
+Drops the unused imageUrl parameter. Now suspend (was sync) since the
+entity-link call is suspending. Callers in ShareSheet already run in a
+coroutineScope so the change is safe.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 10: Playlist regression guard test
+
+**Files:**
+- Modify: `app/src/test/java/com/parachord/android/share/ShareManagerTest.kt`
+
+**Step 1: Add the test.**
+
+```kotlin
+@Test
+fun sharePlaylist_unchanged_stillUsesSmartLinksClient_notAchordion() = runTest {
+    val achordion = mockk<AchordionClient>(relaxed = true)
+    val smartLinks = mockk<SmartLinksClient>(relaxed = true)
+    coEvery { smartLinks.create(any()) } returns com.parachord.shared.api.SmartLinkCreateResponse(
+        url = "https://go.parachord.com/abc123",
+        id = "abc123",
+    )
+
+    val playlistDao = mockk<PlaylistDao>()
+    val playlistTrackDao = mockk<PlaylistTrackDao>()
+    coEvery { playlistDao.getById("p1") } returns com.parachord.android.data.db.entity.PlaylistEntity(
+        id = "p1", name = "My Playlist", ownerName = "me",
+    )
+    coEvery { playlistTrackDao.getByPlaylistIdSync("p1") } returns emptyList()
+
+    val mgr = ShareManager(
+        smartLinksClient = smartLinks,
+        achordionClient = achordion,
+        playlistDao = playlistDao,
+        playlistTrackDao = playlistTrackDao,
+    )
+
+    val result = mgr.sharePlaylist("p1")
+    assertEquals("https://go.parachord.com/abc123", result?.url)
+    coVerify(exactly = 0) { achordion.fetchEntityLink(any(), any(), any()) }
+    coVerify(exactly = 0) { achordion.submitTrackLinks(any()) }
+    coVerify(exactly = 1) { smartLinks.create(any()) }
+}
+```
+
+Verify the `SmartLinkCreateResponse` shape and `PlaylistEntity` constructor match the actual types by reading them. Adjust if needed.
+
+**Step 2: Run.**
+
+Run: `./gradlew :app:testDebugUnitTest --tests "*ShareManagerTest*"`
+Expected: 12/12 PASS.
+
+**Step 3: Commit.**
+
+```bash
+git add app/src/test/java/com/parachord/android/share/ShareManagerTest.kt
+git commit -m "$(cat <<'EOF'
+test: lock sharePlaylist on SmartLinksClient (regression guard) (#share-links)
+
+Phase-3 share-links migration is scoped to track/album/artist. Playlist
+shares must continue going through SmartLinksClient (go.parachord.com)
+since Achordion has no playlist entity page. This test would catch a
+future refactor that accidentally routes playlists through Achordion.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 11: `SmartLinksClient` kdoc refresh
+
+**Files:**
+- Modify: `shared/src/commonMain/kotlin/com/parachord/shared/api/SmartLinksClient.kt`
+
+**Step 1: Update the class kdoc to clarify the post-migration role.**
+
+Read the existing class kdoc and rewrite it to note:
+
+- This client used to handle track + album + artist + playlist shares.
+- After the Achordion migration (v0.6.x), it's playlist-only.
+- Track/album/artist now go through `AchordionClient`.
+- Keeping this client around because (a) it has tests + Koin wiring, (b) Achordion has no playlist entity yet, (c) future smart-link-shaped shares (e.g. albums-with-tracklist) could re-use it.
+
+No code change.
+
+**Step 2: Commit.**
+
+```bash
+git add shared/src/commonMain/kotlin/com/parachord/shared/api/SmartLinksClient.kt
+git commit -m "$(cat <<'EOF'
+docs: SmartLinksClient kdoc — playlist-only after Achordion migration (#share-links)
+
+Document that track/album/artist shares moved to AchordionClient and
+this client is retained for the playlist path only.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 12: Update CLAUDE.md "Outbound Sharing (Smart Links)" section
+
+**Files:**
+- Modify: `CLAUDE.md` (the "Outbound Sharing (Smart Links)" section)
+
+**Step 1: Rewrite the section.**
+
+Search the file for "Outbound Sharing (Smart Links)" — it's around the existing share-related infra notes. Rewrite to describe the new contract:
+
+- **Track / album / artist shares produce Achordion entity URLs** (`achordion.xyz/recording/<mbid>`, etc.), via the new `AchordionClient` in shared.
+- **Track shares** additionally pre-warm Achordion's cache via `/api/track-links/submit` so recipients see fully-resolved per-service links. Submit gates on (a) MBID present, (b) at least one streaming source ID non-blank. Per-session dedup by lowercase MBID.
+- **Playlist shares** still use `SmartLinksClient` → `go.parachord.com/<id>` smart-links. Achordion has no playlist entity.
+- **Bearer token** comes from `AppConfig.achordionBearerToken` (BuildConfig field). Empty token short-circuits cleanly to lookup URLs in debug builds.
+- **Mirrors desktop's `publishSmartLink` / `publishAlbumSmartLink` / `publishArtistSmartLink`** in `parachord-desktop/app.js`.
+- **Fallback** when MBID is missing or the API errors: lookup URL (`/recording/lookup?artist=&title=`, etc.) — Achordion does server-side MB search and 302s to the canonical page.
+
+Add a "Key files" list:
+- `shared/.../api/AchordionClient.kt` — Ktor client
+- `app/.../share/ShareManager.kt` — caller
+- `parachord-desktop/plugins/achordion.axe` — reference implementation
+
+**Step 2: Commit.**
+
+```bash
+git add CLAUDE.md
+git commit -m "$(cat <<'EOF'
+docs: CLAUDE.md — Achordion share-links section update (#share-links)
+
+Replaces the "Outbound Sharing (Smart Links)" section with the new
+post-migration contract. Track/album/artist via AchordionClient,
+playlists via SmartLinksClient. Documents the submit pre-warm gates
+and the bearer-token flow.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 13: Manual on-device verification
+
+**Step 1: Build + install.**
+
+```bash
+cd /Users/jherskowitz/Development/parachord/parachord-android
+adb shell am force-stop com.parachord.android.debug
+./gradlew installDebug
+```
+
+Confirm the new APK has `ACHORDION_BEARER_TOKEN` populated:
+
+```bash
+adb shell pm dump com.parachord.android.debug | grep -i build.config
+```
+
+(If you set the token in `local.properties` before building, it'll be there. If not, the share will fall through to lookup URLs — still works, just no pre-warm or canonical-slug URLs.)
+
+**Step 2: Manual share tests.**
+
+Open the app. For each:
+
+- **Track share** — long-press a track row → Share. Expect a URL like `https://achordion.xyz/recording/<mbid-or-slug>`. Confirm via `adb logcat -s AchordionClient` you see both the entity-link call and the submit call.
+- **Album share** — long-press an album card → Share. Expect `https://achordion.xyz/release-group/lookup?artist=…&title=…` (no MBID plumbed yet, hits the lookup path).
+- **Artist share** — long-press an artist card → Share. Expect `https://achordion.xyz/artist/lookup?name=…`.
+- **Playlist share** — long-press a playlist → Share. Expect `https://go.parachord.com/<id>` (unchanged from before).
+
+**Step 3:** Tap the resulting Achordion URL on the device (paste into Chrome). It should land on the canonical entity page. Track shares should show Parachord-resolved per-service buttons immediately (the submit pre-warm).
+
+No commit; this is verification only. Note any anomalies and either file follow-up issues or roll into a fix commit.
+
+---
+
+## Task 14: Open PR
+
+**Step 1: Push branch.**
+
+```bash
+git push -u origin feature/achordion-share-links
+```
+
+**Step 2: Open PR via `gh`.**
+
+```bash
+gh pr create --title "Share links: track / album / artist → Achordion entity pages" --body "$(cat <<'EOF'
+Migrates outbound share URLs from \`go.parachord.com\` smart-links to Achordion entity pages, matching desktop's \`publishSmartLink\` / \`publishAlbumSmartLink\` / \`publishArtistSmartLink\`. Playlists stay on the existing smart-link path (Achordion has no playlist entity).
+
+## Summary
+
+- New shared **\`AchordionClient\`** (Ktor) — \`fetchEntityLink(type, mbid)\` + \`submitTrackLinks(payload)\`. Bearer-authenticated.
+- **\`ShareManager.shareTrack\`** now fires entity-link + submit in parallel via \`coroutineScope+async\`, awaits both, returns the canonical URL or a lookup-URL fallback. Submit pre-warms Achordion's cache so recipients see Parachord-resolved per-service links on first click.
+- **\`shareAlbum\`** and **\`shareArtist\`** call entity-link only (no submit — desktop comment: "submissions are recording-keyed").
+- **\`sharePlaylist\`** unchanged — \`SmartLinksClient\` retained for playlist shares.
+- **Bearer token** threaded through \`AppConfig.achordionBearerToken\` from a new \`ACHORDION_BEARER_TOKEN\` BuildConfig field (sourced from \`local.properties\` + CI secret). Empty token short-circuits all Achordion calls cleanly.
+
+## Submit gate (matches desktop)
+
+Submit fires when:
+1. \`track.recordingMbid\` is non-null+non-blank (proxies for "high-confidence resolution").
+2. At least one of \`spotifyId\` / \`appleMusicId\` / \`soundcloudId\` is non-blank.
+3. MBID hasn't already been submitted this process lifetime (per-session dedup, lowercase key, Mutex-protected).
+4. \`authFailed\` kill-switch not tripped (first 401 sets it; later calls short-circuit).
+
+## Test plan
+
+- [x] 18 \`AchordionClientTest\` MockEngine cases — entity-link happy/404/malformed/auth/empty-token + submit happy/no-links/no-mbid/dedup/case-insensitive-dedup/auth/short-circuit/HTTP-error/network-error.
+- [x] 12 \`ShareManagerTest\` mockk cases — track with/without MBID, album with/without MBID, artist with/without MBID, payload shape, blank-id filtering, no-sources-no-submit, playlist-regression-guard.
+- [ ] Manual on-device — track / album / artist / playlist shares all produce the expected URL shape. Track share also pre-warms Achordion cache (confirm via logcat \`AchordionClient\` tag + visit the Achordion URL on a fresh-cache instance).
+
+## Manual setup needed
+
+- **GitHub repo secret**: add \`ACHORDION_BEARER_TOKEN\` with the published value from \`parachord-desktop/plugins/achordion.axe\`. Without this, release builds compile and ship but Achordion submits silently no-op and shares fall through to lookup URLs.
+
+## Known follow-ups
+
+- Album / Artist MBID plumbing: callers pass \`releaseGroupMbid = null\` / \`artistMbid = null\` today. \`AlbumEntity\` / \`ArtistEntity\` don't carry MBIDs yet. File-and-defer: thread MBIDs through from \`MetadataService\` results so album/artist shares can use canonical entity URLs (not just lookup fallback).
+- Token leakage protection: workflow uses \`\${{ secrets.ACHORDION_BEARER_TOKEN }}\` directly — GitHub's secret masking handles log redaction. Don't \`echo\` the token in any future workflow step.
+
+## Plan + design
+
+- [docs/plans/2026-05-10-achordion-share-links-design.md](docs/plans/2026-05-10-achordion-share-links-design.md)
+- [docs/plans/2026-05-10-achordion-share-links.md](docs/plans/2026-05-10-achordion-share-links.md)
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+**Step 3: Note in the PR description any anomalies from Task 13's manual verification.**
+
+---
+
+## Risk notes
+
+- **Token leakage in CI logs.** Workflow uses `${{ secrets.ACHORDION_BEARER_TOKEN }}` so GitHub's secret masking redacts it from logs. Don't add `cat local.properties` or `env` dumps anywhere.
+- **API drift.** Achordion's `/api/entity-link` and `/api/track-links/submit` response shapes are what desktop plugin parses today. Coordinate with achordion's owner if either changes.
+- **Submit gate too lax.** Section 3 (design doc) discusses the MBID-only gate. If wrong-track submits start showing up in Achordion's cache, follow-up is to thread `TrackResolverCache` confidence into the gate. Low-probability per the rationale, but worth monitoring after rollout.
+- **Timeout budget.** `SMART_LINK_TIMEOUT_MS = 4_000L` (reused from the old SmartLinks path). Worst case the share sheet shows after up to 4s if Achordion is slow. Consider Phase 3's Snackbar (#137) once it lands so the ack is visible during the wait.
+
+## Out of scope
+
+- Album / Artist MBID plumbing from `MetadataService` (file follow-up).
+- The `fetchEmbedCode` endpoint (desktop has it, Android doesn't surface embeds).
+- iOS share targets (KMP-ready since `AchordionClient` is in commonMain; iOS shell just needs to wire it).
+- Rotating the published token (if achordion rotates it, update `ACHORDION_BEARER_TOKEN` repo secret + cut a new release).

--- a/shared/src/commonMain/kotlin/com/parachord/shared/api/AchordionClient.kt
+++ b/shared/src/commonMain/kotlin/com/parachord/shared/api/AchordionClient.kt
@@ -1,0 +1,103 @@
+package com.parachord.shared.api
+
+import com.parachord.shared.platform.Log
+import io.ktor.client.HttpClient
+import kotlin.concurrent.Volatile
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.Json
+
+/**
+ * Client for the Achordion entity-link + submit-track-links APIs.
+ *
+ * Two endpoints, both Bearer-token authenticated:
+ *
+ *  - `GET /api/entity-link?type={track|release-group|artist}&mbid={mbid}` —
+ *    returns the canonical Achordion entity URL (possibly a slug-based
+ *    redirect target) plus optional names. Used to mint share URLs.
+ *  - `POST /api/track-links/submit` — pre-warms Achordion's match cache
+ *    with the sharer's resolved per-service URLs (Spotify/Apple/SoundCloud)
+ *    so the recipient lands on a fully-populated entity page on first click.
+ *
+ * Per-session dedup: an MBID submitted once won't re-submit until the
+ * process restarts. Matches desktop's `submittedThisSession` in
+ * `parachord-desktop/plugins/achordion.axe`.
+ *
+ * `authFailed` kill-switch: once any call returns 401, subsequent calls
+ * short-circuit without hitting the network until process restart.
+ *
+ * KMP-clean (commonMain). Token is sourced from
+ * [com.parachord.shared.config.AppConfig.achordionBearerToken] which
+ * carries an empty string when not configured — empty-token calls
+ * short-circuit (null entity links / [SubmitResult.AuthFailed]) without
+ * making a request.
+ */
+class AchordionClient(
+    private val httpClient: HttpClient,
+    private val bearerToken: String,
+) {
+    companion object {
+        private const val TAG = "AchordionClient"
+        private const val ENTITY_LINK_ENDPOINT = "https://achordion.xyz/api/entity-link"
+        private const val SUBMIT_ENDPOINT = "https://achordion.xyz/api/track-links/submit"
+        private val json = Json { ignoreUnknownKeys = true; encodeDefaults = false }
+    }
+
+    private val dedupMutex = Mutex()
+    private val submittedThisSession: MutableSet<String> = mutableSetOf()
+    @Volatile private var authFailed: Boolean = false
+
+    suspend fun fetchEntityLink(
+        type: EntityType,
+        mbid: String,
+        includeNames: Boolean = false,
+    ): EntityLink? {
+        TODO("Task 2")
+    }
+
+    suspend fun submitTrackLinks(payload: SubmitTrackLinksRequest): SubmitResult {
+        TODO("Task 3")
+    }
+}
+
+enum class EntityType(val wireValue: String) {
+    Track("track"),
+    ReleaseGroup("release-group"),
+    Artist("artist"),
+}
+
+@Serializable
+data class EntityLink(
+    val url: String,
+    @SerialName("embed_url") val embedUrl: String? = null,
+    val name: String? = null,
+    @SerialName("artist_name") val artistName: String? = null,
+    @SerialName("album_name") val albumName: String? = null,
+)
+
+@Serializable
+data class SubmitTrackLinksRequest(
+    val mbid: String,
+    val links: List<TrackLink>,
+    val trackName: String? = null,
+    val artistName: String? = null,
+    val albumName: String? = null,
+)
+
+@Serializable
+data class TrackLink(
+    val url: String,
+    val host: String,
+    val label: String? = null,
+)
+
+sealed class SubmitResult {
+    object Ok : SubmitResult()
+    object NoLinks : SubmitResult()
+    object AlreadySubmitted : SubmitResult()
+    object NoMbid : SubmitResult()
+    data class HttpError(val status: Int) : SubmitResult()
+    object AuthFailed : SubmitResult()
+    data class NetworkError(val message: String) : SubmitResult()
+}

--- a/shared/src/commonMain/kotlin/com/parachord/shared/api/AchordionClient.kt
+++ b/shared/src/commonMain/kotlin/com/parachord/shared/api/AchordionClient.kt
@@ -6,12 +6,16 @@ import io.ktor.client.request.accept
 import io.ktor.client.request.get
 import io.ktor.client.request.header
 import io.ktor.client.request.parameter
+import io.ktor.client.request.post
+import io.ktor.client.request.setBody
 import io.ktor.client.statement.bodyAsText
 import io.ktor.http.ContentType
 import io.ktor.http.HttpHeaders
 import io.ktor.http.HttpStatusCode
+import io.ktor.http.contentType
 import kotlin.concurrent.Volatile
 import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.Json
@@ -95,7 +99,47 @@ class AchordionClient(
     }
 
     suspend fun submitTrackLinks(payload: SubmitTrackLinksRequest): SubmitResult {
-        TODO("Task 3")
+        if (bearerToken.isBlank()) return SubmitResult.AuthFailed
+        if (authFailed) return SubmitResult.AuthFailed
+        if (payload.mbid.isBlank()) return SubmitResult.NoMbid
+        if (payload.links.isEmpty()) return SubmitResult.NoLinks
+
+        val mbidKey = payload.mbid.lowercase()
+        val alreadySubmitted = dedupMutex.withLock {
+            if (mbidKey in submittedThisSession) true
+            else {
+                submittedThisSession.add(mbidKey)
+                false
+            }
+        }
+        if (alreadySubmitted) return SubmitResult.AlreadySubmitted
+
+        return try {
+            val response = httpClient.post(SUBMIT_ENDPOINT) {
+                header(HttpHeaders.Authorization, "Bearer $bearerToken")
+                contentType(ContentType.Application.Json)
+                setBody(payload)
+            }
+            when (response.status) {
+                HttpStatusCode.OK, HttpStatusCode.Created, HttpStatusCode.Accepted -> SubmitResult.Ok
+                HttpStatusCode.Unauthorized -> {
+                    authFailed = true
+                    Log.w(TAG, "submit returned 401 — suppressing further calls this session")
+                    SubmitResult.AuthFailed
+                }
+                else -> {
+                    dedupMutex.withLock { submittedThisSession.remove(mbidKey) }
+                    Log.w(TAG, "submit returned HTTP ${response.status.value} for mbid=${payload.mbid}")
+                    SubmitResult.HttpError(response.status.value)
+                }
+            }
+        } catch (e: kotlinx.coroutines.CancellationException) {
+            throw e
+        } catch (e: Throwable) {
+            dedupMutex.withLock { submittedThisSession.remove(mbidKey) }
+            Log.w(TAG, "submit failed for mbid=${payload.mbid}: ${e.message}")
+            SubmitResult.NetworkError(e.message ?: "unknown")
+        }
     }
 }
 

--- a/shared/src/commonMain/kotlin/com/parachord/shared/api/AchordionClient.kt
+++ b/shared/src/commonMain/kotlin/com/parachord/shared/api/AchordionClient.kt
@@ -2,6 +2,14 @@ package com.parachord.shared.api
 
 import com.parachord.shared.platform.Log
 import io.ktor.client.HttpClient
+import io.ktor.client.request.accept
+import io.ktor.client.request.get
+import io.ktor.client.request.header
+import io.ktor.client.request.parameter
+import io.ktor.client.statement.bodyAsText
+import io.ktor.http.ContentType
+import io.ktor.http.HttpHeaders
+import io.ktor.http.HttpStatusCode
 import kotlin.concurrent.Volatile
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.serialization.SerialName
@@ -53,7 +61,37 @@ class AchordionClient(
         mbid: String,
         includeNames: Boolean = false,
     ): EntityLink? {
-        TODO("Task 2")
+        if (bearerToken.isBlank()) return null
+        if (authFailed) return null
+        return try {
+            val response = httpClient.get(ENTITY_LINK_ENDPOINT) {
+                parameter("type", type.wireValue)
+                parameter("mbid", mbid)
+                if (includeNames) parameter("include", "names")
+                header(HttpHeaders.Authorization, "Bearer $bearerToken")
+                accept(ContentType.Application.Json)
+            }
+            when (response.status) {
+                HttpStatusCode.Unauthorized -> {
+                    authFailed = true
+                    Log.w(TAG, "entity-link returned 401 — suppressing further calls this session")
+                    null
+                }
+                HttpStatusCode.OK -> {
+                    val body = response.bodyAsText()
+                    json.decodeFromString<EntityLink>(body)
+                }
+                else -> {
+                    Log.w(TAG, "entity-link returned HTTP ${response.status.value} for $type mbid=$mbid")
+                    null
+                }
+            }
+        } catch (e: kotlinx.coroutines.CancellationException) {
+            throw e
+        } catch (e: Throwable) {
+            Log.w(TAG, "entity-link failed for $type mbid=$mbid: ${e.message}")
+            null
+        }
     }
 
     suspend fun submitTrackLinks(payload: SubmitTrackLinksRequest): SubmitResult {

--- a/shared/src/commonMain/kotlin/com/parachord/shared/api/SmartLinksClient.kt
+++ b/shared/src/commonMain/kotlin/com/parachord/shared/api/SmartLinksClient.kt
@@ -11,17 +11,22 @@ import kotlinx.serialization.Serializable
 
 /**
  * Wrapper for the public Smart Links Cloudflare Workers backend that powers
- * desktop's `https://go.parachord.com/<id>` rich share pages — feature.fm /
+ * `https://go.parachord.com/<id>` rich share pages — feature.fm /
  * linkfire-style landing pages with title, artwork, and per-service play
- * buttons. Same backend, same URL shape; the recipient gets a rich preview
- * (Open Graph / oEmbed) on Slack, Discord, iMessage, etc.
+ * buttons. Recipients get a rich preview (Open Graph / oEmbed) on Slack,
+ * Discord, iMessage, etc.
+ *
+ * **Playlist-only after the Achordion migration (v0.6.x+).** Track / album /
+ * artist shares now route through `AchordionClient` (`achordion.xyz`
+ * entity pages with server-side per-service link resolution). This client
+ * is retained for the playlist path because Achordion has no playlist
+ * entity page yet — `ShareManager.sharePlaylist` still mints
+ * `go.parachord.com/<id>` URLs here. Future smart-link-shaped shares
+ * (e.g. albums-with-full-tracklist landing pages) could re-use this
+ * infrastructure if needed.
  *
  * The `/api/create` endpoint is open (CORS `*`, no auth) — see
  * `smart-links/functions/api/create.js` in the Parachord/parachord repo.
- *
- * Migrated from Retrofit → Ktor in the Smart Links cutover (2026-04-29).
- * Closes the last Retrofit footprint in the codebase; the entire app +
- * shared module now uses Ktor exclusively for HTTP.
  *
  * **Base URL trap**: production short URLs land on `go.parachord.com`,
  * NOT `links.parachord.app` (which doesn't even resolve) or the Pages

--- a/shared/src/commonMain/kotlin/com/parachord/shared/config/AppConfig.kt
+++ b/shared/src/commonMain/kotlin/com/parachord/shared/config/AppConfig.kt
@@ -10,6 +10,7 @@ package com.parachord.shared.config
  * is generated in the :app module, which :shared can't reference.
  */
 data class AppConfig(
+    val achordionBearerToken: String = "",
     val lastFmApiKey: String = "",
     val lastFmSharedSecret: String = "",
     val spotifyClientId: String = "",

--- a/shared/src/commonMain/kotlin/com/parachord/shared/di/SharedModule.kt
+++ b/shared/src/commonMain/kotlin/com/parachord/shared/di/SharedModule.kt
@@ -1,5 +1,6 @@
 package com.parachord.shared.di
 
+import com.parachord.shared.api.AchordionClient
 import com.parachord.shared.api.AppleMusicClient
 import com.parachord.shared.api.AppleMusicLibraryClient
 import com.parachord.shared.api.GeoLocationClient
@@ -11,6 +12,7 @@ import com.parachord.shared.api.SmartLinksClient
 import com.parachord.shared.api.SpotifyClient
 import com.parachord.shared.api.TicketmasterClient
 import com.parachord.shared.api.createHttpClient
+import com.parachord.shared.config.AppConfig
 import com.parachord.shared.settings.SettingsStore
 import com.parachord.shared.store.KvStore
 import kotlinx.serialization.json.Json
@@ -89,4 +91,10 @@ val sharedModule = module {
     // auth, CORS-open. Migrated from Retrofit → Ktor in the Smart Links cutover
     // (closes the last Retrofit footprint).
     single { SmartLinksClient(get()) }
+    single {
+        AchordionClient(
+            httpClient = get(),
+            bearerToken = get<AppConfig>().achordionBearerToken,
+        )
+    }
 }

--- a/shared/src/commonTest/kotlin/com/parachord/shared/api/AchordionClientTest.kt
+++ b/shared/src/commonTest/kotlin/com/parachord/shared/api/AchordionClientTest.kt
@@ -140,4 +140,109 @@ class AchordionClientTest {
         assertNull(client.fetchEntityLink(EntityType.Track, "third"))
         assertEquals(1, calls)   // only the first call hits the network
     }
+
+    // ── submitTrackLinks ────────────────────────────────────────────
+
+    private val sampleRequest = SubmitTrackLinksRequest(
+        mbid = "abc-mbid-123",
+        links = listOf(
+            TrackLink(url = "https://open.spotify.com/track/X", host = "spotify.com", label = "Spotify"),
+        ),
+        trackName = "Song",
+        artistName = "Artist",
+        albumName = "Album",
+    )
+
+    @Test
+    fun submitTrackLinks_returnsOk_whenApiReturns200() = runTest {
+        val engine = MockEngine { _ -> respond("", HttpStatusCode.OK) }
+        val client = buildClient(engine)
+        assertEquals(SubmitResult.Ok, client.submitTrackLinks(sampleRequest))
+    }
+
+    @Test
+    fun submitTrackLinks_returnsNoLinks_whenLinksListIsEmpty() = runTest {
+        val engine = MockEngine { _ -> error("should not be called") }
+        val client = buildClient(engine)
+        val result = client.submitTrackLinks(sampleRequest.copy(links = emptyList()))
+        assertEquals(SubmitResult.NoLinks, result)
+    }
+
+    @Test
+    fun submitTrackLinks_returnsNoMbid_whenMbidIsBlank() = runTest {
+        val engine = MockEngine { _ -> error("should not be called") }
+        val client = buildClient(engine)
+        val result = client.submitTrackLinks(sampleRequest.copy(mbid = ""))
+        assertEquals(SubmitResult.NoMbid, result)
+    }
+
+    @Test
+    fun submitTrackLinks_returnsAlreadySubmitted_onSecondCallSameMbid() = runTest {
+        val engine = MockEngine { _ -> respond("", HttpStatusCode.OK) }
+        val client = buildClient(engine)
+        assertEquals(SubmitResult.Ok, client.submitTrackLinks(sampleRequest))
+        assertEquals(SubmitResult.AlreadySubmitted, client.submitTrackLinks(sampleRequest))
+    }
+
+    @Test
+    fun submitTrackLinks_dedupKeyIsLowercaseMbid() = runTest {
+        val engine = MockEngine { _ -> respond("", HttpStatusCode.OK) }
+        val client = buildClient(engine)
+        client.submitTrackLinks(sampleRequest.copy(mbid = "ABC-MBID-123"))
+        val second = client.submitTrackLinks(sampleRequest.copy(mbid = "abc-mbid-123"))
+        assertEquals(SubmitResult.AlreadySubmitted, second)
+    }
+
+    @Test
+    fun submitTrackLinks_returnsAuthFailed_on401() = runTest {
+        val engine = MockEngine { _ -> respond("", HttpStatusCode.Unauthorized) }
+        val client = buildClient(engine)
+        assertEquals(SubmitResult.AuthFailed, client.submitTrackLinks(sampleRequest))
+    }
+
+    @Test
+    fun submitTrackLinks_authFailedShortCircuitsSubsequentCalls() = runTest {
+        var calls = 0
+        val engine = MockEngine { _ ->
+            calls += 1
+            respond("", HttpStatusCode.Unauthorized)
+        }
+        val client = buildClient(engine)
+        client.submitTrackLinks(sampleRequest)
+        val again = client.submitTrackLinks(sampleRequest.copy(mbid = "different-mbid"))
+        assertEquals(SubmitResult.AuthFailed, again)
+        assertEquals(1, calls)
+    }
+
+    @Test
+    fun submitTrackLinks_returnsHttpError_onOther4xx() = runTest {
+        val engine = MockEngine { _ -> respond("", HttpStatusCode.UnprocessableEntity) }
+        val client = buildClient(engine)
+        val result = client.submitTrackLinks(sampleRequest)
+        assertEquals(SubmitResult.HttpError(422), result)
+    }
+
+    @Test
+    fun submitTrackLinks_sendsBearerTokenAndJsonBody() = runTest {
+        var seenAuth: String? = null
+        var seenContentType: String? = null
+        val engine = MockEngine { req ->
+            seenAuth = req.headers["Authorization"]
+            seenContentType = req.body.contentType?.toString() ?: req.headers["Content-Type"]
+            respond("", HttpStatusCode.OK)
+        }
+        val client = buildClient(engine, token = "tok-xyz")
+        client.submitTrackLinks(sampleRequest)
+        assertEquals("Bearer tok-xyz", seenAuth)
+        assertEquals(true, seenContentType?.startsWith("application/json"))
+    }
+
+    @Test
+    fun submitTrackLinks_emptyToken_returnsAuthFailed_doesNotHitNetwork() = runTest {
+        var calls = 0
+        val engine = MockEngine { _ -> calls += 1; respond("", HttpStatusCode.OK) }
+        val client = buildClient(engine, token = "")
+        assertEquals(SubmitResult.AuthFailed, client.submitTrackLinks(sampleRequest))
+        assertEquals(0, calls)
+    }
 }

--- a/shared/src/commonTest/kotlin/com/parachord/shared/api/AchordionClientTest.kt
+++ b/shared/src/commonTest/kotlin/com/parachord/shared/api/AchordionClientTest.kt
@@ -1,0 +1,143 @@
+package com.parachord.shared.api
+
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.mock.MockEngine
+import io.ktor.client.engine.mock.respond
+import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.headersOf
+import io.ktor.serialization.kotlinx.json.json
+import kotlinx.coroutines.test.runTest
+import kotlinx.serialization.json.Json
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+class AchordionClientTest {
+
+    private val json = Json { ignoreUnknownKeys = true }
+
+    private fun buildClient(engine: MockEngine, token: String = "test-token"): AchordionClient {
+        val httpClient = HttpClient(engine) {
+            install(ContentNegotiation) { json(json) }
+        }
+        return AchordionClient(httpClient, token)
+    }
+
+    // ── fetchEntityLink ─────────────────────────────────────────────
+
+    @Test
+    fun fetchEntityLink_returnsCanonicalUrl_whenApiReturns200() = runTest {
+        val engine = MockEngine { _ ->
+            respond(
+                content = """{"url":"https://achordion.xyz/recording/slowdive-sugar","name":"Sugar For The Pill"}""",
+                status = HttpStatusCode.OK,
+                headers = headersOf("Content-Type", "application/json"),
+            )
+        }
+        val client = buildClient(engine)
+        val result = client.fetchEntityLink(EntityType.Track, "abc-mbid")
+        assertEquals("https://achordion.xyz/recording/slowdive-sugar", result?.url)
+        assertEquals("Sugar For The Pill", result?.name)
+    }
+
+    @Test
+    fun fetchEntityLink_returnsNull_on404() = runTest {
+        val engine = MockEngine { _ ->
+            respond(content = """{"error":"Not Found"}""", status = HttpStatusCode.NotFound)
+        }
+        val client = buildClient(engine)
+        assertNull(client.fetchEntityLink(EntityType.Track, "abc-mbid"))
+    }
+
+    @Test
+    fun fetchEntityLink_returnsNull_onMalformedResponse() = runTest {
+        val engine = MockEngine { _ ->
+            respond(
+                content = """{"unexpected":"shape"}""",
+                status = HttpStatusCode.OK,
+                headers = headersOf("Content-Type", "application/json"),
+            )
+        }
+        val client = buildClient(engine)
+        // SerializationException on missing required `url` field → swallowed → null.
+        assertNull(client.fetchEntityLink(EntityType.Track, "abc-mbid"))
+    }
+
+    @Test
+    fun fetchEntityLink_sendsBearerTokenInAuthHeader() = runTest {
+        var seenAuth: String? = null
+        val engine = MockEngine { req ->
+            seenAuth = req.headers["Authorization"]
+            respond(
+                """{"url":"https://achordion.xyz/recording/x"}""",
+                HttpStatusCode.OK,
+                headersOf("Content-Type", "application/json"),
+            )
+        }
+        val client = buildClient(engine, token = "secret-bearer")
+        client.fetchEntityLink(EntityType.Track, "abc-mbid")
+        assertEquals("Bearer secret-bearer", seenAuth)
+    }
+
+    @Test
+    fun fetchEntityLink_encodesMbidAndTypeInQueryString() = runTest {
+        var seenUrl: String? = null
+        val engine = MockEngine { req ->
+            seenUrl = req.url.toString()
+            respond(
+                """{"url":"https://achordion.xyz/release-group/x"}""",
+                HttpStatusCode.OK,
+                headersOf("Content-Type", "application/json"),
+            )
+        }
+        val client = buildClient(engine)
+        client.fetchEntityLink(EntityType.ReleaseGroup, "554b417d-8885-41e6-86c7-ae935e62d571")
+        val url = checkNotNull(seenUrl)
+        assertEquals(true, url.startsWith("https://achordion.xyz/api/entity-link?"))
+        assertEquals(true, url.contains("type=release-group"))
+        assertEquals(true, url.contains("mbid=554b417d-8885-41e6-86c7-ae935e62d571"))
+    }
+
+    @Test
+    fun fetchEntityLink_includeNamesAddsQueryParam() = runTest {
+        var seenUrl: String? = null
+        val engine = MockEngine { req ->
+            seenUrl = req.url.toString()
+            respond(
+                """{"url":"https://achordion.xyz/x"}""",
+                HttpStatusCode.OK,
+                headersOf("Content-Type", "application/json"),
+            )
+        }
+        val client = buildClient(engine)
+        client.fetchEntityLink(EntityType.Track, "abc", includeNames = true)
+        assertEquals(true, seenUrl?.contains("include=names"))
+    }
+
+    @Test
+    fun fetchEntityLink_emptyToken_returnsNull_doesNotHitNetwork() = runTest {
+        var calls = 0
+        val engine = MockEngine { _ ->
+            calls += 1
+            respond("""{"url":"x"}""", HttpStatusCode.OK)
+        }
+        val client = buildClient(engine, token = "")
+        assertNull(client.fetchEntityLink(EntityType.Track, "abc"))
+        assertEquals(0, calls)
+    }
+
+    @Test
+    fun fetchEntityLink_after401_subsequentCallsShortCircuit() = runTest {
+        var calls = 0
+        val engine = MockEngine { _ ->
+            calls += 1
+            respond(content = "", status = HttpStatusCode.Unauthorized)
+        }
+        val client = buildClient(engine)
+        assertNull(client.fetchEntityLink(EntityType.Track, "first"))
+        assertNull(client.fetchEntityLink(EntityType.Track, "second"))
+        assertNull(client.fetchEntityLink(EntityType.Track, "third"))
+        assertEquals(1, calls)   // only the first call hits the network
+    }
+}

--- a/shared/src/commonTest/kotlin/com/parachord/shared/config/AppConfigTest.kt
+++ b/shared/src/commonTest/kotlin/com/parachord/shared/config/AppConfigTest.kt
@@ -28,4 +28,9 @@ class AppConfigTest {
         val config = AppConfig(isDebug = true)
         assertEquals(true, config.isDebug)
     }
+
+    @Test
+    fun achordionBearerToken_defaultIsEmpty() {
+        assertEquals("", AppConfig().achordionBearerToken)
+    }
 }


### PR DESCRIPTION
Migrates outbound share URLs from \`go.parachord.com\` smart-links to Achordion entity pages, matching desktop's \`publishSmartLink\` / \`publishAlbumSmartLink\` / \`publishArtistSmartLink\`. Playlists stay on the existing smart-link path (Achordion has no playlist entity).

## Summary

- New shared **\`AchordionClient\`** (Ktor, commonMain) — \`fetchEntityLink(type, mbid)\` + \`submitTrackLinks(payload)\`. Bearer-authenticated. Per-session dedup (lowercase MBID, Mutex-protected). \`authFailed\` kill-switch on first 401.
- **\`ShareManager.shareTrack\`** fires entity-link + submit in parallel via \`coroutineScope+async\`, awaits both before returning. Submit pre-warms Achordion's cache so recipients see Parachord-resolved per-service links on first click.
- **\`shareAlbum\`** and **\`shareArtist\`** call entity-link only (no submit — desktop comment: \"submissions are recording-keyed\").
- **\`sharePlaylist\`** unchanged. \`SmartLinksClient\` retained for playlist shares + regression test locks the contract.
- **Bearer token** threaded through \`AppConfig.achordionBearerToken\` from a new \`ACHORDION_BEARER_TOKEN\` BuildConfig field. Empty token short-circuits all Achordion calls cleanly.

## Submit gate (matches desktop)

Submit fires when:
1. \`track.recordingMbid\` is non-null+non-blank (proxies for \"high-confidence resolution\").
2. At least one of \`spotifyId\` / \`appleMusicId\` / \`soundcloudId\` is non-blank.
3. MBID hasn't already been submitted this process lifetime (per-session dedup).
4. \`authFailed\` kill-switch not tripped.

HTTP errors roll back the dedup entry so a transient 5xx doesn't permanently mark the MBID as \"submitted\" for the rest of the session.

## Test plan

- [x] 18 \`AchordionClientTest\` MockEngine cases — entity-link happy/404/malformed/auth/empty-token/encoding + submit happy/no-links/no-mbid/dedup/case-insensitive-dedup/auth/short-circuit/HTTP-error.
- [x] 12 \`ShareManagerTest\` mockk + Robolectric cases — track with/without MBID, album with/without MBID, artist with/without MBID, payload shape, blank-id filtering, no-sources-no-submit, playlist-regression-guard.
- [x] All 633 unit tests pass: \`./gradlew :app:testDebugUnitTest :shared:testDebugUnitTest\`
- [x] iOS targets compile clean: \`./gradlew :shared:compileKotlinIosArm64 :shared:compileKotlinIosSimulatorArm64\`
- [ ] Manual on-device — track share lands on \`achordion.xyz/recording/<mbid-or-slug>\`. Cache-warm verifiable via \`adb logcat -s AchordionClient\` + a fresh visit to the resulting URL showing Spotify/Apple/SoundCloud buttons immediately.
- [ ] Manual on-device — album / artist shares fall through to \`/release-group/lookup?…\` / \`/artist/lookup?name=…\` (since callers don't yet plumb MBIDs).
- [ ] Manual on-device — playlist share unchanged (\`go.parachord.com/<id>\`).

## Manual setup needed (before merge for full benefit)

- **GitHub repo secret**: add \`ACHORDION_BEARER_TOKEN\` with the published value from \`parachord-desktop/plugins/achordion.axe\`. Settings → Secrets and variables → Actions → New repository secret. Without this, release builds compile and ship but Achordion submits silently no-op and shares fall through to lookup URLs (still functional, just no pre-warm).

## Known follow-ups

- **Album / Artist MBID plumbing.** Callers currently pass \`releaseGroupMbid = null\` / \`artistMbid = null\` — \`Album\` and \`Artist\` shared models don't carry MBIDs yet. Album/artist shares always hit the lookup path. File-and-defer: thread MBIDs from \`MetadataService\` results so album/artist shares can use canonical entity URLs (not just lookup fallback).
- **Token rotation.** When Achordion rotates the bearer token, update the \`ACHORDION_BEARER_TOKEN\` repo secret + the desktop \`.axe\` plugin in lockstep.

## Plan + design

- [docs/plans/2026-05-10-achordion-share-links-design.md](docs/plans/2026-05-10-achordion-share-links-design.md)
- [docs/plans/2026-05-10-achordion-share-links.md](docs/plans/2026-05-10-achordion-share-links.md)

🤖 Generated with [Claude Code](https://claude.com/claude-code)