### PR TITLE
sync: heal imported-playlist syncedFrom mismatches at startup (closes #146)

### DIFF
--- a/app/src/test/java/com/parachord/android/sync/HealImportedSyncedFromTest.kt
+++ b/app/src/test/java/com/parachord/android/sync/HealImportedSyncedFromTest.kt
@@ -1,0 +1,304 @@
+package com.parachord.android.sync
+
+import com.parachord.android.data.db.TestDatabaseFactory
+import com.parachord.android.data.db.dao.PlaylistDao
+import com.parachord.android.data.db.dao.SyncPlaylistLinkDao
+import com.parachord.android.data.db.dao.SyncPlaylistSourceDao
+import com.parachord.shared.db.ParachordDb
+import kotlinx.coroutines.runBlocking
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Verifies [com.parachord.shared.sync.SyncEngine.healImportedSyncedFromMismatch]:
+ * mirrors desktop's `healImportedSyncedFromMismatch` (closes #146).
+ *
+ * Implementation lives in `shared/commonMain` so iOS inherits it. Test lives
+ * here because `TestDatabaseFactory` (JDBC SQLite driver) is JVM-only and
+ * commonTest can't pull in a JDBC dependency without breaking the iOS build.
+ * Same approach as the sibling [MigrateSourceFromPlaylistsTest].
+ */
+class HealImportedSyncedFromTest {
+
+    private fun ParachordDb.insertPlaylist(
+        id: String,
+        spotifyId: String? = null,
+        snapshotId: String? = null,
+        locallyModified: Long = 0L,
+    ) {
+        playlistQueries.insert(
+            id = id,
+            name = "Test",
+            description = null,
+            artworkUrl = null,
+            trackCount = 0,
+            createdAt = 1L,
+            updatedAt = 1L,
+            spotifyId = spotifyId,
+            snapshotId = snapshotId,
+            lastModified = 1L,
+            locallyModified = locallyModified,
+            ownerName = null,
+            sourceUrl = null,
+            sourceContentHash = null,
+            localOnly = 0L,
+        )
+    }
+
+    @Test
+    fun `healthy spotifyImported is no-op`() = runBlocking {
+        val db = TestDatabaseFactory.create()
+        db.insertPlaylist(id = "spotify-X", spotifyId = "X")
+        val sourceDao = SyncPlaylistSourceDao(db)
+        val linkDao = SyncPlaylistLinkDao(db)
+        val playlistDao = PlaylistDao(db)
+
+        // Pre-seed the healthy source row.
+        sourceDao.upsert(
+            localPlaylistId = "spotify-X",
+            providerId = "spotify",
+            externalId = "X",
+            snapshotId = "snap-1",
+            ownerId = null,
+            syncedAt = 100L,
+        )
+
+        com.parachord.shared.sync.SyncEngine.healImportedSyncedFromMismatch(
+            playlistDao, sourceDao, linkDao,
+        )
+
+        val src = sourceDao.selectForLocal("spotify-X")
+        assertNotNull(src)
+        assertEquals("spotify", src!!.providerId)
+        assertEquals("X", src.externalId)
+        // Unchanged: snapshot preserved, no link created.
+        assertEquals("snap-1", src.snapshotId)
+        assertEquals(100L, src.syncedAt)
+        assertTrue(linkDao.selectForLocal("spotify-X").isEmpty())
+    }
+
+    @Test
+    fun `corrupted spotifyImported with applemusic source heals and demotes`() = runBlocking {
+        val db = TestDatabaseFactory.create()
+        db.insertPlaylist(id = "spotify-X", spotifyId = "X")
+        val sourceDao = SyncPlaylistSourceDao(db)
+        val linkDao = SyncPlaylistLinkDao(db)
+        val playlistDao = PlaylistDao(db)
+
+        // Corrupt: spotify-prefix playlist with applemusic in sync_playlist_source.
+        sourceDao.upsert(
+            localPlaylistId = "spotify-X",
+            providerId = "applemusic",
+            externalId = "AM-Y",
+            snapshotId = "am-snap",
+            ownerId = null,
+            syncedAt = 100L,
+        )
+
+        com.parachord.shared.sync.SyncEngine.healImportedSyncedFromMismatch(
+            playlistDao, sourceDao, linkDao,
+        )
+
+        // Source row corrected to spotify.
+        val src = sourceDao.selectForLocal("spotify-X")
+        assertNotNull(src)
+        assertEquals("spotify", src!!.providerId)
+        assertEquals("X", src.externalId)
+        assertNull(src.snapshotId) // null so next sync repopulates
+
+        // Demoted applemusic mapping preserved as a link.
+        val link = linkDao.selectForLink("spotify-X", "applemusic")
+        assertNotNull(link)
+        assertEquals("AM-Y", link!!.externalId)
+        assertEquals("am-snap", link.snapshotId)
+    }
+
+    @Test
+    fun `corrupted but link already exists for wrong provider does not overwrite link`() = runBlocking {
+        val db = TestDatabaseFactory.create()
+        db.insertPlaylist(id = "spotify-X", spotifyId = "X")
+        val sourceDao = SyncPlaylistSourceDao(db)
+        val linkDao = SyncPlaylistLinkDao(db)
+        val playlistDao = PlaylistDao(db)
+
+        sourceDao.upsert(
+            localPlaylistId = "spotify-X",
+            providerId = "applemusic",
+            externalId = "AM-Y",
+            snapshotId = "am-snap-stale",
+            ownerId = null,
+            syncedAt = 100L,
+        )
+        // Pre-existing applemusic link with a different externalId and fresher snapshot.
+        linkDao.upsertWithSnapshot(
+            localPlaylistId = "spotify-X",
+            providerId = "applemusic",
+            externalId = "AM-PRESERVED",
+            snapshotId = "am-snap-fresh",
+            syncedAt = 200L,
+        )
+
+        com.parachord.shared.sync.SyncEngine.healImportedSyncedFromMismatch(
+            playlistDao, sourceDao, linkDao,
+        )
+
+        // Source corrected.
+        val src = sourceDao.selectForLocal("spotify-X")
+        assertEquals("spotify", src!!.providerId)
+        assertEquals("X", src.externalId)
+
+        // Existing link preserved untouched.
+        val link = linkDao.selectForLink("spotify-X", "applemusic")
+        assertNotNull(link)
+        assertEquals("AM-PRESERVED", link!!.externalId)
+        assertEquals("am-snap-fresh", link.snapshotId)
+        assertEquals(200L, link.syncedAt)
+    }
+
+    @Test
+    fun `missing source spotifyImported creates source from prefix`() = runBlocking {
+        val db = TestDatabaseFactory.create()
+        db.insertPlaylist(id = "spotify-X", spotifyId = "X")
+        val sourceDao = SyncPlaylistSourceDao(db)
+        val linkDao = SyncPlaylistLinkDao(db)
+        val playlistDao = PlaylistDao(db)
+
+        // No source row at all.
+        assertNull(sourceDao.selectForLocal("spotify-X"))
+
+        com.parachord.shared.sync.SyncEngine.healImportedSyncedFromMismatch(
+            playlistDao, sourceDao, linkDao,
+        )
+
+        val src = sourceDao.selectForLocal("spotify-X")
+        assertNotNull(src)
+        assertEquals("spotify", src!!.providerId)
+        assertEquals("X", src.externalId)
+        assertNull(src.snapshotId)
+        assertNull(src.ownerId)
+        // No link should be created when there was no existing source to demote.
+        assertTrue(linkDao.selectForLocal("spotify-X").isEmpty())
+    }
+
+    @Test
+    fun `noPrefix localId skips`() = runBlocking {
+        val db = TestDatabaseFactory.create()
+        db.insertPlaylist(id = "local-uuid-abc")
+        val sourceDao = SyncPlaylistSourceDao(db)
+        val linkDao = SyncPlaylistLinkDao(db)
+        val playlistDao = PlaylistDao(db)
+
+        com.parachord.shared.sync.SyncEngine.healImportedSyncedFromMismatch(
+            playlistDao, sourceDao, linkDao,
+        )
+
+        // Still no source row, no error.
+        assertNull(sourceDao.selectForLocal("local-uuid-abc"))
+        assertTrue(linkDao.selectForLocal("local-uuid-abc").isEmpty())
+    }
+
+    @Test
+    fun `mixed playlists only heals corrupted`() = runBlocking {
+        val db = TestDatabaseFactory.create()
+        db.insertPlaylist(id = "spotify-HEALTHY", spotifyId = "HEALTHY")
+        db.insertPlaylist(id = "applemusic-HEALTHY-AM", spotifyId = null)
+        db.insertPlaylist(id = "spotify-CORRUPT", spotifyId = "CORRUPT")
+        val sourceDao = SyncPlaylistSourceDao(db)
+        val linkDao = SyncPlaylistLinkDao(db)
+        val playlistDao = PlaylistDao(db)
+
+        // Healthy spotify.
+        sourceDao.upsert(
+            localPlaylistId = "spotify-HEALTHY",
+            providerId = "spotify",
+            externalId = "HEALTHY",
+            snapshotId = "sp-snap",
+            ownerId = null,
+            syncedAt = 100L,
+        )
+        // Healthy applemusic.
+        sourceDao.upsert(
+            localPlaylistId = "applemusic-HEALTHY-AM",
+            providerId = "applemusic",
+            externalId = "HEALTHY-AM",
+            snapshotId = "am-snap",
+            ownerId = null,
+            syncedAt = 100L,
+        )
+        // Corrupt: spotify-prefix playlist with applemusic source.
+        sourceDao.upsert(
+            localPlaylistId = "spotify-CORRUPT",
+            providerId = "applemusic",
+            externalId = "WRONG-ID",
+            snapshotId = "wrong-snap",
+            ownerId = null,
+            syncedAt = 100L,
+        )
+
+        com.parachord.shared.sync.SyncEngine.healImportedSyncedFromMismatch(
+            playlistDao, sourceDao, linkDao,
+        )
+
+        // Healthy rows unchanged.
+        val healthySp = sourceDao.selectForLocal("spotify-HEALTHY")!!
+        assertEquals("spotify", healthySp.providerId)
+        assertEquals("HEALTHY", healthySp.externalId)
+        assertEquals("sp-snap", healthySp.snapshotId)
+        assertEquals(100L, healthySp.syncedAt)
+
+        val healthyAm = sourceDao.selectForLocal("applemusic-HEALTHY-AM")!!
+        assertEquals("applemusic", healthyAm.providerId)
+        assertEquals("HEALTHY-AM", healthyAm.externalId)
+        assertEquals("am-snap", healthyAm.snapshotId)
+        assertEquals(100L, healthyAm.syncedAt)
+
+        // Corrupt row corrected.
+        val healed = sourceDao.selectForLocal("spotify-CORRUPT")!!
+        assertEquals("spotify", healed.providerId)
+        assertEquals("CORRUPT", healed.externalId)
+        assertNull(healed.snapshotId)
+
+        // Demoted link only for the corrupt one.
+        val link = linkDao.selectForLink("spotify-CORRUPT", "applemusic")
+        assertNotNull(link)
+        assertEquals("WRONG-ID", link!!.externalId)
+        assertEquals("wrong-snap", link.snapshotId)
+
+        // Healthy ones never got a phantom link.
+        assertTrue(linkDao.selectForLocal("spotify-HEALTHY").isEmpty())
+        assertTrue(linkDao.selectForLocal("applemusic-HEALTHY-AM").isEmpty())
+    }
+
+    @Test
+    fun `clears locallyModified flag on healed playlist`() = runBlocking {
+        val db = TestDatabaseFactory.create()
+        db.insertPlaylist(id = "spotify-X", spotifyId = "X", locallyModified = 1L)
+        val sourceDao = SyncPlaylistSourceDao(db)
+        val linkDao = SyncPlaylistLinkDao(db)
+        val playlistDao = PlaylistDao(db)
+
+        sourceDao.upsert(
+            localPlaylistId = "spotify-X",
+            providerId = "applemusic",
+            externalId = "AM-Y",
+            snapshotId = null,
+            ownerId = null,
+            syncedAt = 100L,
+        )
+
+        // Sanity-check the seed.
+        assertTrue(playlistDao.getAllSync().first { it.id == "spotify-X" }.locallyModified)
+
+        com.parachord.shared.sync.SyncEngine.healImportedSyncedFromMismatch(
+            playlistDao, sourceDao, linkDao,
+        )
+
+        // Flag cleared.
+        val pl = playlistDao.getAllSync().first { it.id == "spotify-X" }
+        assertFalse(pl.locallyModified)
+    }
+}

--- a/shared/src/commonMain/kotlin/com/parachord/shared/sync/SyncEngine.kt
+++ b/shared/src/commonMain/kotlin/com/parachord/shared/sync/SyncEngine.kt
@@ -125,6 +125,110 @@ class SyncEngine constructor(
                 Log.d(TAG, "Backfilled $added playlist source(s) into sync_playlist_source")
             }
         }
+
+        /**
+         * Heal playlists whose `sync_playlist_source.providerId` doesn't match the
+         * provider implied by the playlist's `id` prefix. Mirrors desktop's
+         * `healImportedSyncedFromMismatch` (runs in `main.js` alongside
+         * `migrateSyncLinksFromPlaylists`).
+         *
+         * Cross-platform invariant: when one client has a sync bug that flips a
+         * Spotify-imported playlist's `syncedFrom.resolver` to `applemusic` (or
+         * `undefined`), the OTHER client's launch must silently restore it. Without
+         * this on Android, an Android regression corrupts a fleet and only desktop
+         * heals.
+         *
+         * Idempotent. Runs every launch. No-op on healthy data (no log unless N > 0).
+         *
+         * For each playlist row whose `id` starts with `spotify-` or `applemusic-`:
+         *   1. Derive `impliedProvider` from the prefix and `externalIdFromPrefix`
+         *      from the substring after it.
+         *   2. Read the current `sync_playlist_source` row.
+         *   3. If existing row matches `impliedProvider`, skip (healthy).
+         *   4. Otherwise:
+         *      a. If the existing row points at a different provider, demote it
+         *         into `sync_playlist_link` (only if no link already exists for
+         *         that provider — never overwrite, an existing link may carry a
+         *         more-recent snapshot).
+         *      b. Restore `sync_playlist_source` with the implied provider +
+         *         externalId from the prefix. `snapshotId = null` so the next sync
+         *         from that provider repopulates it.
+         *      c. Clear `playlist.locallyModified` — the row's state on the
+         *         implied provider is now considered canonical.
+         *
+         * Slot in `syncAll()` between `migrateSourceFromPlaylists` and
+         * `migrateMergeCrossProviderDuplicates`: the source backfill must run
+         * first (it may CREATE source rows from `spotifyId` for installs that
+         * pre-date the source table); the heal then validates / corrects those
+         * rows.
+         */
+        // static for test isolation — avoids constructing SyncEngine with unrelated deps
+        suspend fun healImportedSyncedFromMismatch(
+            playlistDao: PlaylistDao,
+            syncPlaylistSourceDao: SyncPlaylistSourceDao,
+            syncPlaylistLinkDao: SyncPlaylistLinkDao,
+        ) {
+            val supportedProviders = listOf(
+                SpotifySyncProvider.PROVIDER_ID,
+                AppleMusicSyncProvider.PROVIDER_ID,
+            )
+            var healed = 0
+            for (playlist in playlistDao.getAllSync()) {
+                val impliedProvider = supportedProviders.firstOrNull {
+                    playlist.id.startsWith("$it-")
+                } ?: continue
+                val externalIdFromPrefix = playlist.id.substringAfter("$impliedProvider-")
+
+                val existing = syncPlaylistSourceDao.selectForLocal(playlist.id)
+                if (existing != null && existing.providerId == impliedProvider) {
+                    // Healthy — providerId matches the prefix.
+                    continue
+                }
+
+                // Demote: if a source points at the wrong provider, preserve its
+                // external mapping as a link (push target) — but only if no link
+                // already exists. An existing link may carry a more-recent
+                // snapshot we shouldn't clobber.
+                if (existing != null && existing.providerId != impliedProvider) {
+                    val existingLink = syncPlaylistLinkDao.selectForLink(
+                        playlist.id, existing.providerId,
+                    )
+                    if (existingLink == null) {
+                        syncPlaylistLinkDao.upsertWithSnapshot(
+                            localPlaylistId = playlist.id,
+                            providerId = existing.providerId,
+                            externalId = existing.externalId,
+                            snapshotId = existing.snapshotId,
+                            syncedAt = existing.syncedAt,
+                        )
+                    }
+                }
+
+                // Restore the correct syncedFrom. snapshotId = null so the next
+                // sync from impliedProvider repopulates it. ownerId = null —
+                // playlist row doesn't persist ownerId separately on Android.
+                syncPlaylistSourceDao.upsert(
+                    localPlaylistId = playlist.id,
+                    providerId = impliedProvider,
+                    externalId = externalIdFromPrefix,
+                    snapshotId = null,
+                    ownerId = null,
+                    syncedAt = currentTimeMillis(),
+                )
+
+                // Clear locallyModified — the row's state on the implied
+                // provider is now considered canonical. Android's Playlist
+                // model has no `hasUpdates` field; only locallyModified.
+                if (playlist.locallyModified) {
+                    playlistDao.update(playlist.copy(locallyModified = false))
+                }
+
+                healed++
+            }
+            if (healed > 0) {
+                Log.d(TAG, "Healed $healed imported-playlist syncedFrom mismatches")
+            }
+        }
     }
 
     private val syncMutex = Mutex()
@@ -868,6 +972,26 @@ class SyncEngine constructor(
         // `syncedFrom` row so future pull cycles have a stable key beyond
         // the id-prefix convention.
         migrateSourceFromPlaylists(db, syncPlaylistSourceDao)
+
+        // Heal `spotify-*` / `applemusic-*` rows whose
+        // `sync_playlist_source.providerId` doesn't match the id prefix.
+        // Mirrors desktop's `healImportedSyncedFromMismatch` (runs in
+        // main.js alongside migrateSyncLinksFromPlaylists). Cross-
+        // platform invariant: when one client has a sync bug that flips
+        // a Spotify-imported playlist's syncedFrom to applemusic, the
+        // OTHER client's launch must silently restore it. Without this
+        // on Android, an Android regression corrupts a fleet and only
+        // desktop heals.
+        //
+        // Runs AFTER migrateSourceFromPlaylists so the backfill has
+        // populated any missing rows from `spotifyId`, and BEFORE
+        // migrateMergeCrossProviderDuplicates so the dedup pass sees
+        // the corrected providerId values.
+        healImportedSyncedFromMismatch(
+            playlistDao,
+            syncPlaylistSourceDao,
+            syncPlaylistLinkDao,
+        )
 
         // One-shot cleanup for installs that pre-date the cross-provider
         // pull-path name-match (commit ef5a3c2). Walks all playlist


### PR DESCRIPTION
Closes #146. Mirrors desktop's \`healImportedSyncedFromMismatch\` (runs in main.js alongside \`migrateSyncLinksFromPlaylists\`).

## Why cross-platform invariant

When one client has a sync bug that flips a Spotify-imported playlist's \`syncedFrom.resolver\` to \`applemusic\` (or \`undefined\`), the OTHER client's launch must silently restore it. Without this on Android, an Android-side regression corrupts a fleet of playlists and only desktop heals.

Desktop docs explicitly call out that BOTH platforms need it. Implementing in \`shared/commonMain\` means iOS inherits it for free when the shell lands.

## Behavior

Walks every playlist with an ID prefix (\`spotify-*\` or \`applemusic-*\`):
- If \`sync_playlist_source.providerId\` doesn't match the implied prefix:
  - **Demote** the wrong source into \`sync_playlist_link\` (only if no link already exists for that provider — preserves more-recent snapshots).
  - **Restore** \`sync_playlist_source\` with \`impliedProvider + externalId\` derived from the ID prefix. \`snapshotId = null\` so the next sync repopulates.
  - **Clear** \`playlist.locallyModified\`.
- Idempotent. No-op on healthy data. No log unless \`N > 0\`.

Slots into \`SyncEngine.syncAll()\` between \`migrateSourceFromPlaylists\` (which backfills the source table from \`playlist.spotifyId\`) and \`migrateMergeCrossProviderDuplicates\`. The source backfill must run first so the heal has something to validate / correct.

## Architecture

Static helper on \`SyncEngine\`'s companion object — mirrors the existing \`migrateSourceFromPlaylists\` pattern. Tests construct the helper with mock DAOs directly, no full \`SyncEngine\` instance needed.

## Test plan

- [x] 7 \`HealImportedSyncedFromTest\` cases all pass:
  - healthy no-op
  - corrupted (wrong source provider) → heal + demote
  - corrupted + wrong-provider link already exists → don't overwrite link
  - no-source-row (corruption that wiped both spotifyId AND source) → create from prefix
  - no-prefix \`local-*\` ID → skip
  - mixed playlists → only the corrupted one changes
  - \`locallyModified = true\` corrupted → cleared after heal
- [x] Full \`:app:testDebugUnitTest\` + \`:shared:testDebugUnitTest\` green
- [x] iOS targets compile clean (\`:shared:compileKotlinIosArm64\` / \`compileKotlinIosSimulatorArm64\`)

## Cross-refs

- Desktop: \`parachord-desktop/CLAUDE.md\` L517-563 ("Implement the imported-playlist \`syncedFrom\` heal")
- Audit doc that surfaced this: PR #144 / PR #151 / issue #146

🤖 Generated with [Claude Code](https://claude.com/claude-code)