### PR TITLE
applemusic: throttle catalog API calls via MusicKitCatalogLimiter (closes #148)

### DIFF
--- a/app/src/main/java/com/parachord/android/playback/handlers/MusicKitCatalogLimiter.kt
+++ b/app/src/main/java/com/parachord/android/playback/handlers/MusicKitCatalogLimiter.kt
@@ -1,0 +1,134 @@
+package com.parachord.android.playback.handlers
+
+import com.parachord.shared.platform.Log
+import com.parachord.shared.platform.currentTimeMillis
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.Semaphore
+import kotlinx.coroutines.sync.withLock
+import kotlinx.coroutines.sync.withPermit
+import kotlin.concurrent.Volatile
+
+/**
+ * Concurrency + rate-limit gate for Apple Music catalog API calls made
+ * through the MusicKit JS bridge.
+ *
+ * Apple's catalog API (`api.music.apple.com/v1/catalog/{storefront}/...`) is
+ * aggressively throttled per dev-token / IP. Once a burst trips the throttle,
+ * subsequent calls — including the `/songs/{id}` lookup that
+ * [MusicKitWebBridge.play] does internally — fail with
+ * `MusicDataRequest.Error 1`, killing the active play path too.
+ *
+ * Mirrors desktop's `nativeMusicKitLimiter` (parachord-desktop/CLAUDE.md
+ * "Apple Music catalog API IS rate-limited — throttle parallel calls"):
+ *
+ *  - **Concurrency cap** ([MAX_CONCURRENT]): at most 3 in-flight catalog calls.
+ *  - **Inter-request delay** ([INTER_REQUEST_DELAY_MS]): 150 ms minimum gap
+ *    between starts. Spreads bursts thin enough that Apple's edge throttle
+ *    doesn't see a single-second spike.
+ *  - **Circuit breaker**: after [CONSECUTIVE_429_THRESHOLD] consecutive
+ *    rate-limit signals, opens for [COOLDOWN_MS] (5 minutes). In-cooldown
+ *    [runThrottled] calls short-circuit returning null without hitting the
+ *    bridge. Auto-resets after the cooldown expires.
+ *
+ * The kill-switch is **time-bound**, not session-permanent. One transient
+ * catalog throttle shouldn't disable Apple Music for the rest of the
+ * session — that's the corollary from the desktop docs.
+ */
+class MusicKitCatalogLimiter {
+
+    companion object {
+        private const val TAG = "MusicKitCatalogLimiter"
+        const val MAX_CONCURRENT: Int = 3
+        const val INTER_REQUEST_DELAY_MS: Long = 150L
+        const val CONSECUTIVE_429_THRESHOLD: Int = 3
+        const val COOLDOWN_MS: Long = 5L * 60L * 1000L  // 5 min
+    }
+
+    private val semaphore = Semaphore(MAX_CONCURRENT)
+    private val timestampMutex = Mutex()
+
+    /** Last permit-acquisition epoch-ms; the next acquirer sleeps to honor [INTER_REQUEST_DELAY_MS]. */
+    @Volatile
+    private var lastStartEpochMs: Long = 0L
+
+    @Volatile
+    private var consecutive429s: Int = 0
+
+    @Volatile
+    private var cooldownUntilMs: Long = 0L
+
+    /**
+     * Run [block] under the gate. Returns null when the kill-switch is active
+     * (the caller treats that as "no result"). Otherwise acquires a permit,
+     * sleeps to honor the inter-request gap, and runs [block].
+     *
+     * On a rate-limit signal in [block]'s result, the caller invokes
+     * [reportRateLimit]. On success, [reportSuccess]. The limiter doesn't
+     * inspect [block]'s return value itself.
+     */
+    suspend fun <T> runThrottled(block: suspend () -> T): T? {
+        val now = currentTimeMillis()
+        if (now < cooldownUntilMs) {
+            val remaining = cooldownUntilMs - now
+            Log.d(TAG, "Catalog limiter in cooldown for ${remaining / 1000}s — short-circuiting")
+            return null
+        }
+        return semaphore.withPermit {
+            // Inter-request delay. Synchronized via a mutex so two coroutines
+            // that grab permits simultaneously space themselves correctly.
+            timestampMutex.withLock {
+                val sinceLast = currentTimeMillis() - lastStartEpochMs
+                if (sinceLast < INTER_REQUEST_DELAY_MS) {
+                    delay(INTER_REQUEST_DELAY_MS - sinceLast)
+                }
+                lastStartEpochMs = currentTimeMillis()
+            }
+            block()
+        }
+    }
+
+    /**
+     * Caller invokes when [block]'s result indicates a rate-limit (the JS
+     * response carried `MusicDataRequest.Error 1`, `429`, or `rate-limit`-ish
+     * error text). Trips the circuit breaker after [CONSECUTIVE_429_THRESHOLD]
+     * consecutive signals.
+     */
+    fun reportRateLimit() {
+        consecutive429s += 1
+        if (consecutive429s >= CONSECUTIVE_429_THRESHOLD) {
+            val until = currentTimeMillis() + COOLDOWN_MS
+            cooldownUntilMs = until
+            Log.w(TAG, "Catalog rate-limit threshold reached ($consecutive429s consecutive) — opening cooldown until $until (${COOLDOWN_MS / 1000}s)")
+        }
+    }
+
+    /** Caller invokes on success to reset the 429 counter. */
+    fun reportSuccess() {
+        if (consecutive429s > 0) {
+            Log.d(TAG, "Catalog success after $consecutive429s consecutive rate-limit(s) — reset")
+        }
+        consecutive429s = 0
+    }
+
+    /**
+     * Heuristic: does this response string look like a rate-limit signal?
+     * MusicKit JS surfaces three distinct strings depending on which layer
+     * tripped (the catalog HTTP 429, MusicKit's internal `MusicDataRequest`
+     * error wrapping, or a JS-side network timeout that often correlates
+     * with throttling).
+     */
+    fun looksLikeRateLimit(errorString: String?): Boolean {
+        if (errorString.isNullOrBlank()) return false
+        val lc = errorString.lowercase()
+        return "musicdatarequest.error 1" in lc
+            || "429" in lc
+            || "rate-limit" in lc
+            || "rate limit" in lc
+            || "too many requests" in lc
+    }
+
+    /** Test hook — exposed for unit tests that need to inspect internal state. */
+    internal val consecutive429sForTest: Int get() = consecutive429s
+    internal val cooldownUntilMsForTest: Long get() = cooldownUntilMs
+}

--- a/app/src/main/java/com/parachord/android/playback/handlers/MusicKitWebBridge.kt
+++ b/app/src/main/java/com/parachord/android/playback/handlers/MusicKitWebBridge.kt
@@ -51,6 +51,15 @@ class MusicKitWebBridge constructor(
     private val settingsStore: SettingsStore,
     private val json: Json,
 ) {
+    /**
+     * Throttle gate for Apple Music catalog API calls. All three call sites
+     * ([search], [getPlaylist], [preload]) wrap their JS evaluate() in
+     * [catalogLimiter.runThrottled] so a burst of MBID-enrichment fallback
+     * searches (large library import / hosted-XSPF refresh) can't trip
+     * Apple's per-token throttle and cascade into `MusicDataRequest.Error 1`
+     * on the active play path. Mirrors desktop's `nativeMusicKitLimiter`.
+     */
+    private val catalogLimiter = MusicKitCatalogLimiter()
     companion object {
         private const val TAG = "MusicKitWebBridge"
         /** Served via WebViewAssetLoader so the bridge has an https:// origin,
@@ -597,19 +606,26 @@ class MusicKitWebBridge constructor(
     suspend fun search(query: String, limit: Int = 10): List<AppleMusicSearchResult> {
         musicKitReady.await()
         val storefront = settingsStore.getAppleMusicStorefront() ?: "us"
-        val result = evaluate("search(atob('${b64(query)}'), $limit, atob('${b64(storefront)}'))") ?: return emptyList()
-        return try {
-            val parsed = json.decodeFromString<MusicKitSearchResponse>(cleanJsString(result))
-            if (!parsed.success) {
-                Log.w(TAG, "Search failed: ${parsed.error}")
+        return catalogLimiter.runThrottled {
+            val result = evaluate("search(atob('${b64(query)}'), $limit, atob('${b64(storefront)}'))")
+                ?: return@runThrottled emptyList()
+            try {
+                val parsed = json.decodeFromString<MusicKitSearchResponse>(cleanJsString(result))
+                if (!parsed.success) {
+                    if (catalogLimiter.looksLikeRateLimit(parsed.error)) {
+                        catalogLimiter.reportRateLimit()
+                    }
+                    Log.w(TAG, "Search failed: ${parsed.error}")
+                    emptyList()
+                } else {
+                    catalogLimiter.reportSuccess()
+                    parsed.results
+                }
+            } catch (e: Exception) {
+                Log.e(TAG, "Failed to parse search response: $result", e)
                 emptyList()
-            } else {
-                parsed.results
             }
-        } catch (e: Exception) {
-            Log.e(TAG, "Failed to parse search response: $result", e)
-            emptyList()
-        }
+        } ?: emptyList()
     }
 
     // ── Playlist Fetch ─────────────────────────────────────────────
@@ -629,29 +645,39 @@ class MusicKitWebBridge constructor(
     suspend fun getPlaylist(playlistId: String): AppleMusicPlaylistResult? {
         musicKitReady.await()
         val storefront = settingsStore.getAppleMusicStorefront() ?: "us"
-        val result = evaluate("getPlaylist(atob('${b64(playlistId)}'), atob('${b64(storefront)}'))") ?: return null
-        return try {
-            val response = json.decodeFromString<GetPlaylistResponse>(cleanJsString(result))
-            if (!response.success || response.tracks.isNullOrEmpty()) return null
-            AppleMusicPlaylistResult(
-                name = response.name ?: "Playlist",
-                tracks = response.tracks.map { t ->
-                    AppleMusicSearchResult(
-                        id = t.id,
-                        title = t.title,
-                        artist = t.artist,
-                        album = t.album,
-                        duration = t.duration,
-                        artworkUrl = t.artworkUrl,
-                        isrc = null,
-                        previewUrl = null,
-                        appleMusicUrl = null,
-                    )
-                },
-            )
-        } catch (e: Exception) {
-            Log.w(TAG, "Failed to parse getPlaylist response: ${e.message}")
-            null
+        return catalogLimiter.runThrottled {
+            val result = evaluate("getPlaylist(atob('${b64(playlistId)}'), atob('${b64(storefront)}'))")
+                ?: return@runThrottled null
+            try {
+                val response = json.decodeFromString<GetPlaylistResponse>(cleanJsString(result))
+                if (!response.success) {
+                    if (catalogLimiter.looksLikeRateLimit(response.error)) {
+                        catalogLimiter.reportRateLimit()
+                    }
+                    return@runThrottled null
+                }
+                if (response.tracks.isNullOrEmpty()) return@runThrottled null
+                catalogLimiter.reportSuccess()
+                AppleMusicPlaylistResult(
+                    name = response.name ?: "Playlist",
+                    tracks = response.tracks.map { t ->
+                        AppleMusicSearchResult(
+                            id = t.id,
+                            title = t.title,
+                            artist = t.artist,
+                            album = t.album,
+                            duration = t.duration,
+                            artworkUrl = t.artworkUrl,
+                            isrc = null,
+                            previewUrl = null,
+                            appleMusicUrl = null,
+                        )
+                    },
+                )
+            } catch (e: Exception) {
+                Log.w(TAG, "Failed to parse getPlaylist response: ${e.message}")
+                null
+            }
         }
     }
 
@@ -663,7 +689,13 @@ class MusicKitWebBridge constructor(
      */
     suspend fun preload(songId: String) {
         if (!musicKitReady.isCompleted) return
-        evaluate("preload(atob('${b64(songId)}'))")
+        // Throttled — preload calls fan out per-track during background source
+        // resolution. Best-effort: if the limiter's cooldown is open, the
+        // preload is silently skipped (playback's catalog lookup will reload
+        // it lazily anyway).
+        catalogLimiter.runThrottled {
+            evaluate("preload(atob('${b64(songId)}'))")
+        }
     }
 
     /** Play a song by Apple Music catalog ID. Returns true on success. */

--- a/app/src/test/java/com/parachord/android/playback/handlers/MusicKitCatalogLimiterTest.kt
+++ b/app/src/test/java/com/parachord/android/playback/handlers/MusicKitCatalogLimiterTest.kt
@@ -1,0 +1,102 @@
+package com.parachord.android.playback.handlers
+
+import kotlinx.coroutines.test.runTest
+import org.junit.Test
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+
+class MusicKitCatalogLimiterTest {
+
+    @Test
+    fun runThrottled_returnsBlockResult_whenNoCooldown() = runTest {
+        val limiter = MusicKitCatalogLimiter()
+        val result = limiter.runThrottled { 42 }
+        assertEquals(42, result)
+    }
+
+    @Test
+    fun runThrottled_skipsBlock_whenCooldownActive() = runTest {
+        val limiter = MusicKitCatalogLimiter()
+        // Trip the breaker
+        repeat(MusicKitCatalogLimiter.CONSECUTIVE_429_THRESHOLD) { limiter.reportRateLimit() }
+        var ran = false
+        val result = limiter.runThrottled {
+            ran = true
+            "should not run"
+        }
+        assertNull(result)
+        assertFalse("block must not execute while cooldown is open", ran)
+    }
+
+    @Test
+    fun reportRateLimit_underThreshold_doesNotOpenCooldown() = runTest {
+        val limiter = MusicKitCatalogLimiter()
+        // 2 of 3 — still under
+        limiter.reportRateLimit()
+        limiter.reportRateLimit()
+        var ran = false
+        val result = limiter.runThrottled {
+            ran = true
+            "ok"
+        }
+        assertEquals("ok", result)
+        assertTrue(ran)
+    }
+
+    @Test
+    fun reportRateLimit_atThreshold_opensCooldown() = runTest {
+        val limiter = MusicKitCatalogLimiter()
+        repeat(MusicKitCatalogLimiter.CONSECUTIVE_429_THRESHOLD) { limiter.reportRateLimit() }
+        assertTrue(
+            "cooldownUntil must be in the future",
+            limiter.cooldownUntilMsForTest > System.currentTimeMillis(),
+        )
+    }
+
+    @Test
+    fun reportSuccess_resetsCounter() = runTest {
+        val limiter = MusicKitCatalogLimiter()
+        limiter.reportRateLimit()
+        limiter.reportRateLimit()
+        assertEquals(2, limiter.consecutive429sForTest)
+        limiter.reportSuccess()
+        assertEquals(0, limiter.consecutive429sForTest)
+    }
+
+    @Test
+    fun reportSuccess_afterReset_threshold_takes3MoreToTrip() = runTest {
+        val limiter = MusicKitCatalogLimiter()
+        limiter.reportRateLimit()
+        limiter.reportRateLimit()  // 2 of 3
+        limiter.reportSuccess()    // resets to 0
+        limiter.reportRateLimit()
+        limiter.reportRateLimit()  // 2 of 3 again — should still be open
+        assertNotNull(limiter.runThrottled { "still open" })
+        limiter.reportRateLimit()  // 3 of 3 — now closed
+        assertNull(limiter.runThrottled { "should skip" })
+    }
+
+    @Test
+    fun looksLikeRateLimit_detectsKnownStrings() {
+        val limiter = MusicKitCatalogLimiter()
+        assertTrue(limiter.looksLikeRateLimit("MusicKit.MusicDataRequest.Error 1"))
+        assertTrue(limiter.looksLikeRateLimit("musicdatarequest.error 1"))
+        assertTrue(limiter.looksLikeRateLimit("HTTP 429 Too Many Requests"))
+        assertTrue(limiter.looksLikeRateLimit("rate-limit exceeded"))
+        assertTrue(limiter.looksLikeRateLimit("Rate Limit"))
+        assertTrue(limiter.looksLikeRateLimit("Too Many Requests"))
+    }
+
+    @Test
+    fun looksLikeRateLimit_returnsFalseForUnrelatedErrors() {
+        val limiter = MusicKitCatalogLimiter()
+        assertFalse(limiter.looksLikeRateLimit(null))
+        assertFalse(limiter.looksLikeRateLimit(""))
+        assertFalse(limiter.looksLikeRateLimit("No results found"))
+        assertFalse(limiter.looksLikeRateLimit("Invalid storefront"))
+        assertFalse(limiter.looksLikeRateLimit("Network error"))
+    }
+}


### PR DESCRIPTION
Closes #148.

## Why

Apple Music's catalog API (\`api.music.apple.com/v1/catalog/{storefront}/...\`) is aggressively throttled per dev-token / IP. Once a burst trips the throttle, subsequent calls — including the \`/songs/{id}\` lookup that playback does internally — fail with \`MusicDataRequest.Error 1\`, killing the active play path too. No real-world report yet, but the risk is concrete: an MBID-enrichment burst during a large library import or hosted-XSPF refresh can fan out 50+ parallel catalog calls.

Mirrors desktop's \`nativeMusicKitLimiter\` per \`parachord-desktop/CLAUDE.md\` "Apple Music catalog API IS rate-limited — throttle parallel calls".

## What

Three \`MusicKitWebBridge\` call sites wrap their JS \`evaluate()\` in \`catalogLimiter.runThrottled\`:

- \`search(query, limit)\` — used by \`ResolverManager\` AM resolution
- \`getPlaylist(playlistId)\` — used by Apple Music playlist import
- \`preload(songId)\` — fired per-track during background source enrichment

The limiter (\`MusicKitCatalogLimiter\`, pure Kotlin, \`:app\`-only since the bridge is WebView-specific):

| Knob | Value | Why |
|---|---|---|
| Concurrency | 3 | Same as desktop — matches Apple's per-token comfort |
| Inter-request gap | 150 ms | Spreads bursts thin enough Apple's edge throttle doesn't see a single-second spike |
| Circuit breaker | 3 consecutive 429-equivalent signals | Time-bound 5-min cooldown — NOT session-permanent (one transient throttle shouldn't disable Apple Music for the session) |
| Rate-limit detection | \`looksLikeRateLimit(errorString)\` | Matches "MusicDataRequest.Error 1", "429", "rate-limit", "too many requests" |

## Test plan

- [x] 8/8 \`MusicKitCatalogLimiterTest\` cases:
  - block executes when no cooldown
  - block skipped when cooldown active (returns null)
  - under-threshold doesn't trip
  - at-threshold opens the cooldown
  - \`reportSuccess\` resets the counter
  - post-reset takes 3 more to trip
  - positive rate-limit string matching (5 variants)
  - negative cases (null / empty / unrelated errors)
- [x] Full \`:app:testDebugUnitTest :shared:testDebugUnitTest\` green
- [ ] Manual on-device: large playlist import / hosted-XSPF refresh + \`adb logcat -s MusicKitCatalogLimiter\` — should NOT see "rate-limit threshold reached" under normal load (and if it does, subsequent calls should silently return null for 5 minutes rather than thrashing)

## Cross-platform note

iOS will need its own MusicKit limiter when the shell lands — \`MusicKitWebBridge\` is WebView-specific and \`:app\`-only. iOS uses the native MusicKit framework with its own concurrency model; the *design pattern* (concurrency cap + inter-request gap + circuit breaker) ports cleanly but the implementation is platform-specific.

## Cross-refs

- Desktop: \`parachord-desktop/CLAUDE.md\` "Apple Music catalog API IS rate-limited — throttle parallel calls"
- Sibling shape: \`shared/.../api/RateLimitGate.kt\` (Ktor-based; this is a separate WebView-shaped sibling)

🤖 Generated with [Claude Code](https://claude.com/claude-code)