### PR TITLE
enrichment: slow-trickle cross-resolver background fill for local-files tracks (closes #150)

### DIFF
--- a/app/src/main/java/com/parachord/android/app/ParachordApplication.kt
+++ b/app/src/main/java/com/parachord/android/app/ParachordApplication.kt
@@ -3,6 +3,7 @@ package com.parachord.android.app
 import android.app.Application
 import com.parachord.android.data.metadata.ImageEnrichmentService
 import com.parachord.android.di.androidModule
+import com.parachord.android.enrichment.CrossResolverEnrichmentScheduler
 import com.parachord.android.playlist.HostedPlaylistScheduler
 import com.parachord.shared.di.sharedModule
 import kotlinx.coroutines.CoroutineScope
@@ -17,6 +18,7 @@ class ParachordApplication : Application() {
 
     private val hostedPlaylistScheduler: HostedPlaylistScheduler by inject()
     private val imageEnrichmentService: ImageEnrichmentService by inject()
+    private val crossResolverEnrichmentScheduler: CrossResolverEnrichmentScheduler by inject()
 
     private val appScope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
 
@@ -32,6 +34,13 @@ class ParachordApplication : Application() {
         // The scheduler short-circuits when there are no hosted rows.
         hostedPlaylistScheduler.startInAppTimer()
         hostedPlaylistScheduler.enableWorkManagerPolling()
+
+        // Slow-trickle cross-resolver enrichment (#150): backfills
+        // streaming-service IDs for local-files-only tracks so the
+        // Achordion contribution loop closes for the ~30% of users who
+        // never connect a streaming service. 24h periodic, unmetered +
+        // battery-not-low. Idempotent via WorkManager KEEP policy.
+        crossResolverEnrichmentScheduler.enable()
 
         // On every app launch, regenerate playlist mosaics for any playlist
         // whose artwork isn't already a locally-generated `file://` mosaic.

--- a/app/src/main/java/com/parachord/android/di/AndroidModule.kt
+++ b/app/src/main/java/com/parachord/android/di/AndroidModule.kt
@@ -444,6 +444,37 @@ val androidModule = module {
     singleOf(::ResolverScoring)
     singleOf(::TrackResolverCache)
 
+    // ── Slow-trickle cross-resolver enrichment (#150) ────────────────
+    // The service itself lives in shared/commonMain; the Android Koin
+    // binding closes the resolver lambda over ResolverManager.resolveWithHints.
+    // Per-source confidence gate at 0.95 — well above the 0.60 floor in
+    // ResolverScoring. We don't want to pollute Achordion's match cache
+    // with wrong-song matches that scored just above the playback floor.
+    single {
+        val resolverManager: ResolverManager = get()
+        com.parachord.shared.enrichment.CrossResolverEnrichmentService(
+            trackDao = get(),
+            mbidEnrichmentService = get(),
+            achordionClient = get(),
+            resolveByTitleArtist = { title, artist ->
+                val sources = resolverManager.resolveWithHints(
+                    query = "$artist - $title",
+                    targetTitle = title,
+                    targetArtist = artist,
+                )
+                fun pick(name: String) = sources
+                    .filter { it.resolver == name && (it.confidence ?: 0.0) >= 0.95 }
+                    .maxByOrNull { it.confidence ?: 0.0 }
+                com.parachord.shared.enrichment.CrossResolverEnrichmentService.ResolvedSources(
+                    spotifyId = pick("spotify")?.spotifyId,
+                    appleMusicId = pick("applemusic")?.appleMusicId,
+                    soundcloudId = pick("soundcloud")?.soundcloudId,
+                )
+            },
+        )
+    }
+    single { com.parachord.android.enrichment.CrossResolverEnrichmentScheduler(androidContext()) }
+
     // ── Repositories ─────────────────────────────────────────────────
 
     // LibraryRepository — shared. MbidEnrichmentService is also shared,

--- a/app/src/main/java/com/parachord/android/di/AndroidModule.kt
+++ b/app/src/main/java/com/parachord/android/di/AndroidModule.kt
@@ -255,6 +255,14 @@ val androidModule = module {
         } catch (_: Exception) {
             // Column already present (idempotent on repeat launches).
         }
+        // Slow-trickle cross-resolver enrichment (#150): tracks the last time
+        // we tried to backfill streaming-service IDs for a localfiles-only
+        // track. Same idempotent ALTER pattern as above.
+        try {
+            driver.execute(null, "ALTER TABLE tracks ADD COLUMN crossResolverEnrichedAt INTEGER", 0)
+        } catch (_: Exception) {
+            // Column already present (idempotent on repeat launches).
+        }
         com.parachord.shared.db.ParachordDb(driver)
     }
 

--- a/app/src/main/java/com/parachord/android/enrichment/CrossResolverEnrichmentScheduler.kt
+++ b/app/src/main/java/com/parachord/android/enrichment/CrossResolverEnrichmentScheduler.kt
@@ -1,0 +1,48 @@
+package com.parachord.android.enrichment
+
+import android.content.Context
+import androidx.work.BackoffPolicy
+import androidx.work.Constraints
+import androidx.work.ExistingPeriodicWorkPolicy
+import androidx.work.NetworkType
+import androidx.work.PeriodicWorkRequestBuilder
+import androidx.work.WorkManager
+import com.parachord.shared.platform.Log
+import java.util.concurrent.TimeUnit
+
+/**
+ * Enqueues a periodic [CrossResolverEnrichmentWorker]. Idempotent on
+ * subsequent app launches via `KEEP` policy — once scheduled, WorkManager
+ * keeps the existing job.
+ *
+ * Constraints: requires unmetered network (Wi-Fi) + battery-not-low so
+ * the slow trickle doesn't burn cellular data or drain the battery for
+ * a low-urgency background task.
+ */
+class CrossResolverEnrichmentScheduler(private val context: Context) {
+    companion object {
+        private const val TAG = "CrossResolverEnrichmentScheduler"
+        const val INTERVAL_HOURS: Long = 24
+    }
+
+    fun enable() {
+        val constraints = Constraints.Builder()
+            .setRequiredNetworkType(NetworkType.UNMETERED)
+            .setRequiresBatteryNotLow(true)
+            .build()
+        val request = PeriodicWorkRequestBuilder<CrossResolverEnrichmentWorker>(INTERVAL_HOURS, TimeUnit.HOURS)
+            .setConstraints(constraints)
+            .setBackoffCriteria(BackoffPolicy.EXPONENTIAL, 1, TimeUnit.HOURS)
+            .build()
+        WorkManager.getInstance(context).enqueueUniquePeriodicWork(
+            CrossResolverEnrichmentWorker.WORK_NAME,
+            ExistingPeriodicWorkPolicy.KEEP,
+            request,
+        )
+        Log.d(TAG, "Slow-trickle scheduled (${INTERVAL_HOURS}h interval, unmetered, battery-not-low)")
+    }
+
+    fun disable() {
+        WorkManager.getInstance(context).cancelUniqueWork(CrossResolverEnrichmentWorker.WORK_NAME)
+    }
+}

--- a/app/src/main/java/com/parachord/android/enrichment/CrossResolverEnrichmentWorker.kt
+++ b/app/src/main/java/com/parachord/android/enrichment/CrossResolverEnrichmentWorker.kt
@@ -1,0 +1,39 @@
+package com.parachord.android.enrichment
+
+import android.content.Context
+import androidx.work.CoroutineWorker
+import androidx.work.WorkerParameters
+import com.parachord.shared.enrichment.CrossResolverEnrichmentService
+import com.parachord.shared.platform.Log
+import org.koin.core.component.KoinComponent
+import org.koin.core.component.inject
+
+/**
+ * WorkManager wrapper around [CrossResolverEnrichmentService.runOnce].
+ * Scheduled by [CrossResolverEnrichmentScheduler.enable] every 24h with
+ * unmetered-network + battery-not-low constraints — the slow-trickle
+ * doesn't need to fire often, and the streaming-service API hits
+ * shouldn't burn the user's data or battery.
+ *
+ * Mirrors the shape of [com.parachord.android.playlist.HostedPlaylistWorker].
+ */
+class CrossResolverEnrichmentWorker(
+    appContext: Context,
+    workerParams: WorkerParameters,
+) : CoroutineWorker(appContext, workerParams), KoinComponent {
+
+    private val service: CrossResolverEnrichmentService by inject()
+
+    companion object {
+        private const val TAG = "CrossResolverEnrichmentWorker"
+        const val WORK_NAME = "cross_resolver_enrichment"
+    }
+
+    override suspend fun doWork(): Result = try {
+        service.runOnce()
+        Result.success()
+    } catch (e: Exception) {
+        Log.w(TAG, "Slow-trickle run failed", e)
+        if (runAttemptCount < 3) Result.retry() else Result.failure()
+    }
+}

--- a/app/src/test/java/com/parachord/android/enrichment/CrossResolverEnrichmentServiceTest.kt
+++ b/app/src/test/java/com/parachord/android/enrichment/CrossResolverEnrichmentServiceTest.kt
@@ -1,0 +1,216 @@
+package com.parachord.android.enrichment
+
+import com.parachord.shared.api.AchordionClient
+import com.parachord.shared.api.SubmitResult
+import com.parachord.shared.api.SubmitTrackLinksRequest
+import com.parachord.shared.db.dao.TrackDao
+import com.parachord.shared.enrichment.CrossResolverEnrichmentService
+import com.parachord.shared.enrichment.CrossResolverEnrichmentService.ResolvedSources
+import com.parachord.shared.metadata.MbidEnrichmentService
+import com.parachord.shared.metadata.TrackEnrichmentRequest
+import com.parachord.shared.model.Track
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.mockk
+import io.mockk.slot
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Locks the contract of [CrossResolverEnrichmentService]:
+ *
+ *  - markCrossResolverEnriched ALWAYS fires (even on empty/no-match runs)
+ *    so un-findable tracks aren't thrashed each cycle.
+ *  - DB persistence is additive — never overwrites an existing ID.
+ *  - Achordion submit only fires when MBID + >= 1 streaming ID are
+ *    BOTH present.
+ *  - The slow-trickle delay is enforced between tracks.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+class CrossResolverEnrichmentServiceTest {
+
+    private fun newTrack(
+        id: String = "t1",
+        title: String = "Song",
+        artist: String = "Artist",
+        album: String? = "Album",
+        spotifyId: String? = null,
+        appleMusicId: String? = null,
+        soundcloudId: String? = null,
+        recordingMbid: String? = null,
+    ) = Track(
+        id = id,
+        title = title,
+        artist = artist,
+        album = album,
+        resolver = "localfiles",
+        spotifyId = spotifyId,
+        appleMusicId = appleMusicId,
+        soundcloudId = soundcloudId,
+        recordingMbid = recordingMbid,
+    )
+
+    private fun newService(
+        trackDao: TrackDao,
+        mbidService: MbidEnrichmentService = mockk(relaxed = true),
+        achordion: AchordionClient = mockk(relaxed = true),
+        resolve: suspend (String, String) -> ResolvedSources = { _, _ -> ResolvedSources() },
+    ) = CrossResolverEnrichmentService(
+        trackDao = trackDao,
+        mbidEnrichmentService = mbidService,
+        achordionClient = achordion,
+        resolveByTitleArtist = resolve,
+    )
+
+    @Test
+    fun `runOnce with no candidates returns zero counts and makes no API calls`() = runTest {
+        val dao = mockk<TrackDao>(relaxed = true)
+        coEvery { dao.selectCrossResolverEnrichmentCandidates(any(), any()) } returns emptyList()
+        val achordion = mockk<AchordionClient>(relaxed = true)
+        val service = newService(dao, achordion = achordion)
+
+        val result = service.runOnce()
+
+        assertEquals(0, result.visited)
+        assertEquals(0, result.enrichedAnyId)
+        assertEquals(0, result.submittedToAchordion)
+        coVerify(exactly = 0) { dao.markCrossResolverEnriched(any(), any()) }
+        coVerify(exactly = 0) { achordion.submitTrackLinks(any()) }
+    }
+
+    @Test
+    fun `runOnce with one track that finds no MBID and no resolver results stamps timestamp only`() = runTest {
+        val track = newTrack()
+        val dao = mockk<TrackDao>(relaxed = true)
+        coEvery { dao.selectCrossResolverEnrichmentCandidates(any(), any()) } returns listOf(track)
+        coEvery { dao.getById("t1") } returns track
+        val achordion = mockk<AchordionClient>(relaxed = true)
+        val service = newService(dao, achordion = achordion) { _, _ -> ResolvedSources() }
+
+        val result = service.runOnce()
+
+        assertEquals(1, result.visited)
+        assertEquals(0, result.enrichedAnyId)
+        assertEquals(0, result.submittedToAchordion)
+        coVerify(exactly = 1) { dao.markCrossResolverEnriched("t1", any()) }
+        coVerify(exactly = 0) { dao.backfillResolverIds(any(), any(), any(), any(), any()) }
+        coVerify(exactly = 0) { achordion.submitTrackLinks(any()) }
+    }
+
+    @Test
+    fun `runOnce persists new streaming ID but does NOT submit to Achordion when MBID is missing`() = runTest {
+        val track = newTrack(recordingMbid = null)
+        val dao = mockk<TrackDao>(relaxed = true)
+        coEvery { dao.selectCrossResolverEnrichmentCandidates(any(), any()) } returns listOf(track)
+        // After backfill, getById still returns the same track (no MBID since
+        // mbidService is a relaxed mock and writes nothing).
+        coEvery { dao.getById("t1") } returns track
+        val achordion = mockk<AchordionClient>(relaxed = true)
+        val service = newService(dao, achordion = achordion) { _, _ ->
+            ResolvedSources(spotifyId = "SPOT123")
+        }
+
+        val result = service.runOnce()
+
+        assertEquals(1, result.visited)
+        assertEquals(1, result.enrichedAnyId)
+        assertEquals(0, result.submittedToAchordion)
+        coVerify(exactly = 1) {
+            dao.backfillResolverIds(
+                trackId = "t1",
+                spotifyId = "SPOT123",
+                spotifyUri = "spotify:track:SPOT123",
+                appleMusicId = null,
+                soundcloudId = null,
+            )
+        }
+        coVerify(exactly = 0) { achordion.submitTrackLinks(any()) }
+        coVerify(exactly = 1) { dao.markCrossResolverEnriched("t1", any()) }
+    }
+
+    @Test
+    fun `runOnce with MBID present and resolver finds IDs submits to Achordion with all links`() = runTest {
+        val initial = newTrack(recordingMbid = "mbid-abc")
+        val afterBackfill = initial.copy(spotifyId = "SPOT", appleMusicId = "AM")
+        val dao = mockk<TrackDao>(relaxed = true)
+        coEvery { dao.selectCrossResolverEnrichmentCandidates(any(), any()) } returns listOf(initial)
+        coEvery { dao.getById("t1") } returns afterBackfill
+        val achordion = mockk<AchordionClient>(relaxed = true)
+        coEvery { achordion.submitTrackLinks(any()) } returns SubmitResult.Ok
+        val payload = slot<SubmitTrackLinksRequest>()
+        val service = newService(dao, achordion = achordion) { _, _ ->
+            ResolvedSources(spotifyId = "SPOT", appleMusicId = "AM")
+        }
+
+        val result = service.runOnce()
+
+        assertEquals(1, result.visited)
+        assertEquals(1, result.enrichedAnyId)
+        assertEquals(1, result.submittedToAchordion)
+        coVerify(exactly = 1) { achordion.submitTrackLinks(capture(payload)) }
+        assertEquals("mbid-abc", payload.captured.mbid)
+        assertEquals(2, payload.captured.links.size)
+        assertTrue(payload.captured.links.any { it.host == "spotify.com" })
+        assertTrue(payload.captured.links.any { it.host == "music.apple.com" })
+        assertEquals("Song", payload.captured.trackName)
+        assertEquals("Artist", payload.captured.artistName)
+        assertEquals("Album", payload.captured.albumName)
+        coVerify(exactly = 1) { dao.markCrossResolverEnriched("t1", any()) }
+    }
+
+    @Test
+    fun `runOnce throttles between tracks with DELAY_BETWEEN_TRACKS_MS`() = runTest {
+        val tracks = listOf(newTrack(id = "a"), newTrack(id = "b"), newTrack(id = "c"))
+        val dao = mockk<TrackDao>(relaxed = true)
+        coEvery { dao.selectCrossResolverEnrichmentCandidates(any(), any()) } returns tracks
+        coEvery { dao.getById(any()) } answers { tracks.find { it.id == firstArg() } }
+        val service = newService(dao) { _, _ -> ResolvedSources() }
+
+        val start = testScheduler.currentTime
+        service.runOnce()
+        val elapsed = testScheduler.currentTime - start
+
+        // Two delays for three tracks (none before first iter).
+        val expectedMinDelay = 2 * CrossResolverEnrichmentService.DELAY_BETWEEN_TRACKS_MS
+        assertTrue(
+            "Expected at least $expectedMinDelay ms of virtual delay between 3 tracks, got $elapsed",
+            elapsed >= expectedMinDelay,
+        )
+        coVerify(exactly = 1) { dao.markCrossResolverEnriched("a", any()) }
+        coVerify(exactly = 1) { dao.markCrossResolverEnriched("b", any()) }
+        coVerify(exactly = 1) { dao.markCrossResolverEnriched("c", any()) }
+    }
+
+    @Test
+    fun `runOnce does not overwrite existing streaming IDs`() = runTest {
+        // Track already has a Spotify ID; resolver returns a DIFFERENT spotify ID
+        // — must NOT be persisted. Apple Music IS new and SHOULD be persisted.
+        val track = newTrack(spotifyId = "EXISTING", recordingMbid = "mbid-abc")
+        val dao = mockk<TrackDao>(relaxed = true)
+        coEvery { dao.selectCrossResolverEnrichmentCandidates(any(), any()) } returns listOf(track)
+        coEvery { dao.getById("t1") } returns track.copy(appleMusicId = "AM_NEW")
+        val achordion = mockk<AchordionClient>(relaxed = true)
+        coEvery { achordion.submitTrackLinks(any()) } returns SubmitResult.Ok
+        val service = newService(dao, achordion = achordion) { _, _ ->
+            ResolvedSources(spotifyId = "DIFFERENT_SPOT", appleMusicId = "AM_NEW")
+        }
+
+        service.runOnce()
+
+        // Spotify is filtered out (existing) → null. AM is new → "AM_NEW".
+        // No spotifyUri either (since spotify is filtered out).
+        coVerify(exactly = 1) {
+            dao.backfillResolverIds(
+                trackId = "t1",
+                spotifyId = null,
+                spotifyUri = null,
+                appleMusicId = "AM_NEW",
+                soundcloudId = null,
+            )
+        }
+    }
+}

--- a/shared/src/commonMain/kotlin/com/parachord/shared/db/dao/TrackDao.kt
+++ b/shared/src/commonMain/kotlin/com/parachord/shared/db/dao/TrackDao.kt
@@ -7,6 +7,7 @@ import app.cash.sqldelight.db.SqlDriver
 import com.parachord.shared.db.ParachordDb
 import com.parachord.shared.db.Tracks
 import com.parachord.shared.model.Track
+import com.parachord.shared.platform.currentTimeMillis
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
@@ -29,6 +30,7 @@ class TrackDao(private val db: ParachordDb, private val driver: SqlDriver) {
         resolver = resolver, spotifyUri = spotifyUri, soundcloudId = soundcloudId,
         spotifyId = spotifyId, appleMusicId = appleMusicId,
         recordingMbid = recordingMbid, artistMbid = artistMbid, releaseMbid = releaseMbid,
+        crossResolverEnrichedAt = crossResolverEnrichedAt,
     )
 
     /* ---- Queries returning Flow ---- */
@@ -155,6 +157,26 @@ class TrackDao(private val db: ParachordDb, private val driver: SqlDriver) {
             soundcloudId = soundcloudId,
             id = trackId,
         )
+    }
+
+    /**
+     * Slow-trickle candidates: localfiles tracks missing >=1 streaming-service
+     * ID, not visited within the cooldown window. Never-tried first.
+     */
+    suspend fun selectCrossResolverEnrichmentCandidates(
+        olderThanEpochMs: Long,
+        limit: Int,
+    ): List<Track> = withContext(Dispatchers.Default) {
+        queries.selectCrossResolverEnrichmentCandidates(olderThanEpochMs, limit.toLong())
+            .executeAsList()
+            .map { it.toTrack() }
+    }
+
+    suspend fun markCrossResolverEnriched(
+        id: String,
+        epochMs: Long = currentTimeMillis(),
+    ): Unit = withContext(Dispatchers.Default) {
+        queries.markCrossResolverEnriched(epochMs, id)
     }
 
     suspend fun backfillMbids(

--- a/shared/src/commonMain/kotlin/com/parachord/shared/enrichment/CrossResolverEnrichmentService.kt
+++ b/shared/src/commonMain/kotlin/com/parachord/shared/enrichment/CrossResolverEnrichmentService.kt
@@ -1,0 +1,209 @@
+package com.parachord.shared.enrichment
+
+import com.parachord.shared.api.AchordionClient
+import com.parachord.shared.api.SubmitTrackLinksRequest
+import com.parachord.shared.api.TrackLink
+import com.parachord.shared.db.dao.TrackDao
+import com.parachord.shared.metadata.MbidEnrichmentService
+import com.parachord.shared.metadata.TrackEnrichmentRequest
+import com.parachord.shared.model.Track
+import com.parachord.shared.platform.Log
+import com.parachord.shared.platform.currentTimeMillis
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.delay
+
+/**
+ * Slow-trickle enrichment of local-files-only tracks: tries to find
+ * streaming-service IDs (Spotify / Apple Music / SoundCloud) via the
+ * resolver cascade and pushes the matches to Achordion's match cache.
+ *
+ * Mirrors desktop's slow-trickle path (CLAUDE.md "Cross-Resolver
+ * Enrichment (Eager Gate + Slow Trickle)"). The purpose isn't user-
+ * facing speed-up — it's the **Achordion contribution loop** for the
+ * ~30% of users whose libraries are local-files only. Without this,
+ * those users never feed track-links back to Achordion's match cache.
+ *
+ * Throttled per-track to avoid hammering streaming-service APIs:
+ *
+ *  - At most [BATCH_SIZE] tracks per run (default 20).
+ *  - [DELAY_BETWEEN_TRACKS_MS] between tracks (default 3000ms).
+ *  - Cooldown of [COOLDOWN_MS] before revisiting a previously-enriched
+ *    track (default 30 days).
+ *
+ * Per-track flow:
+ *
+ *  1. If the track lacks `recordingMbid`, kick the [MbidEnrichmentService]
+ *     synchronously and re-read.
+ *  2. Run [resolveByTitleArtist] to find streaming-service matches.
+ *  3. Persist any new IDs to the track row (additive — never overwrites
+ *     an existing populated ID).
+ *  4. If MBID is now present AND we have >=1 streaming ID, submit to
+ *     Achordion via [AchordionClient.submitTrackLinks].
+ *  5. Stamp `crossResolverEnrichedAt = now` regardless of outcome (so a
+ *     track with no findable matches isn't retried until the cooldown
+ *     elapses).
+ *
+ * Lives in shared/commonMain so iOS inherits. Generic over the resolver:
+ * takes a `(title, artist) -> ResolvedSources` lambda so the service
+ * itself doesn't depend on `:app`-only `ResolverManager`. The Android
+ * Koin binding closes over `ResolverManager.resolveWithHints` and applies
+ * the per-source confidence gate at 0.95.
+ */
+class CrossResolverEnrichmentService(
+    private val trackDao: TrackDao,
+    private val mbidEnrichmentService: MbidEnrichmentService,
+    private val achordionClient: AchordionClient,
+    private val resolveByTitleArtist: suspend (title: String, artist: String) -> ResolvedSources,
+) {
+    /** Bundle of IDs that the resolver cascade can return. Any can be null. */
+    data class ResolvedSources(
+        val spotifyId: String? = null,
+        val appleMusicId: String? = null,
+        val soundcloudId: String? = null,
+    ) {
+        val isEmpty: Boolean
+            get() = spotifyId.isNullOrBlank() && appleMusicId.isNullOrBlank() && soundcloudId.isNullOrBlank()
+    }
+
+    companion object {
+        private const val TAG = "CrossResolverEnrichmentService"
+        const val BATCH_SIZE: Int = 20
+        const val DELAY_BETWEEN_TRACKS_MS: Long = 3_000L
+        const val COOLDOWN_MS: Long = 30L * 24L * 60L * 60L * 1000L // 30 days
+    }
+
+    /**
+     * One run of the slow trickle. Picks up to [BATCH_SIZE] candidates,
+     * walks them sequentially with a [DELAY_BETWEEN_TRACKS_MS] gap, and
+     * reports counts.
+     */
+    suspend fun runOnce(): RunResult {
+        val cutoff = currentTimeMillis() - COOLDOWN_MS
+        val candidates = trackDao.selectCrossResolverEnrichmentCandidates(cutoff, BATCH_SIZE)
+        if (candidates.isEmpty()) {
+            return RunResult(visited = 0, enrichedAnyId = 0, submittedToAchordion = 0)
+        }
+        Log.d(TAG, "Slow-trickle run starting: ${candidates.size} candidate(s)")
+        var enrichedAnyId = 0
+        var submittedToAchordion = 0
+        for ((index, track) in candidates.withIndex()) {
+            if (index > 0) delay(DELAY_BETWEEN_TRACKS_MS)
+            val outcome = enrichOne(track)
+            if (outcome.gainedAnyStreamingId) enrichedAnyId++
+            if (outcome.submittedToAchordion) submittedToAchordion++
+        }
+        Log.d(
+            TAG,
+            "Slow-trickle run done: visited=${candidates.size} enrichedAnyId=$enrichedAnyId submittedToAchordion=$submittedToAchordion",
+        )
+        return RunResult(
+            visited = candidates.size,
+            enrichedAnyId = enrichedAnyId,
+            submittedToAchordion = submittedToAchordion,
+        )
+    }
+
+    /** Per-run outcome. */
+    data class RunResult(val visited: Int, val enrichedAnyId: Int, val submittedToAchordion: Int)
+
+    private data class PerTrackOutcome(val gainedAnyStreamingId: Boolean, val submittedToAchordion: Boolean)
+
+    private suspend fun enrichOne(originalTrack: Track): PerTrackOutcome {
+        var track = originalTrack
+        try {
+            // 1. MBID backfill if missing.
+            if (track.recordingMbid.isNullOrBlank()) {
+                try {
+                    mbidEnrichmentService.enrichTrack(
+                        TrackEnrichmentRequest(track.id, track.artist, track.title),
+                    )
+                    // Re-read for the freshly-populated MBID.
+                    val refreshed = trackDao.getById(track.id)
+                    if (refreshed != null) track = refreshed
+                } catch (e: CancellationException) {
+                    throw e
+                } catch (e: Exception) {
+                    Log.d(TAG, "MBID enrichment failed for ${track.artist} - ${track.title}: ${e.message}")
+                    // Continue — we may still find streaming IDs even without MBID
+                    // (just can't submit to Achordion).
+                }
+            }
+
+            // 2. Resolve streaming-service matches.
+            val resolved = try {
+                resolveByTitleArtist(track.title, track.artist)
+            } catch (e: CancellationException) {
+                throw e
+            } catch (e: Exception) {
+                Log.d(TAG, "Resolve failed for ${track.artist} - ${track.title}: ${e.message}")
+                ResolvedSources()
+            }
+
+            // 3. Persist additively. Don't overwrite existing IDs.
+            val newSpotify = resolved.spotifyId?.takeIf { it.isNotBlank() && track.spotifyId.isNullOrBlank() }
+            val newAppleMusic = resolved.appleMusicId?.takeIf { it.isNotBlank() && track.appleMusicId.isNullOrBlank() }
+            val newSoundCloud = resolved.soundcloudId?.takeIf { it.isNotBlank() && track.soundcloudId.isNullOrBlank() }
+            val gainedAny = newSpotify != null || newAppleMusic != null || newSoundCloud != null
+
+            if (gainedAny) {
+                trackDao.backfillResolverIds(
+                    trackId = track.id,
+                    spotifyId = newSpotify,
+                    spotifyUri = newSpotify?.let { "spotify:track:$it" },
+                    appleMusicId = newAppleMusic,
+                    soundcloudId = newSoundCloud,
+                )
+                track = trackDao.getById(track.id) ?: track
+            }
+
+            // 4. Submit to Achordion when MBID + at least one streaming ID is present.
+            val mbid = track.recordingMbid
+            val submitted = if (!mbid.isNullOrBlank()) {
+                val links = buildList {
+                    track.spotifyId?.takeIf { it.isNotBlank() }?.let {
+                        add(TrackLink("https://open.spotify.com/track/$it", "spotify.com", "Spotify"))
+                    }
+                    track.appleMusicId?.takeIf { it.isNotBlank() }?.let {
+                        add(TrackLink("https://music.apple.com/song/$it", "music.apple.com", "Apple Music"))
+                    }
+                    track.soundcloudId?.takeIf { it.isNotBlank() }?.let {
+                        add(TrackLink("https://soundcloud.com/$it", "soundcloud.com", "SoundCloud"))
+                    }
+                }
+                if (links.isNotEmpty()) {
+                    try {
+                        achordionClient.submitTrackLinks(
+                            SubmitTrackLinksRequest(
+                                mbid = mbid,
+                                links = links,
+                                trackName = track.title,
+                                artistName = track.artist,
+                                albumName = track.album,
+                            ),
+                        )
+                        true
+                    } catch (e: CancellationException) {
+                        throw e
+                    } catch (e: Exception) {
+                        Log.d(TAG, "Achordion submit failed for ${track.artist} - ${track.title}: ${e.message}")
+                        false
+                    }
+                } else false
+            } else false
+
+            return PerTrackOutcome(gainedAnyStreamingId = gainedAny, submittedToAchordion = submitted)
+        } finally {
+            // 5. ALWAYS stamp the cooldown — even on failure — so a track
+            // with no findable matches isn't revisited until the next
+            // cooldown window. Otherwise the loop would thrash on the
+            // same un-findable tracks every run.
+            try {
+                trackDao.markCrossResolverEnriched(track.id, currentTimeMillis())
+            } catch (e: CancellationException) {
+                throw e
+            } catch (e: Exception) {
+                Log.w(TAG, "Failed to mark enrichment timestamp for ${track.id}: ${e.message}")
+            }
+        }
+    }
+}

--- a/shared/src/commonMain/kotlin/com/parachord/shared/metadata/MbidEnrichmentService.kt
+++ b/shared/src/commonMain/kotlin/com/parachord/shared/metadata/MbidEnrichmentService.kt
@@ -115,6 +115,24 @@ class MbidEnrichmentService(
     }
 
     /**
+     * Synchronously enrich one track and return when the mapper lookup
+     * + Room backfill is complete. Unlike [enrichInBackground], this
+     * suspends until the work is done — required by the slow-trickle
+     * cross-resolver visitor which needs the MBID populated before it
+     * can submit to Achordion. Safe to call from any coroutine context;
+     * dedup-friendly via the same [tryClaim]/[release] gate.
+     */
+    suspend fun enrichTrack(req: TrackEnrichmentRequest) {
+        if (req.artist.isBlank() || req.title.isBlank()) return
+        if (!tryClaim(req.trackId)) return
+        try {
+            enrichTrack(req.trackId, req.artist, req.title)
+        } finally {
+            release(req.trackId)
+        }
+    }
+
+    /**
      * Look up an artist MBID from the cache or via the mapper.
      * Returns null if not found. Does not persist to Room (no trackId context).
      * Used by FreshDropsRepository for release-group browsing.

--- a/shared/src/commonMain/kotlin/com/parachord/shared/model/Track.kt
+++ b/shared/src/commonMain/kotlin/com/parachord/shared/model/Track.kt
@@ -33,6 +33,12 @@ data class Track(
     val artistMbid: String? = null,
     /** MusicBrainz release MBID. */
     val releaseMbid: String? = null,
+    /**
+     * Epoch-ms timestamp of the last slow-trickle cross-resolver enrichment
+     * attempt. Null = never tried. Set by [CrossResolverEnrichmentService]
+     * regardless of outcome so un-findable tracks aren't thrashed every run.
+     */
+    val crossResolverEnrichedAt: Long? = null,
 ) {
     /**
      * Derive all available resolvers from stored IDs.

--- a/shared/src/commonMain/sqldelight/com/parachord/shared/db/Track.sq
+++ b/shared/src/commonMain/sqldelight/com/parachord/shared/db/Track.sq
@@ -16,7 +16,8 @@ CREATE TABLE IF NOT EXISTS tracks (
     appleMusicId TEXT,
     recordingMbid TEXT,
     artistMbid TEXT,
-    releaseMbid TEXT
+    releaseMbid TEXT,
+    crossResolverEnrichedAt INTEGER
 );
 
 getAll:
@@ -67,6 +68,17 @@ UPDATE tracks SET
     artistMbid = CASE WHEN (artistMbid IS NULL OR artistMbid = '') THEN ? ELSE artistMbid END,
     releaseMbid = CASE WHEN (releaseMbid IS NULL OR releaseMbid = '') THEN ? ELSE releaseMbid END
 WHERE id = ?;
+
+selectCrossResolverEnrichmentCandidates:
+SELECT * FROM tracks
+WHERE resolver = 'localfiles'
+  AND (spotifyId IS NULL OR appleMusicId IS NULL OR soundcloudId IS NULL)
+  AND (crossResolverEnrichedAt IS NULL OR crossResolverEnrichedAt < ?)
+ORDER BY (crossResolverEnrichedAt IS NULL) DESC, addedAt DESC
+LIMIT ?;
+
+markCrossResolverEnriched:
+UPDATE tracks SET crossResolverEnrichedAt = ? WHERE id = ?;
 
 deleteSyncedTracks:
 DELETE FROM tracks WHERE id LIKE 'spotify-%';


### PR DESCRIPTION
Closes #150. Three commits, in order.

## Why

~30% of Parachord users are local-files-only. Their tracks never get streaming-service IDs populated, which means the **Achordion contribution loop is broken** for them — they never feed track-links back to Achordion's match cache. Desktop has a background "slow trickle" that fixes this; Android didn't. This PR ports the equivalent.

The purpose isn't user-facing speed-up. It's the contribution loop. The longer this stays broken, the more silently degraded Achordion's match cache becomes for newcomers.

## Commits

1. **`fcd72bb` db: tracks.crossResolverEnrichedAt column + candidate query** — schema scaffolding. New nullable epoch-ms column + two SQL queries (\`selectCrossResolverEnrichmentCandidates(olderThan, limit)\` and \`markCrossResolverEnriched(id, ts)\`). \`ALTER TABLE\` migration follows the existing \`sourceUrl\` / \`sourceContentHash\` pattern (try once, swallow duplicate-column on subsequent runs).

2. **`64902ab` enrichment: CrossResolverEnrichmentService + tests** — pure logic in shared/commonMain so iOS inherits. Per-track flow: MBID backfill if missing → resolver cascade → additive DB persist → Achordion submitTrackLinks when MBID + ≥1 streaming ID present. Always stamps cooldown (even on failure). Throttle defaults: 20 tracks/run, 3s between tracks, 30d cooldown. Generic over the resolver via a \`suspend (title, artist) -> ResolvedSources\` lambda so the service compiles in commonMain. 6 unit tests cover the contract.

3. **`038d1a5` enrichment: WorkManager + scheduler + Koin wiring** — Android glue. \`CrossResolverEnrichmentWorker\` (CoroutineWorker, 24h periodic), \`CrossResolverEnrichmentScheduler\` (unmetered + battery-not-low constraints, KEEP policy for idempotent re-scheduling), Koin binding that closes over \`ResolverManager.resolveWithHints\` gated at ≥0.95 confidence per desktop's PER_SOURCE_MIN_CONFIDENCE.

## Design notes

- **0.95 confidence gate**: \`MIN_CONFIDENCE_THRESHOLD\` is 0.60 for playback filtering, but the slow-trickle submits to Achordion's shared cache. Pollution risk is real; matches \<0.95 are dropped. Per-resolver \`maxByOrNull { it.confidence }\` picks the best candidate when the cascade returns multiple.
- **Always stamp cooldown**: a track with no findable matches still gets \`crossResolverEnrichedAt = now\` set so the loop doesn't thrash on un-findable tracks every cycle.
- **Additive persist**: never overwrites existing streaming IDs. Both the Kotlin filter AND the existing \`backfillResolverIds\` SQL enforce the null-only-update invariant.
- **MBID requirement for Achordion submit**: if a track lacks \`recordingMbid\` after enrichment, the streaming IDs are persisted locally but no Achordion submit fires. The next mapper backfill via \`MbidEnrichmentService\` will eventually populate the MBID, and a subsequent slow-trickle cycle catches it.

## Out of scope

- Per-track immediate-trickle (the slow part is the point — gentle background contribution, not eager fan-out).
- iOS scheduler (the service is KMP-ready; the iOS shell needs its own equivalent of \`CrossResolverEnrichmentScheduler\` when iOS lands).

## Test plan

- [x] 6/6 \`CrossResolverEnrichmentServiceTest\` cases pass:
  - empty candidates → visited=0
  - no MBID + no result → marks cooldown, no other writes
  - resolver finds Spotify ID, MBID missing → persists locally, no Achordion submit
  - MBID present + resolver finds 2 IDs → DB updated + AchordionClient.submitTrackLinks called
  - 3 tracks → throttle delays between them
  - existing streaming ID → not overwritten
- [x] Full \`:app:testDebugUnitTest :shared:testDebugUnitTest\` green
- [x] iOS targets compile clean (\`:shared:compileKotlinIosArm64\` / \`compileKotlinIosSimulatorArm64\`)
- [ ] Manual on-device: install, force a worker run, watch \`adb logcat -s CrossResolverEnrichmentService CrossResolverEnrichmentWorker\` for one cycle. Expect \`"Slow-trickle run starting: N candidate(s)"\` followed by per-track lines or \`"Slow-trickle run done: visited=N enrichedAnyId=X submittedToAchordion=Y"\`.

## Cross-refs

- Desktop: \`parachord-desktop/CLAUDE.md\` "Cross-Resolver Enrichment (Eager Gate + Slow Trickle)"
- Sibling: \`ShareManager.trySubmitForTrack\` (the per-track Achordion submit pattern this mirrors at track-add time)
- Reference impl: \`HostedPlaylistWorker\` / \`HostedPlaylistScheduler\` (same WorkManager shape)

🤖 Generated with [Claude Code](https://claude.com/claude-code)