### PR TITLE
applinks: register https://parachord.com/<verb> + HTTPS routing (closes #123)

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -107,6 +107,55 @@
                 <data android:scheme="parachord" android:host="import" />
             </intent-filter>
 
+            <!-- Universal-Links / App-Links HTTPS counterpart to parachord://.
+                 Auto-verifies against https://parachord.com/.well-known/assetlinks.json
+                 (lives in the parachord-website repo). Until the website ships
+                 that file, taps to https://parachord.com/<verb> show Android's
+                 chooser dialog ("Open with: Parachord / Browser"). After the
+                 website ships and Android re-verifies (24h propagation,
+                 can be forced with the `pm verify-app-links` adb command
+                 + re-verify flag), the chooser disappears and Parachord
+                 opens directly.
+
+                 Filter belongs on MainActivity, NOT OAuthRedirectActivity —
+                 that one is OAuth-only and uses parachord://auth/...
+
+                 autoVerify is on the filter, not the data tags — Android
+                 verifies the host once per filter.
+
+                 Paths mirror the parachord:// host list above. New verbs
+                 added later need entries here too. Tracked by #122 / #123. -->
+            <intent-filter android:autoVerify="true">
+                <action android:name="android.intent.action.VIEW" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+                <data android:scheme="https" android:host="parachord.com" />
+                <!-- Playback -->
+                <data android:path="/play" />
+                <data android:pathPrefix="/play/" />
+                <data android:path="/listen-along" />
+                <data android:path="/import" />
+                <data android:pathPrefix="/queue/" />
+                <data android:pathPrefix="/control/" />
+                <data android:pathPrefix="/shuffle/" />
+                <data android:pathPrefix="/volume/" />
+                <!-- Navigation -->
+                <data android:pathPrefix="/artist/" />
+                <data android:pathPrefix="/album/" />
+                <data android:pathPrefix="/library" />
+                <data android:pathPrefix="/history" />
+                <data android:pathPrefix="/friend/" />
+                <data android:pathPrefix="/recommendations" />
+                <data android:path="/charts" />
+                <data android:path="/critics-picks" />
+                <data android:path="/playlists" />
+                <data android:pathPrefix="/playlist/" />
+                <data android:pathPrefix="/settings" />
+                <data android:path="/search" />
+                <data android:path="/chat" />
+                <data android:path="/home" />
+            </intent-filter>
+
             <!-- Spotify web URLs -->
             <intent-filter>
                 <action android:name="android.intent.action.VIEW" />

--- a/app/src/main/java/com/parachord/android/deeplink/DeepLinkHandler.kt
+++ b/app/src/main/java/com/parachord/android/deeplink/DeepLinkHandler.kt
@@ -380,8 +380,38 @@ class DeepLinkHandler constructor() {
         return when (uri.host) {
             "open.spotify.com" -> parseSpotifyUrl(uri)
             "music.apple.com" -> parseAppleMusicUrl(uri)
+            "parachord.com" -> parseParachordHttps(uri)
             else -> DeepLinkAction.Unknown(uri.toString())
         }
+    }
+
+    /**
+     * Map a Universal-Link / App-Link of the form
+     *   `https://parachord.com/<verb>[/<sub>]?<query>`
+     * onto the same [DeepLinkAction] the equivalent
+     *   `parachord://<verb>[/<sub>]?<query>`
+     * URL would produce.
+     *
+     * Strategy: rewrite the HTTPS URI into the matching custom-scheme URI
+     * (first path segment becomes the authority, rest becomes the path,
+     * query carries verbatim) and delegate to [parseParachord]. That makes
+     * every existing AND future verb HTTPS-compatible for free — adding a
+     * new `parachord://` verb in [parseParachord] automatically gains
+     * `https://parachord.com/...` coverage without touching this method.
+     *
+     * Pairs with the matching `<intent-filter android:autoVerify="true">`
+     * in AndroidManifest.xml. See `docs/plans/2026-05-21-android-app-links-design.md`.
+     */
+    private fun parseParachordHttps(uri: Uri): DeepLinkAction {
+        val segments = uri.pathSegments
+        if (segments.isEmpty()) return DeepLinkAction.Unknown(uri.toString())
+        val rebuilt = Uri.Builder()
+            .scheme("parachord")
+            .authority(segments.first())
+            .apply { segments.drop(1).forEach { appendPath(it) } }
+            .encodedQuery(uri.encodedQuery)
+            .build()
+        return parseParachord(rebuilt)
     }
 
     private fun parseSpotifyUrl(uri: Uri): DeepLinkAction {

--- a/app/src/test/java/com/parachord/android/deeplink/DeepLinkHandlerTest.kt
+++ b/app/src/test/java/com/parachord/android/deeplink/DeepLinkHandlerTest.kt
@@ -360,3 +360,161 @@ class DeepLinkHandlerRadioContractTest {
         assertFalse((b as DeepLinkAction.PlayRadio).shuffle)
     }
 }
+
+/**
+ * Round-trip tests for the Universal-Link / App-Link HTTPS form
+ * (`https://parachord.com/<verb>`) against its custom-scheme counterpart
+ * (`parachord://<verb>`).
+ *
+ * Each test asserts `parse(httpsUrl) == parse(parachordUrl)` for one verb.
+ * This locks the contract: the HTTPS form is a complete drop-in for the
+ * custom scheme. If [DeepLinkHandler.parseParachordHttps]'s URL rewrite
+ * breaks for any verb, exactly one of these tests fails.
+ *
+ * Adding a new verb to [DeepLinkHandler.parseParachord]? Add a parallel
+ * test here AND a matching `<data android:path|pathPrefix=...>` entry to
+ * the `https://parachord.com` `<intent-filter>` in AndroidManifest.xml.
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(application = Application::class)
+class DeepLinkHandlerHttpsParachordTest {
+
+    private val handler = DeepLinkHandler()
+
+    private fun assertRoundTrip(httpsPath: String, parachordPath: String) {
+        val https = handler.parse(Uri.parse("https://parachord.com$httpsPath"))
+        val parachord = handler.parse(Uri.parse("parachord:$parachordPath"))
+        assertEquals(
+            "HTTPS form (https://parachord.com$httpsPath) must produce the same DeepLinkAction as the custom scheme (parachord:$parachordPath)",
+            parachord,
+            https,
+        )
+        // Reject the "both Unknown" trivial pass — a real verb must resolve.
+        assertFalse(
+            "Both forms resolved to Unknown — the test isn't actually exercising parseParachord's switch",
+            https is DeepLinkAction.Unknown,
+        )
+    }
+
+    // -- Playback verbs --
+
+    @Test fun play_artist_title() =
+        assertRoundTrip("/play?artist=Radiohead&title=Creep", "//play?artist=Radiohead&title=Creep")
+
+    @Test fun play_album_byMbid() =
+        assertRoundTrip("/play/album?mbid=554b417d-8885-41e6-86c7-ae935e62d571", "//play/album?mbid=554b417d-8885-41e6-86c7-ae935e62d571")
+
+    @Test fun play_playlist_bySpotifyId() =
+        assertRoundTrip(
+            "/play/playlist?spotify=37i9dQZF1DXcBWIGoYBM5M&title=Hits",
+            "//play/playlist?spotify=37i9dQZF1DXcBWIGoYBM5M&title=Hits",
+        )
+
+    @Test fun play_radio_artistSeed() =
+        assertRoundTrip("/play/radio?artist=Slowdive", "//play/radio?artist=Slowdive")
+
+    @Test fun listen_along() =
+        assertRoundTrip("/listen-along?service=lastfm&user=jherskow", "//listen-along?service=lastfm&user=jherskow")
+
+    @Test fun control_pause() =
+        assertRoundTrip("/control/pause", "//control/pause")
+
+    @Test fun control_play() =
+        assertRoundTrip("/control/play", "//control/play")
+
+    @Test fun control_next() =
+        assertRoundTrip("/control/next", "//control/next")
+
+    @Test fun queue_add() =
+        assertRoundTrip("/queue/add?artist=Beatles&title=Yesterday", "//queue/add?artist=Beatles&title=Yesterday")
+
+    @Test fun queue_clear() =
+        assertRoundTrip("/queue/clear", "//queue/clear")
+
+    @Test fun shuffle_on() =
+        assertRoundTrip("/shuffle/on", "//shuffle/on")
+
+    @Test fun shuffle_off() =
+        assertRoundTrip("/shuffle/off", "//shuffle/off")
+
+    @Test fun volume_set() =
+        assertRoundTrip("/volume/50", "//volume/50")
+
+    @Test fun import_playlist() =
+        assertRoundTrip(
+            "/import?url=https%3A%2F%2Fexample.com%2Fp.xspf",
+            "//import?url=https%3A%2F%2Fexample.com%2Fp.xspf",
+        )
+
+    // -- Navigation verbs --
+
+    @Test fun navigate_home() =
+        assertRoundTrip("/home", "//home")
+
+    @Test fun navigate_artist() =
+        assertRoundTrip("/artist/Radiohead", "//artist/Radiohead")
+
+    @Test fun navigate_artist_withTab() =
+        assertRoundTrip("/artist/Radiohead?tab=tour", "//artist/Radiohead?tab=tour")
+
+    @Test fun navigate_album() =
+        assertRoundTrip("/album/Radiohead/OK%20Computer", "//album/Radiohead/OK%20Computer")
+
+    @Test fun navigate_library() =
+        assertRoundTrip("/library", "//library")
+
+    @Test fun navigate_library_withTab() =
+        assertRoundTrip("/library?tab=artists", "//library?tab=artists")
+
+    @Test fun navigate_history() =
+        assertRoundTrip("/history", "//history")
+
+    @Test fun navigate_friend() =
+        assertRoundTrip("/friend/jherskow?tab=top-tracks", "//friend/jherskow?tab=top-tracks")
+
+    @Test fun navigate_recommendations() =
+        assertRoundTrip("/recommendations", "//recommendations")
+
+    @Test fun navigate_charts() =
+        assertRoundTrip("/charts", "//charts")
+
+    @Test fun navigate_critics_picks() =
+        assertRoundTrip("/critics-picks", "//critics-picks")
+
+    @Test fun navigate_playlists() =
+        assertRoundTrip("/playlists", "//playlists")
+
+    @Test fun navigate_playlist_byId() =
+        assertRoundTrip("/playlist/local-abc123", "//playlist/local-abc123")
+
+    @Test fun navigate_settings() =
+        assertRoundTrip("/settings", "//settings")
+
+    @Test fun navigate_search() =
+        assertRoundTrip("/search?q=Radiohead", "//search?q=Radiohead")
+
+    @Test fun navigate_chat() =
+        assertRoundTrip("/chat", "//chat")
+
+    // -- Negative / edge cases --
+
+    @Test fun rootPath_returnsUnknown() {
+        // No verb → no action. (parseParachord with no host produces Unknown
+        // too; we just want to confirm no NPE / crash on a bare host.)
+        val a = handler.parse(Uri.parse("https://parachord.com/"))
+        assertTrue(a is DeepLinkAction.Unknown)
+    }
+
+    @Test fun emptyPath_returnsUnknown() {
+        val a = handler.parse(Uri.parse("https://parachord.com"))
+        assertTrue(a is DeepLinkAction.Unknown)
+    }
+
+    @Test fun unknownVerb_returnsUnknown() {
+        // parachord://nonexistent is also Unknown; the HTTPS form must
+        // match.
+        val httpsResult = handler.parse(Uri.parse("https://parachord.com/nonexistent-verb"))
+        val parachordResult = handler.parse(Uri.parse("parachord://nonexistent-verb"))
+        assertEquals(parachordResult, httpsResult)
+    }
+}

--- a/docs/plans/2026-05-21-android-app-links-design.md
+++ b/docs/plans/2026-05-21-android-app-links-design.md
@@ -1,0 +1,83 @@
+# Android App Links for `https://parachord.com/*` — design
+
+Date: 2026-05-21
+Closes: #123 (sub-issue of master #122)
+
+## Goal
+
+Register `https://parachord.com/<verb>` URLs with Android so that taps from any source (Gmail, Messages, Chrome, Achordion `PlayOnHoverFab`, etc.) open the Parachord app directly on devices where it's installed, falling back to the website otherwise. No behavior change for the existing `parachord://` custom scheme.
+
+## Scope
+
+Three additive changes. None of them touch `parseParachord` itself or any existing intent filter — full backward compatibility.
+
+### 1. Manifest filter (`AndroidManifest.xml`)
+
+Add a second `<intent-filter android:autoVerify="true">` on `MainActivity`, alongside the existing `parachord://` filter. Scheme `https`, host `parachord.com`, one `<data android:path|pathPrefix=...>` per supported verb. The full list (mirrors the issue):
+
+- Playback verbs: `/play`, `/play/`, `/listen-along`, `/import`, `/queue/`, `/control/`, `/shuffle/`, `/volume/`
+- Navigation verbs: `/artist/`, `/album/`, `/library`, `/history`, `/friend/`, `/recommendations`, `/charts`, `/critics-picks`, `/playlists`, `/playlist/`, `/settings`, `/search`, `/chat`, `/home`
+
+`autoVerify="true"` lives on the filter element, not the data tags — Android verifies the host once per filter. Existing passthrough filters for `open.spotify.com` + `music.apple.com` stay unchanged (those don't autoVerify because we don't own those hosts).
+
+The filter belongs on `MainActivity`, NOT `OAuthRedirectActivity`. `OAuthRedirectActivity` is OAuth-only and uses `parachord://auth/...`; mixing HTTPS filters there would confuse Android's verifier.
+
+### 2. `DeepLinkHandler.parseHttpUrl` extension
+
+`parseHttpUrl` already has two branches (`open.spotify.com`, `music.apple.com`). Add a third for `parachord.com`. The new branch is a thin URL rewrite:
+
+```kotlin
+private fun parseParachordHttps(uri: Uri): DeepLinkAction {
+    val segments = uri.pathSegments
+    if (segments.isEmpty()) return DeepLinkAction.Unknown(uri.toString())
+    val rebuilt = Uri.Builder()
+        .scheme("parachord")
+        .authority(segments.first())                            // first segment becomes host
+        .apply { segments.drop(1).forEach { appendPath(it) } }  // rest becomes path
+        .encodedQuery(uri.encodedQuery)                         // query carries verbatim
+        .build()
+    return parseParachord(rebuilt)
+}
+```
+
+`https://parachord.com/play?artist=X&title=Y` rewrites to `parachord://play?artist=X&title=Y`. `https://parachord.com/play/album?mbid=...` rewrites to `parachord://play/album?mbid=...`. Every verb that `parseParachord` understands now has free HTTPS coverage — including future verbs we haven't added yet.
+
+### 3. Unit tests
+
+Add per-verb round-trip tests in `DeepLinkHandlerTest`. Each test asserts that `parseHttpUrl(https://parachord.com/<path>)` produces the same `DeepLinkAction` as `parse(parachord://<path>)`. One test per verb in the manifest filter — locks the contract that the HTTPS form is a complete drop-in for the custom scheme.
+
+### 4. Signing-cert SHA-256 fingerprints
+
+Extract debug + release signing cert SHA-256 fingerprints via `keytool`. Drop them in the PR description for the website team's `assetlinks.json` file. Fingerprints aren't sensitive — they're in every release APK and Play Store listing — no secret channel needed.
+
+## Out of scope
+
+- **Website `assetlinks.json` deployment.** Lives in `parachord-website`; their work is a separate ticket. Until they ship, Android shows a "Open with: Parachord / Browser" chooser instead of routing automatically. Still better than today's silent failure.
+- **iOS Universal Links** — blocked on iOS app target existing; tracked in #124.
+- **Voice search / Assistant integration** — `https://parachord.com/<verb>` URLs are for tap-routing; voice search uses a different MediaSession callback surface.
+- **Changes to `parseParachord` switch.** No new verbs are added in this PR.
+
+## Acceptance criteria
+
+- `./gradlew :app:lintDebug` passes — manifest validates.
+- `DeepLinkHandlerTest` has per-verb HTTPS round-trip tests; all pass.
+- No regression on existing `parachord://` URLs — the existing `DeepLinkHandlerTest` suite still passes unchanged.
+- `adb shell am start -a android.intent.action.VIEW -d "https://parachord.com/play?artist=X&title=Y"` on a device with the app installed → shows a chooser dialog (pre-website-ship) or opens the app directly (post-website-ship).
+- `adb shell pm get-app-links com.parachord.android.debug` reports `parachord.com: ask` initially, `parachord.com: verified` after website's `assetlinks.json` is live and Android re-verifies (24h propagation, can be forced with `pm verify-app-links --re-verify`).
+
+## Verification matrix
+
+After all three pieces (this PR, website, eventual iOS) ship, smoke test on real devices:
+
+- Gmail / iMessage link tap
+- Chrome address bar paste + go
+- Notes / Slack long-press → "Open in Parachord"
+- Achordion `PlayOnHoverFab` tap (the real-world canonical entry point)
+
+Each should: open the app directly when installed; land on the website fallback page when not.
+
+## File changes
+
+- `app/src/main/AndroidManifest.xml` — second `<intent-filter>` on `MainActivity`
+- `app/src/main/java/com/parachord/android/deeplink/DeepLinkHandler.kt` — third branch in `parseHttpUrl` + new `parseParachordHttps` private helper
+- `app/src/test/java/com/parachord/android/deeplink/DeepLinkHandlerTest.kt` — per-verb round-trip tests


### PR DESCRIPTION
## Summary
Android sub-issue of the Universal Links / App Links rollout (master: #122). Three additive changes — no behavior change for the existing `parachord://` custom scheme.

- **Manifest** — second `<intent-filter android:autoVerify="true">` on `MainActivity` alongside the existing `parachord://` filter. Scheme `https`, host `parachord.com`, one `<data android:path|pathPrefix=...>` per supported verb.
- **`DeepLinkHandler.parseHttpUrl`** — third branch for `parachord.com`. The `parseParachordHttps` shim rewrites `https://parachord.com/<verb>/<sub>?<query>` into the equivalent `parachord://<verb>/<sub>?<query>` Uri and delegates to `parseParachord`. Every existing AND future verb gets HTTPS coverage for free.
- **Tests** — new `DeepLinkHandlerHttpsParachordTest` (Robolectric) round-trips every verb. 28 verb tests + 3 negative cases. One test per `<data>` entry in the manifest filter.

Design doc: `docs/plans/2026-05-21-android-app-links-design.md`.

## Signing-cert SHA-256 fingerprints (for website's `assetlinks.json`)

**Debug** (universal across dev machines — not sensitive, lives in every dev's `~/.android/debug.keystore`):

```
BB:C4:49:AF:39:A3:AA:31:10:F8:A6:C2:E7:29:88:4E:E4:34:1B:38:E1:C3:E9:F5:9A:34:91:BF:23:ED:A0:EB
```

**Release**: this app uses Play App Signing, so the fingerprint that matters for App Links verification is Google's signing cert (not the upload key). The website team should grab it from Play Console → Setup → App integrity → App signing → **App signing key certificate → SHA-256 certificate fingerprint**.

## Test plan

- [x] `./gradlew :app:testDebugUnitTest` — full app suite green; new `DeepLinkHandlerHttpsParachordTest` adds 31 tests, all pass
- [x] On-device with `pm get-app-links com.parachord.android.debug`: reports `parachord.com: 1024` (ASK state — expected pre-website-ship)
- [x] On-device end-to-end: with `pm set-app-links-user-selection` forcing the user choice, `am start -d "https://parachord.com/play?..."` routes to `com.parachord.android.ui.MainActivity` (not Chrome) — confirms manifest registration + DeepLinkHandler.parseParachordHttps both work
- [ ] **Post-website-ship verification (this PR doesn't block on it):**
  - [ ] `pm get-app-links com.parachord.android.debug` reports `parachord.com: verified`
  - [ ] Tap `https://parachord.com/play?...` in Gmail / Messages / Chrome → app opens directly (no chooser)

## Coordination

Until parachord-website ships `/.well-known/assetlinks.json` with the matching SHA-256 fingerprint, tapping `https://parachord.com/...` on a device with Parachord installed will show Android's "Open with: Parachord / Browser" chooser dialog instead of routing automatically. Still better than today's silent failure on the custom scheme for users without the app installed.

Force-reverification after website ships: `adb shell pm verify-app-links --re-verify com.parachord.android.debug`

## Notes

- Pre-existing lint baseline error `MissingIntentFilterForMediaSearch` on the `<application>` tag is unrelated to this PR (`./gradlew :app:lintDebug` fails on `main` without these changes too). Fix that one in a separate ticket.
- Out of scope: iOS sub-issue (#124, blocked on iOS app target existing) and website sub-issue (filed in parachord-website).

🤖 Generated with [Claude Code](https://claude.com/claude-code)