### PR TITLE
friends: stop log-spamming Last.fm rate-limit exceptions (closes #130)

### DIFF
--- a/shared/src/commonMain/kotlin/com/parachord/shared/repository/FriendsRepository.kt
+++ b/shared/src/commonMain/kotlin/com/parachord/shared/repository/FriendsRepository.kt
@@ -1,6 +1,7 @@
 package com.parachord.shared.repository
 
 import com.parachord.shared.api.LastFmClient
+import com.parachord.shared.api.LastFmRateLimitedException
 import com.parachord.shared.api.ListenBrainzClient
 import com.parachord.shared.api.bestImageUrl
 import com.parachord.shared.db.dao.FriendDao
@@ -431,6 +432,16 @@ class FriendsRepository(
                 "lastfm" -> refreshLastFmActivity(friend)
                 "listenbrainz" -> refreshListenBrainzActivity(friend)
             }
+        } catch (e: LastFmRateLimitedException) {
+            // Expected transient under load — the [LastFmClient] rate-limit
+            // gate is doing its job (cooldown is active, short-circuiting
+            // further calls without a network hit). Demote to debug so a
+            // user with 60+ Last.fm friends doesn't see a stack-trace burst
+            // every 2-minute refresh cycle. Re-thrown from the call below
+            // so [refreshAllActivity] can short-circuit the rest of the
+            // cycle's Last.fm friends.
+            Log.d(TAG, "Last.fm rate-limited for ${friend.username} (cooldown active) — skipping")
+            throw e
         } catch (e: Exception) {
             Log.w(TAG, "Failed to refresh activity for ${friend.username}", e)
         }
@@ -439,12 +450,26 @@ class FriendsRepository(
     /**
      * Refresh all friends' activity and update auto-pins.
      * Called periodically (every 2 minutes) by MainViewModel.
+     *
+     * Skips remaining Last.fm friends in the cycle once the rate-limit gate
+     * trips — those calls would all throw [LastFmRateLimitedException]
+     * synchronously without making a network call, but the noise still
+     * accumulates in logcat and wastes a few hundred coroutine launches
+     * every cycle. ListenBrainz friends are unaffected (separate API +
+     * separate gate) so the loop continues for them.
      */
     suspend fun refreshAllActivity() = withContext(Dispatchers.Default) {
         val allFriends = friendDao.getAllFriendsSync()
+        var lastFmRateLimited = false
         for (friend in allFriends) {
+            if (lastFmRateLimited && friend.service == "lastfm") continue
             try {
                 refreshFriendActivity(friend)
+            } catch (e: LastFmRateLimitedException) {
+                // First trip of the cycle — log once at debug, then suppress
+                // for the rest of this cycle's Last.fm friends.
+                lastFmRateLimited = true
+                Log.d(TAG, "Last.fm rate-limit tripped; skipping remaining Last.fm friends this cycle")
             } catch (e: Exception) {
                 Log.w(TAG, "Failed to refresh ${friend.username}", e)
             }


### PR DESCRIPTION
Closes #130.

## Root cause

\`FriendsRepository.refreshAllActivity()\` fires every 2 minutes and calls \`refreshFriendActivity\` for every friend. For accounts with 60+ Last.fm friends, the first few calls succeed (or hit a 429 directly), and the [LastFmClient rate-limit gate](shared/src/commonMain/kotlin/com/parachord/shared/api/RateLimitGate.kt) enters cooldown — at which point every remaining \`refreshLastFmActivity\` call short-circuits with \`LastFmRateLimitedException\` synchronously, without hitting the network.

The gate's behavior is correct. The bug was that every short-circuit was caught at WARN level with a full stack trace, producing 60+ stack-trace bursts every 2 minutes and saturating the 256KB logcat ring buffer.

## Fix

Two surgical changes in \`FriendsRepository\`:

1. \`refreshFriendActivity\` — catch \`LastFmRateLimitedException\` specifically, log at DEBUG (\`"Last.fm rate-limited for \\\$friend (cooldown active) — skipping"\`), and rethrow so the caller can short-circuit.

2. \`refreshAllActivity\` — track a \`lastFmRateLimited: Boolean\` per cycle. On the first rate-limit, log once at debug ("Last.fm rate-limit tripped; skipping remaining Last.fm friends this cycle") and skip remaining Last.fm friends. ListenBrainz friends keep refreshing (separate API + separate gate).

## Functional behavior unchanged

The skipped calls were already failing without network hits. The fix doesn't change what data the user sees — only the log volume and a small CPU saving (no longer launching ~50 coroutines that immediately throw every cycle).

## Test plan

- [x] Compile clean across \`:app:compileDebugKotlin\` and \`:shared:compileKotlinIosArm64\`.
- [x] Existing \`:app:testDebugUnitTest\` and \`:shared:testDebugUnitTest\` green.
- [ ] Manual on-device with 60+ Last.fm friends: \`adb logcat -v threadtime -s FriendsRepository\` over a 2-minute window should produce **at most one debug line** per cycle (\`"Last.fm rate-limit tripped..."\`), vs. dozens of stack traces previously.

## No unit test for the short-circuit

The change is well-localized (14 functional lines, two methods, no new public surface). \`FriendsRepository\` has no existing test harness in shared/commonTest — and mockk isn't multiplatform-friendly there (we'd need MockEngine fixtures + a fake DAO). A 60-line test fixture for a 14-line bug-fix didn't feel worth the proportional cost.

🤖 Generated with [Claude Code](https://claude.com/claude-code)