### PR TITLE
announcements: consume Achordion's /api/announcements + home banner (closes #127)

### DIFF
--- a/app/src/main/java/com/parachord/android/app/ParachordApplication.kt
+++ b/app/src/main/java/com/parachord/android/app/ParachordApplication.kt
@@ -19,6 +19,7 @@ class ParachordApplication : Application() {
     private val hostedPlaylistScheduler: HostedPlaylistScheduler by inject()
     private val imageEnrichmentService: ImageEnrichmentService by inject()
     private val crossResolverEnrichmentScheduler: CrossResolverEnrichmentScheduler by inject()
+    private val announcementsRepository: com.parachord.shared.repository.AnnouncementsRepository by inject()
 
     private val appScope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
 
@@ -60,6 +61,19 @@ class ParachordApplication : Application() {
                 imageEnrichmentService.regenerateAllPlaylistMosaics()
             } catch (_: Exception) {
                 // Background pass; don't take down the app on a failure.
+            }
+        }
+
+        // Announcements feed (#127). Fire-and-forget cold-start refresh —
+        // populates the home-screen banner StateFlow before HomeScreen
+        // collects it. Failures inside listAnnouncements() return an empty
+        // list and the banner just hides. The MainActivity.onResume path
+        // (gated to 6h) handles subsequent foreground returns.
+        appScope.launch {
+            try {
+                announcementsRepository.refreshNow()
+            } catch (_: Exception) {
+                // Swallow; banner stays hidden until next foreground refresh.
             }
         }
     }

--- a/app/src/main/java/com/parachord/android/di/AndroidModule.kt
+++ b/app/src/main/java/com/parachord/android/di/AndroidModule.kt
@@ -620,6 +620,18 @@ val androidModule = module {
         )
     }
     singleOf(::WeeklyPlaylistsRepository)
+    // AnnouncementsRepository (#127) — consumes Achordion's `/api/announcements`
+    // feed. appVersion is sourced from BuildConfig.VERSION_NAME so client-side
+    // semver filtering matches the actual installed build. KvStore-backed:
+    // last-fetched timestamp + dismissed-ids CSV. Fetched on cold start
+    // (ParachordApplication) + onResume gated to 6h (MainActivity).
+    single {
+        com.parachord.shared.repository.AnnouncementsRepository(
+            achordionClient = get(),
+            kvStore = get(),
+            appVersion = com.parachord.android.BuildConfig.VERSION_NAME,
+        )
+    }
     // ConcertsRepository takes file I/O as suspend lambdas + per-API
     // BuildConfig key fallbacks (the shared class is platform-agnostic).
     // Cache lives at `<filesDir>/concerts_cache.json`; failures are swallowed.

--- a/app/src/main/java/com/parachord/android/ui/MainActivity.kt
+++ b/app/src/main/java/com/parachord/android/ui/MainActivity.kt
@@ -95,6 +95,7 @@ class MainActivity : ComponentActivity() {
     private val oAuthManager: OAuthManager by inject()
     private val musicKitBridge: MusicKitWebBridge by inject()
     private val settingsStore: SettingsStore by inject()
+    private val announcementsRepository: com.parachord.shared.repository.AnnouncementsRepository by inject()
 
     /** Pending deep link URI stored for the composable to process. */
     internal val pendingDeepLink = MutableStateFlow<Uri?>(null)
@@ -153,6 +154,15 @@ class MainActivity : ComponentActivity() {
                     musicKitBridge.configure()
                 }
             }
+        }
+        // Announcements feed (#127). Gated to 6h since last successful fetch
+        // so we don't slam the endpoint on every foreground return — the
+        // server caches at s-maxage=60 but our own gate is the polite floor.
+        // Fire-and-forget: failures inside refreshIfStale() are swallowed.
+        CoroutineScope(Dispatchers.IO).launch {
+            try {
+                announcementsRepository.refreshIfStale()
+            } catch (_: Exception) { /* swallow */ }
         }
     }
 

--- a/app/src/main/java/com/parachord/android/ui/components/AnnouncementBanner.kt
+++ b/app/src/main/java/com/parachord/android/ui/components/AnnouncementBanner.kt
@@ -1,0 +1,149 @@
+package com.parachord.android.ui.components
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Close
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.hapticfeedback.HapticFeedbackType
+import androidx.compose.ui.platform.LocalHapticFeedback
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import coil.compose.AsyncImage
+import com.parachord.android.ui.theme.ParachordTheme
+import com.parachord.shared.api.Announcement
+
+/**
+ * Achordion announcements banner (#127).
+ *
+ * Renders a single [Announcement] at the top of the home screen. Severity
+ * picks a background tint:
+ *
+ *  - `info` / null / unknown → brand-purple (matches desktop's accent)
+ *  - `success` → green
+ *  - `warn` → amber
+ *  - `error` → red
+ *
+ * `iconUrl` wins over `icon` if both are present (server-side validation
+ * caps `icon` at 4 chars, but a remote PNG is a stronger signal than an
+ * emoji fallback). The CTA is optional — when absent, the banner is a
+ * read-only headline + body + dismiss button.
+ *
+ * Dark-mode tints are slightly desaturated so the foreground text stays
+ * readable. Foreground color is fixed (`#F3F4F6` dark / `#111827` light)
+ * because Material's `onSurface` doesn't track our custom severity tints.
+ */
+@Composable
+fun AnnouncementBanner(
+    announcement: Announcement,
+    onDismiss: () -> Unit,
+    onCtaClick: (String) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val haptic = LocalHapticFeedback.current
+    val isDark = ParachordTheme.isDark
+    val severity = announcement.severity ?: "info"
+    val bg = when (severity) {
+        "error" -> if (isDark) Color(0xFF4A1212) else Color(0xFFFDECEC)
+        "warn" -> if (isDark) Color(0xFF3F2E10) else Color(0xFFFFF4E0)
+        "success" -> if (isDark) Color(0xFF103D24) else Color(0xFFE8F7EF)
+        else -> if (isDark) Color(0xFF2A1D4A) else Color(0xFFEFE8FD) // info / unknown → brand purple
+    }
+    val fg = if (isDark) Color(0xFFF3F4F6) else Color(0xFF111827)
+
+    Surface(
+        color = bg,
+        shape = RoundedCornerShape(12.dp),
+        modifier = modifier.fillMaxWidth(),
+    ) {
+        Row(
+            verticalAlignment = Alignment.Top,
+            modifier = Modifier.padding(12.dp),
+        ) {
+            // Optional icon (iconUrl wins over emoji icon if both present).
+            val iconUrl = announcement.iconUrl
+            val icon = announcement.icon
+            when {
+                !iconUrl.isNullOrBlank() -> {
+                    AsyncImage(
+                        model = iconUrl,
+                        contentDescription = null,
+                        modifier = Modifier.size(24.dp),
+                    )
+                    Spacer(Modifier.width(12.dp))
+                }
+                !icon.isNullOrBlank() -> {
+                    Text(
+                        text = icon,
+                        fontSize = 20.sp,
+                        modifier = Modifier.size(24.dp),
+                    )
+                    Spacer(Modifier.width(12.dp))
+                }
+            }
+
+            Column(modifier = Modifier.weight(1f)) {
+                Text(
+                    text = announcement.title,
+                    style = MaterialTheme.typography.titleMedium,
+                    color = fg,
+                )
+                val body = announcement.body
+                if (!body.isNullOrBlank()) {
+                    Spacer(Modifier.height(2.dp))
+                    Text(
+                        text = body,
+                        style = MaterialTheme.typography.bodySmall,
+                        color = fg.copy(alpha = 0.85f),
+                        maxLines = 3,
+                        overflow = TextOverflow.Ellipsis,
+                    )
+                }
+                announcement.cta?.let { cta ->
+                    Spacer(Modifier.height(6.dp))
+                    TextButton(
+                        onClick = {
+                            haptic.performHapticFeedback(HapticFeedbackType.LongPress)
+                            onCtaClick(cta.url)
+                        },
+                        contentPadding = PaddingValues(horizontal = 8.dp, vertical = 4.dp),
+                    ) {
+                        Text(text = cta.label, color = fg)
+                    }
+                }
+            }
+
+            IconButton(
+                onClick = {
+                    haptic.performHapticFeedback(HapticFeedbackType.LongPress)
+                    onDismiss()
+                },
+                modifier = Modifier.size(28.dp),
+            ) {
+                Icon(
+                    imageVector = Icons.Default.Close,
+                    contentDescription = "Dismiss",
+                    tint = fg.copy(alpha = 0.7f),
+                )
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/parachord/android/ui/screens/home/HomeScreen.kt
+++ b/app/src/main/java/com/parachord/android/ui/screens/home/HomeScreen.kt
@@ -65,6 +65,8 @@ import androidx.compose.material3.TopAppBar
 import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.rememberCoroutineScope
+import kotlinx.coroutines.launch
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -97,6 +99,9 @@ import com.parachord.android.data.db.entity.AlbumEntity
 import com.parachord.android.data.db.entity.FriendEntity
 import com.parachord.android.data.db.entity.PlaylistEntity
 import com.parachord.android.ui.components.AlbumArtCard
+import com.parachord.android.ui.components.AnnouncementBanner
+import android.content.Intent
+import android.net.Uri
 import android.widget.Toast
 import androidx.compose.ui.platform.LocalContext
 import com.parachord.android.share.rememberSharePlaylistById
@@ -292,10 +297,54 @@ fun HomeScreen(
                 }
             }
         } else {
+            // ── Achordion announcements banner (#127) ────────────────────
+            val announcementsRepository: com.parachord.shared.repository.AnnouncementsRepository =
+                org.koin.compose.koinInject()
+            val announcements by announcementsRepository.visibleAnnouncements
+                .collectAsStateWithLifecycle()
+            val bannerScope = rememberCoroutineScope()
+            val firstAnnouncement = announcements.firstOrNull()
+            if (firstAnnouncement != null) {
+                LaunchedEffect(firstAnnouncement.id) {
+                    announcementsRepository.trackView(firstAnnouncement.id)
+                }
+            }
+
             LazyColumn(
                 modifier = Modifier.fillMaxSize(),
                 contentPadding = PaddingValues(bottom = 24.dp),
             ) {
+                if (firstAnnouncement != null) {
+                    item(key = "announcement-${firstAnnouncement.id}") {
+                        AnnouncementBanner(
+                            announcement = firstAnnouncement,
+                            onDismiss = {
+                                bannerScope.launch {
+                                    announcementsRepository.dismiss(firstAnnouncement.id)
+                                }
+                            },
+                            onCtaClick = { url ->
+                                announcementsRepository.trackCtaClick(firstAnnouncement.id)
+                                try {
+                                    context.startActivity(
+                                        Intent(Intent.ACTION_VIEW, Uri.parse(url))
+                                    )
+                                } catch (_: Exception) {
+                                    Toast.makeText(
+                                        context,
+                                        "Couldn't open the link",
+                                        Toast.LENGTH_SHORT,
+                                    ).show()
+                                }
+                            },
+                            modifier = Modifier.padding(
+                                horizontal = 16.dp,
+                                vertical = 8.dp,
+                            ),
+                        )
+                    }
+                }
+
                 // ── Continue Listening ──────────────────────────────────
                 if (playbackState.currentTrack != null) {
                     item {

--- a/app/src/test/java/com/parachord/android/repository/AnnouncementsRepositoryTest.kt
+++ b/app/src/test/java/com/parachord/android/repository/AnnouncementsRepositoryTest.kt
@@ -1,0 +1,272 @@
+package com.parachord.android.repository
+
+import com.parachord.shared.api.AchordionClient
+import com.parachord.shared.api.Announcement
+import com.parachord.shared.repository.AnnouncementsRepository
+import com.parachord.shared.repository.compareSemverOrNull
+import com.parachord.shared.store.KvStore
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.coVerifyAll
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.slot
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Locks the contract of [AnnouncementsRepository] (#127).
+ *
+ * Covers:
+ *  - [compareSemverOrNull] basic comparison cases
+ *  - [filterForClient] surface / version / expiry / dismissal predicates
+ *  - [AnnouncementsRepository.refreshIfStale] 6h gate
+ *  - [AnnouncementsRepository.refreshNow] always-fetch
+ *  - [AnnouncementsRepository.dismiss] persistence + state flow update + telemetry
+ *  - [AnnouncementsRepository.trackView] once-per-session dedup
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+class AnnouncementsRepositoryTest {
+
+    /** Build an in-memory KvStore stand-in with a backing map. */
+    private fun fakeKv(
+        initialLastFetchedMs: Long = 0L,
+        initialDismissedCsv: String = "",
+    ): KvStore {
+        val storage = mutableMapOf<String, Any?>(
+            AnnouncementsRepository.KEY_LAST_FETCHED_MS to initialLastFetchedMs,
+            AnnouncementsRepository.KEY_DISMISSED_IDS to initialDismissedCsv,
+        )
+        val kv = mockk<KvStore>(relaxed = true)
+        every { kv.getLong(any(), any()) } answers {
+            val key = firstArg<String>()
+            val default = secondArg<Long>()
+            (storage[key] as? Long) ?: default
+        }
+        every { kv.getStringSetCsv(any()) } answers {
+            val key = firstArg<String>()
+            val raw = (storage[key] as? String) ?: ""
+            raw.split(',').map { it.trim() }.filter { it.isNotEmpty() }.toSet()
+        }
+        coEvery { kv.setLong(any(), any()) } answers {
+            storage[firstArg()] = secondArg<Long>()
+        }
+        coEvery { kv.setStringSetCsv(any(), any()) } answers {
+            storage[firstArg()] = secondArg<Set<String>>().joinToString(",")
+        }
+        return kv
+    }
+
+    private fun ann(
+        id: String = "a1",
+        title: String = "Hello",
+        surfaces: List<String>? = null,
+        minVersion: String? = null,
+        maxVersion: String? = null,
+        expiresAt: String? = null,
+        severity: String? = "info",
+    ) = Announcement(
+        id = id,
+        title = title,
+        surfaces = surfaces,
+        minVersion = minVersion,
+        maxVersion = maxVersion,
+        expiresAt = expiresAt,
+        severity = severity,
+    )
+
+    @Test
+    fun compareSemverOrNull_basicCases() {
+        assertEquals(0, compareSemverOrNull("0.6.1", "0.6.1"))
+        assertTrue((compareSemverOrNull("0.6.1", "0.7.0") ?: 0) < 0)
+        assertTrue((compareSemverOrNull("0.7.0", "0.6.1") ?: 0) > 0)
+        // Leading v
+        assertEquals(0, compareSemverOrNull("v1.0.0", "1.0.0"))
+        // Pre-release tags ignored
+        assertEquals(0, compareSemverOrNull("1.2.3-alpha", "1.2.3"))
+        // Missing components zero-padded
+        assertTrue((compareSemverOrNull("1", "1.0.0") ?: 99) == 0)
+        assertTrue((compareSemverOrNull("1.2", "1.2.0") ?: 99) == 0)
+        // Unparseable → null (fail-open)
+        assertNull(compareSemverOrNull("abc", "1.0.0"))
+        assertNull(compareSemverOrNull("1.0.0", "xyz"))
+    }
+
+    @Test
+    fun filterForClient_excludesNonParachordSurface() = runTest {
+        val achordion = mockk<AchordionClient>(relaxed = true)
+        val repo = AnnouncementsRepository(achordion, fakeKv(), appVersion = "0.6.1")
+        val result = repo.filterForClient(listOf(ann(surfaces = listOf("achordion"))))
+        assertTrue(result.isEmpty())
+    }
+
+    @Test
+    fun filterForClient_includesWhenSurfacesNullOrContainsParachord() = runTest {
+        val achordion = mockk<AchordionClient>(relaxed = true)
+        val repo = AnnouncementsRepository(achordion, fakeKv(), appVersion = "0.6.1")
+        val result = repo.filterForClient(
+            listOf(
+                ann(id = "a1", surfaces = null),
+                ann(id = "a2", surfaces = listOf("parachord")),
+                ann(id = "a3", surfaces = emptyList()),
+                ann(id = "a4", surfaces = listOf("achordion", "parachord")),
+            ),
+        )
+        assertEquals(listOf("a1", "a2", "a3", "a4"), result.map { it.id })
+    }
+
+    @Test
+    fun filterForClient_excludesWhenAppBelowMinVersion() = runTest {
+        val achordion = mockk<AchordionClient>(relaxed = true)
+        val repo = AnnouncementsRepository(achordion, fakeKv(), appVersion = "0.6.1")
+        val result = repo.filterForClient(listOf(ann(minVersion = "0.7.0")))
+        assertTrue(result.isEmpty())
+    }
+
+    @Test
+    fun filterForClient_includesAtOrAboveMinVersion() = runTest {
+        val achordion = mockk<AchordionClient>(relaxed = true)
+        val repo = AnnouncementsRepository(achordion, fakeKv(), appVersion = "0.7.0")
+        val result = repo.filterForClient(
+            listOf(
+                ann(id = "a1", minVersion = "0.7.0"),
+                ann(id = "a2", minVersion = "0.5.0"),
+            ),
+        )
+        assertEquals(listOf("a1", "a2"), result.map { it.id })
+    }
+
+    @Test
+    fun filterForClient_failsOpenOnUnparseableVersionBound() = runTest {
+        val achordion = mockk<AchordionClient>(relaxed = true)
+        val repo = AnnouncementsRepository(achordion, fakeKv(), appVersion = "0.6.1")
+        val result = repo.filterForClient(
+            listOf(
+                ann(id = "a1", minVersion = "abc"),
+                ann(id = "a2", maxVersion = "abc"),
+            ),
+        )
+        // Unparseable bounds compare to null → no constraint enforced → both included.
+        assertEquals(listOf("a1", "a2"), result.map { it.id })
+    }
+
+    @Test
+    fun filterForClient_excludesExpiredAnnouncements() = runTest {
+        val achordion = mockk<AchordionClient>(relaxed = true)
+        val repo = AnnouncementsRepository(achordion, fakeKv(), appVersion = "0.6.1")
+        val pastIso = java.time.Instant.now().minus(java.time.Duration.ofHours(1)).toString()
+        val result = repo.filterForClient(listOf(ann(expiresAt = pastIso)))
+        assertTrue(result.isEmpty())
+    }
+
+    @Test
+    fun filterForClient_includesValidFutureExpiry() = runTest {
+        val achordion = mockk<AchordionClient>(relaxed = true)
+        val repo = AnnouncementsRepository(achordion, fakeKv(), appVersion = "0.6.1")
+        val futureIso = java.time.Instant.now().plus(java.time.Duration.ofHours(1)).toString()
+        val result = repo.filterForClient(listOf(ann(expiresAt = futureIso)))
+        assertEquals(1, result.size)
+    }
+
+    @Test
+    fun filterForClient_excludesDismissedIds() = runTest {
+        val achordion = mockk<AchordionClient>(relaxed = true)
+        val repo = AnnouncementsRepository(
+            achordion,
+            fakeKv(initialDismissedCsv = "a1,a3"),
+            appVersion = "0.6.1",
+        )
+        val result = repo.filterForClient(
+            listOf(ann(id = "a1"), ann(id = "a2"), ann(id = "a3")),
+        )
+        assertEquals(listOf("a2"), result.map { it.id })
+    }
+
+    @Test
+    fun refreshIfStale_skipsWhenWithinGate() = runTest {
+        val achordion = mockk<AchordionClient>(relaxed = true)
+        // Last fetched 1h ago — within the 6h gate.
+        val recent = System.currentTimeMillis() - 60L * 60 * 1000
+        val repo = AnnouncementsRepository(
+            achordion,
+            fakeKv(initialLastFetchedMs = recent),
+            appVersion = "0.6.1",
+        )
+        repo.refreshIfStale()
+        coVerify(exactly = 0) { achordion.listAnnouncements() }
+    }
+
+    @Test
+    fun refreshIfStale_fetchesWhenStale() = runTest {
+        val achordion = mockk<AchordionClient>(relaxed = true)
+        coEvery { achordion.listAnnouncements() } returns emptyList()
+        // Last fetched 7h ago — outside the 6h gate.
+        val stale = System.currentTimeMillis() - 7L * 60 * 60 * 1000
+        val repo = AnnouncementsRepository(
+            achordion,
+            fakeKv(initialLastFetchedMs = stale),
+            appVersion = "0.6.1",
+        )
+        repo.refreshIfStale()
+        coVerify(exactly = 1) { achordion.listAnnouncements() }
+    }
+
+    @Test
+    fun refreshNow_alwaysFetches() = runTest {
+        val achordion = mockk<AchordionClient>(relaxed = true)
+        coEvery { achordion.listAnnouncements() } returns emptyList()
+        // Last fetched 1min ago — refreshNow should ignore the gate.
+        val veryRecent = System.currentTimeMillis() - 60L * 1000
+        val repo = AnnouncementsRepository(
+            achordion,
+            fakeKv(initialLastFetchedMs = veryRecent),
+            appVersion = "0.6.1",
+        )
+        repo.refreshNow()
+        coVerify(exactly = 1) { achordion.listAnnouncements() }
+    }
+
+    @Test
+    fun dismiss_persistsAndRemovesFromVisibleAndFiresEvent() = runTest {
+        val achordion = mockk<AchordionClient>(relaxed = true)
+        coEvery { achordion.listAnnouncements() } returns listOf(
+            ann(id = "a1"), ann(id = "a2"),
+        )
+        val kv = fakeKv()
+        val repo = AnnouncementsRepository(achordion, kv, appVersion = "0.6.1")
+        repo.refreshNow()
+        assertEquals(listOf("a1", "a2"), repo.visibleAnnouncements.value.map { it.id })
+
+        val writtenSet = slot<Set<String>>()
+        coEvery { kv.setStringSetCsv(AnnouncementsRepository.KEY_DISMISSED_IDS, capture(writtenSet)) } answers {
+            // No-op — fakeKv() already wired persistence; this overlay just captures.
+        }
+        repo.dismiss("a1")
+        advanceUntilIdle()
+
+        // Visible list now excludes a1.
+        assertEquals(listOf("a2"), repo.visibleAnnouncements.value.map { it.id })
+        // Dismiss telemetry fired.
+        coVerify(exactly = 1) { achordion.trackAnnouncementEvent("a1", "dismiss") }
+        // KvStore write happened with a1 in the set.
+        assertTrue(writtenSet.isCaptured)
+        assertTrue("a1" in writtenSet.captured)
+    }
+
+    @Test
+    fun trackView_firesOncePerSession() = runTest {
+        val achordion = mockk<AchordionClient>(relaxed = true)
+        val repo = AnnouncementsRepository(achordion, fakeKv(), appVersion = "0.6.1")
+        repo.trackView("a1")
+        repo.trackView("a1")
+        repo.trackView("a1")
+        advanceUntilIdle()
+        coVerify(exactly = 1) { achordion.trackAnnouncementEvent("a1", "view") }
+    }
+}

--- a/shared/src/commonMain/kotlin/com/parachord/shared/api/AchordionClient.kt
+++ b/shared/src/commonMain/kotlin/com/parachord/shared/api/AchordionClient.kt
@@ -13,6 +13,7 @@ import io.ktor.http.ContentType
 import io.ktor.http.HttpHeaders
 import io.ktor.http.HttpStatusCode
 import io.ktor.http.contentType
+import io.ktor.http.isSuccess
 import kotlin.concurrent.Volatile
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
@@ -53,6 +54,8 @@ class AchordionClient(
         private const val TAG = "AchordionClient"
         private const val ENTITY_LINK_ENDPOINT = "https://achordion.xyz/api/entity-link"
         private const val SUBMIT_ENDPOINT = "https://achordion.xyz/api/track-links/submit"
+        private const val ANNOUNCEMENTS_ENDPOINT = "https://achordion.xyz/api/announcements"
+        private const val ANNOUNCEMENTS_EVENT_ENDPOINT = "https://achordion.xyz/api/announcements/event"
         private val json = Json { ignoreUnknownKeys = true; encodeDefaults = false }
     }
 
@@ -95,6 +98,60 @@ class AchordionClient(
         } catch (e: Throwable) {
             Log.w(TAG, "entity-link failed for $type mbid=$mbid: ${e.message}")
             null
+        }
+    }
+
+    /**
+     * Fetch the live announcements feed.
+     *
+     * Public endpoint — no auth header, no bearer token gate. Server returns
+     * a JSON array of [Announcement] objects (cached `s-maxage=60`). Clients
+     * are responsible for surface / version / expiry / dismissal filtering
+     * (see [com.parachord.shared.repository.AnnouncementsRepository]).
+     *
+     * Returns an empty list on any error so the banner just hides instead of
+     * the home screen exploding. Cancellation re-throws to keep coroutine
+     * semantics clean.
+     */
+    suspend fun listAnnouncements(): List<Announcement> {
+        return try {
+            val response = httpClient.get(ANNOUNCEMENTS_ENDPOINT) {
+                accept(ContentType.Application.Json)
+            }
+            if (response.status != HttpStatusCode.OK) {
+                Log.w(TAG, "announcements returned HTTP ${response.status.value}")
+                return emptyList()
+            }
+            val body = response.bodyAsText()
+            json.decodeFromString<List<Announcement>>(body)
+        } catch (e: kotlinx.coroutines.CancellationException) {
+            throw e
+        } catch (e: Throwable) {
+            Log.w(TAG, "announcements fetch failed: ${e.message}")
+            emptyList()
+        }
+    }
+
+    /**
+     * Best-effort telemetry post for view / dismiss / cta-click events.
+     *
+     * Public endpoint, no auth. Rate-limited 60/min/IP — failures (including
+     * 429) are logged at debug level and swallowed because telemetry is
+     * fire-and-forget by design (the banner UX must never block on this).
+     */
+    suspend fun trackAnnouncementEvent(id: String, event: String) {
+        try {
+            val response = httpClient.post(ANNOUNCEMENTS_EVENT_ENDPOINT) {
+                contentType(ContentType.Application.Json)
+                setBody(AnnouncementEventRequest(id = id, event = event))
+            }
+            if (!response.status.isSuccess()) {
+                Log.d(TAG, "announcements/event ${event} for id=${id} returned HTTP ${response.status.value}")
+            }
+        } catch (e: kotlinx.coroutines.CancellationException) {
+            throw e
+        } catch (e: Throwable) {
+            Log.d(TAG, "announcements/event ${event} for id=${id} failed: ${e.message}")
         }
     }
 
@@ -173,6 +230,34 @@ data class TrackLink(
     val host: String,
     val label: String? = null,
 )
+
+/**
+ * One announcement from Achordion's `/api/announcements` feed.
+ *
+ * The server returns a validated list — clients filter by `surfaces`,
+ * `minVersion`/`maxVersion`, `expiresAt`, and the local dismissed-id set
+ * (see [com.parachord.shared.repository.AnnouncementsRepository.filterForClient]).
+ */
+@Serializable
+data class Announcement(
+    val id: String,
+    val title: String,
+    val severity: String? = null,
+    val body: String? = null,
+    val icon: String? = null,
+    val iconUrl: String? = null,
+    val cta: Cta? = null,
+    val surfaces: List<String>? = null,
+    val minVersion: String? = null,
+    val maxVersion: String? = null,
+    val expiresAt: String? = null,
+)
+
+@Serializable
+data class Cta(val label: String, val url: String)
+
+@Serializable
+internal data class AnnouncementEventRequest(val id: String, val event: String)
 
 sealed class SubmitResult {
     object Ok : SubmitResult()

--- a/shared/src/commonMain/kotlin/com/parachord/shared/repository/AnnouncementsRepository.kt
+++ b/shared/src/commonMain/kotlin/com/parachord/shared/repository/AnnouncementsRepository.kt
@@ -1,0 +1,181 @@
+package com.parachord.shared.repository
+
+import com.parachord.shared.api.AchordionClient
+import com.parachord.shared.api.Announcement
+import com.parachord.shared.platform.Log
+import com.parachord.shared.platform.currentTimeMillis
+import com.parachord.shared.store.KvStore
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+import kotlinx.datetime.Clock
+import kotlinx.datetime.Instant
+
+/**
+ * Repository for Achordion's announcements feed.
+ *
+ * The server hosts a validated list at `/api/announcements`; clients fetch the
+ * full feed and apply local filters (surface match, semver range, expiry,
+ * dismissal). Visible announcements flow out via [visibleAnnouncements] for
+ * Compose collection on the home screen.
+ *
+ * **Cadence:** [refreshNow] from `ParachordApplication.onCreate` (cold start),
+ * [refreshIfStale] from `MainActivity.onResume` gated to a 6-hour minimum
+ * between successful fetches. The gate is persisted in [KvStore] so it
+ * survives process kills.
+ *
+ * **Dismissal:** persistent — once dismissed, an announcement stays dismissed
+ * until it's removed from the server feed (or the user reinstalls the app).
+ * Backed by a CSV-encoded set in [KvStore] under [KEY_DISMISSED_IDS] since
+ * [KvStore] doesn't expose a native string-set API.
+ *
+ * **Telemetry:** `view` fires once per session per id (in-memory dedup);
+ * `dismiss` and `cta-click` fire every time. All telemetry is fire-and-forget
+ * via the internal supervised scope — failures are swallowed inside
+ * [AchordionClient.trackAnnouncementEvent].
+ */
+class AnnouncementsRepository(
+    private val achordionClient: AchordionClient,
+    private val kvStore: KvStore,
+    private val appVersion: String,
+) {
+    companion object {
+        private const val TAG = "AnnouncementsRepo"
+        const val KEY_LAST_FETCHED_MS = "announcements_last_fetched_ms"
+        const val KEY_DISMISSED_IDS = "announcements_dismissed_ids"
+        const val REFRESH_GATE_MS = 6L * 60 * 60 * 1000 // 6h
+    }
+
+    private val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+    private val fetchMutex = Mutex()
+    private val viewedThisSession = mutableSetOf<String>()
+    private val viewedMutex = Mutex()
+
+    private val _visibleAnnouncements = MutableStateFlow<List<Announcement>>(emptyList())
+    val visibleAnnouncements: StateFlow<List<Announcement>> = _visibleAnnouncements.asStateFlow()
+
+    /** Always fetches — bypasses the 6h staleness gate. Used on cold start. */
+    suspend fun refreshNow() {
+        fetchAndPublish()
+    }
+
+    /** Fetches only if the last successful fetch was ≥ [REFRESH_GATE_MS] ago. */
+    suspend fun refreshIfStale() {
+        val lastFetched = kvStore.getLong(KEY_LAST_FETCHED_MS, 0L)
+        if (currentTimeMillis() - lastFetched < REFRESH_GATE_MS) return
+        fetchAndPublish()
+    }
+
+    /**
+     * Mark an announcement as dismissed. Persists to KvStore, removes from the
+     * visible list, and fires the dismiss telemetry event.
+     */
+    suspend fun dismiss(id: String) {
+        val dismissed = readDismissed().toMutableSet()
+        if (dismissed.add(id)) {
+            writeDismissed(dismissed)
+        }
+        _visibleAnnouncements.value = _visibleAnnouncements.value.filter { it.id != id }
+        scope.launch { achordionClient.trackAnnouncementEvent(id, "dismiss") }
+    }
+
+    /** Fire a view event once per session per id. Safe to call repeatedly. */
+    fun trackView(id: String) {
+        scope.launch {
+            val already = viewedMutex.withLock {
+                if (id in viewedThisSession) {
+                    true
+                } else {
+                    viewedThisSession.add(id)
+                    false
+                }
+            }
+            if (!already) achordionClient.trackAnnouncementEvent(id, "view")
+        }
+    }
+
+    /** Fire a cta-click event. */
+    fun trackCtaClick(id: String) {
+        scope.launch { achordionClient.trackAnnouncementEvent(id, "cta-click") }
+    }
+
+    private suspend fun fetchAndPublish() = fetchMutex.withLock {
+        val raw = achordionClient.listAnnouncements()
+        val filtered = filterForClient(raw)
+        _visibleAnnouncements.value = filtered
+        kvStore.setLong(KEY_LAST_FETCHED_MS, currentTimeMillis())
+        Log.d(TAG, "Fetched ${raw.size} announcements, ${filtered.size} visible after filter")
+    }
+
+    /**
+     * Filter the server feed to what's visible on this client right now.
+     *
+     * 1. Surface match — null/empty surfaces means "all"; otherwise must contain "parachord".
+     * 2. Semver range — fail-open on unparseable bounds (don't crash on bad input).
+     * 3. Not expired — `expiresAt` ISO-8601 in the past → filtered out.
+     * 4. Not dismissed — id in [KEY_DISMISSED_IDS] CSV → filtered out.
+     */
+    suspend fun filterForClient(items: List<Announcement>): List<Announcement> {
+        val now = Clock.System.now()
+        val dismissed = readDismissed()
+        return items.filter { item ->
+            // 1. Surface match
+            val surfaces = item.surfaces
+            if (!(surfaces.isNullOrEmpty() || "parachord" in surfaces)) return@filter false
+
+            // 2. Version range (fail-open on unparseable)
+            if (item.minVersion != null) {
+                val cmp = compareSemverOrNull(appVersion, item.minVersion)
+                if (cmp != null && cmp < 0) return@filter false
+            }
+            if (item.maxVersion != null) {
+                val cmp = compareSemverOrNull(appVersion, item.maxVersion)
+                if (cmp != null && cmp > 0) return@filter false
+            }
+
+            // 3. Expiry
+            if (item.expiresAt != null) {
+                val expiry = runCatching { Instant.parse(item.expiresAt) }.getOrNull()
+                if (expiry != null && now >= expiry) return@filter false
+            }
+
+            // 4. Dismissed
+            if (item.id in dismissed) return@filter false
+
+            true
+        }
+    }
+
+    private fun readDismissed(): Set<String> = kvStore.getStringSetCsv(KEY_DISMISSED_IDS)
+
+    private suspend fun writeDismissed(set: Set<String>) {
+        kvStore.setStringSetCsv(KEY_DISMISSED_IDS, set)
+    }
+}
+
+/**
+ * Numeric semver comparator. Returns negative / zero / positive in the
+ * conventional way, or `null` if either side can't be parsed (caller
+ * should treat null as "no constraint" — fail-open).
+ *
+ * Accepts leading `v` and pre-release tags (everything after the first
+ * `-` is dropped). Missing components are zero-padded (e.g. `"1"` →
+ * `1.0.0`).
+ */
+fun compareSemverOrNull(a: String, b: String): Int? {
+    val aParts = a.removePrefix("v").substringBefore('-').split(".").mapNotNull { it.toIntOrNull() }
+    val bParts = b.removePrefix("v").substringBefore('-').split(".").mapNotNull { it.toIntOrNull() }
+    if (aParts.isEmpty() || bParts.isEmpty()) return null
+    for (i in 0 until maxOf(aParts.size, bParts.size)) {
+        val ap = aParts.getOrElse(i) { 0 }
+        val bp = bParts.getOrElse(i) { 0 }
+        if (ap != bp) return ap.compareTo(bp)
+    }
+    return 0
+}


### PR DESCRIPTION
Closes #127. Three commits.

## Why

Achordion + desktop already share an \`announcements:json\` Upstash row that drives in-app banners (outage notices, launch announcements, Discord-invite pushes, etc.). Android wasn't consuming it. With iOS launch on the horizon, landing this on Android now means:

1. Existing Android users see the same broadcasts desktop does.
2. iOS shell inherits the shared client + repository for free.
3. Ops has a single switch to push iOS-launch messaging to every existing client when iOS ships.

## Commits

1. **\`9f0aebc\` AchordionClient + AnnouncementsRepository + tests** — shared/commonMain. Two new client methods (\`listAnnouncements\`, \`trackAnnouncementEvent\`). Repository wraps with surface filter (\`"parachord"\`), semver minVersion/maxVersion range check, expiresAt comparison via \`kotlinx.datetime.Clock\`, persisted-dismissed-id set via \`KvStore\`, 6h refresh gate, per-session view de-dup via in-memory Mutex+Set. 14 unit tests.

2. **\`564cf1e\` Koin binding + cold-start + onResume hooks** — Koin singleton in \`AndroidModule.kt\` (closed over \`BuildConfig.VERSION_NAME\`). \`ParachordApplication.onCreate\` fires \`refreshNow()\` fire-and-forget on cold start. \`MainActivity.onResume\` fires \`refreshIfStale()\` (gated on the 6h KvStore timestamp).

3. **\`c95ac7e\` AnnouncementBanner + HomeScreen render** — severity-themed banner at the top of the home screen. Light/dark variants via \`ParachordTheme.isDark\`. \`LaunchedEffect(id)\` fires the \`view\` event once per session per id. CTA opens \`Intent.ACTION_VIEW\` (defensive try/catch w/ toast fallback) and fires \`cta-click\`. Dismiss X persists to KvStore + fires \`dismiss\` + removes from StateFlow.

## Client-side filtering (load-bearing)

Server returns the full validated list. Clients filter:

- **Surface**: \`surfaces == null/empty\` OR \`"parachord" in surfaces\`.
- **Version range**: \`appVersion >= minVersion\` and \`appVersion <= maxVersion\`. Unparseable bounds fail-open (no crash).
- **Expiry**: \`expiresAt == null\` OR \`Clock.System.now() < Instant.parse(expiresAt)\`. Unparseable timestamps fail-open.
- **Dismissed**: announcement \`id\` not in \`KvStore[announcements_dismissed_ids]\`.

## Test plan

- [x] 14/14 \`AnnouncementsRepositoryTest\` cases pass.
- [x] Full \`:app:testDebugUnitTest :shared:testDebugUnitTest\` green.
- [x] iOS targets compile clean (\`:shared:compileKotlinIosArm64\` / \`compileKotlinIosSimulatorArm64\`).
- [ ] Manual: push a test announcement to \`announcements:json\` with \`surfaces: ["parachord"]\` → installed app surfaces it on home, \`adb logcat\` shows the \`view\` event fire. Dismiss → banner gone, KvStore stores the id, next launch doesn't re-surface.

## Notes on the implementer's deviations (intentional)

- \`compareSemverOrNull\` / \`filterForClient\` are \`public\` (not \`internal\`) — Kotlin's \`internal\` scopes to the Gradle module, and \`:app\` tests can't see \`internal\` from \`:shared\`. Per CLAUDE.md rule #10.
- Tests use \`java.time\` for expiry-cutoff values since \`kotlinx-datetime\` is an \`implementation\` (not \`api\`) dep in \`shared/build.gradle.kts\`. Production code in the repository uses \`kotlinx.datetime\` as required.
- \`SharedModule.kt\` left untouched — \`BuildConfig.VERSION_NAME\` only exists on the Android platform side, so the entire binding lives in \`AndroidModule\`.

## Cross-refs

- Achordion: [\`AGENTS.md §POST /api/announcements\`](https://github.com/jherskowitz/achordion/blob/main/AGENTS.md#L382)
- Desktop: \`parachord-desktop/CLAUDE.md\` "In-App Announcements"
- Filed during the audit that surfaced this pre-iOS queue (PR #151).

🤖 Generated with [Claude Code](https://claude.com/claude-code)