### PR TITLE
resolver: stamp direct-ID hint matches at confidence 1.0 (closes #128)

### DIFF
--- a/app/src/main/java/com/parachord/android/resolver/ResolverManager.kt
+++ b/app/src/main/java/com/parachord/android/resolver/ResolverManager.kt
@@ -195,7 +195,12 @@ class ResolverManager constructor(
                     sourceType = "soundcloud",
                     resolver = "soundcloud",
                     soundcloudId = soundcloudId,
-                    confidence = 0.95, // High confidence — direct ID match
+                    // Direct-ID hint: a previously-validated streaming ID is
+                    // by definition correct, so stamp 1.0. Reserves 0.95 for
+                    // fuzzy scoreConfidence() matches. Matches desktop's
+                    // two-tier model (see CLAUDE.md "Achordion Pre-resolution
+                    // Plugin" — tier-1 dispatch gates on >= 1.0).
+                    confidence = 1.0,
                 )
             )
         }
@@ -208,7 +213,8 @@ class ResolverManager constructor(
                     sourceType = "applemusic",
                     resolver = "applemusic",
                     appleMusicId = appleMusicId,
-                    confidence = 0.95, // High confidence — direct ID match
+                    // Direct-ID hint — see SoundCloud branch above.
+                    confidence = 1.0,
                 )
             )
         }
@@ -313,7 +319,8 @@ class ResolverManager constructor(
                 resolver = "spotify",
                 spotifyUri = "spotify:track:${track.id}",
                 spotifyId = track.id,
-                confidence = 0.95, // High confidence — verified ID match
+                // Direct-ID match — see SoundCloud branch above (~L190).
+                confidence = 1.0,
                 artworkUrl = track.album?.images?.firstOrNull()?.url,
             )
         } catch (e: com.parachord.shared.api.SpotifyRateLimitedException) {
@@ -424,7 +431,12 @@ class ResolverManager constructor(
                 url = sourceUrl,
                 sourceType = "local",
                 resolver = "localfiles",
-                confidence = 0.95, // High confidence — exact title+artist match in local library
+                // Direct-match path: findLocalFile is a deterministic
+                // case-insensitive equality SQL lookup, not a fuzzy search.
+                // Matches desktop's localfiles resolver, which the
+                // eager-enrichment gate at app.js:24143 treats as a 1.0
+                // signal. See SoundCloud branch (~L190) for the contract.
+                confidence = 1.0,
                 matchedTitle = track.title,
                 matchedArtist = track.artist,
                 matchedDurationMs = track.duration,


### PR DESCRIPTION
Closes #128.

Android's \`ResolverManager\` stamped \`0.95\` for every successful resolve, including direct-ID hint matches where the streaming ID was already cached. Desktop reserves \`0.95\` for fuzzy \`scoreConfidence()\` matches and uses \`1.0\` for direct-ID matches — the two-tier system is what powers the achordion plugin's **tier-1** (track-start submit) vs **tier-2** (scrobble submit) dispatch.

Today, Android's \`0.95\` ceiling means tier-1 never fires; every Achordion submission is delayed to tier-2 (≥50% play / 4 min). After this PR, tier-1 fires immediately on tracks the resolver had a direct ID hint for.

## Changes — four sites bumped from \`0.95\` → \`1.0\`

| File:Line | Site | Why |
|---|---|---|
| \`ResolverManager.kt:198\` | \`resolveWithHints\` SoundCloud direct-ID branch | Direct \`soundcloudId\` hint = previously-validated ID |
| \`ResolverManager.kt:211\` | \`resolveWithHints\` Apple Music direct-ID branch | Direct \`appleMusicId\` hint = previously-validated ID |
| \`ResolverManager.kt:316\` | \`verifySpotifyTrack\` Spotify ID verification | Direct \`spotifyId\` round-tripped through Spotify API |
| \`ResolverManager.kt:434\` | \`resolveLocalFile\` exact-match | Deterministic case-insensitive SQL equality lookup on title+artist, not fuzzy search |

The local-file site (\`resolveLocalFile\`) is included beyond the original issue scope because \`findLocalFile\` is a deterministic SQL equality lookup (\`LOWER(title) = LOWER(?) AND LOWER(artist) = LOWER(?) LIMIT 1\`) — matching desktop's \`localfiles\` resolver, whose eager-enrichment gate at [\`app.js:24143\`](https://github.com/Parachord/parachord/blob/main/app.js#L24143) explicitly treats localfiles \`confidence >= 1.0\` as the trigger.

## Intentionally NOT touched

\`ResolverModels.kt\`'s \`scoreConfidence()\` stays returning \`0.95\` for fuzzy matches that pass the both-axes (title + artist substring) gate. The tier-2 floor depends on it.

## Test plan

- [x] Full \`:app:testDebugUnitTest\` + \`:shared:testDebugUnitTest\` green. No test updates needed:
  - \`ConfidenceScoringTest\` targets \`scoreConfidence\` (still \`0.95\` — unchanged).
  - \`ResolverScoringTest\` uses \`0.95\` as an arbitrary tie-breaker fixture, not a contract assertion on direct-ID matches.
- [ ] On-device with \`adb logcat -s achordion\` while playing a track that has a cached \`spotifyId\` / \`appleMusicId\` / \`soundcloudId\`: expect \`[achordion] tier-1 POSTing: ...\` at track-start, not waiting for the scrobble threshold.

## Downstream impact (verified per the issue's risk surface)

- \`ResolverScoring.selectBest()\` — direct-ID matches winning ties within the same priority tier more decisively. Correct behavior.
- \`MIN_CONFIDENCE_THRESHOLD\` (\`0.60\`) — both \`0.95\` and \`1.0\` are well above. No filter impact.
- \`ResolverIconRow\` UI dimming threshold (\`<= 0.80\`) — both \`0.95\` and \`1.0\` render at full opacity. No badge change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)