### PR TITLE
ui: stop clipping descenders in CollectionFilterBar's search field

### DIFF
--- a/app/src/main/java/com/parachord/android/ui/screens/library/CollectionFilterBar.kt
+++ b/app/src/main/java/com/parachord/android/ui/screens/library/CollectionFilterBar.kt
@@ -10,7 +10,6 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
@@ -177,9 +176,13 @@ fun CollectionFilterBar(
                                 )
                             }
                         },
+                        // No explicit .height() — Material 3's OutlinedTextField
+                        // has an enforced minimum content height (56dp); forcing
+                        // it shorter (44dp originally) clipped the rendered text's
+                        // descenders because the internal layout positions the
+                        // text baseline as if it had the full 56dp to work with.
                         modifier = Modifier
                             .width(200.dp)
-                            .height(44.dp)
                             .focusRequester(focusRequester),
                     )
                 }


### PR DESCRIPTION
## Summary

The filter pill in `CollectionFilterBar` (used on Library + Playlists tabs) was forcing `OutlinedTextField` to `.height(44.dp)`. Material 3's `OutlinedTextField` has an enforced minimum content height (56dp by default); when constrained shorter, the internal layout still positions the text baseline as if it had the full 56dp, so the rendered text's descenders fall outside the clipped bounds and get cropped. Typing into the filter showed only the upper half of glyphs (g/p/q/y descenders cut off, all other glyphs visible only down to the baseline).

## Fix

Remove the `.height(44.dp)`. Let the field use M3's default height. One-line behavior change + inline comment explaining why a fixed height would clip + dropped the now-unused `androidx.compose.foundation.layout.height` import.

## Side effect

The bar grows ~12dp when the search expands. That matches the M3-standard outlined-text-field height and the rest of the app's text fields. If the slight vertical jump in the expand animation ever becomes a visual problem, the follow-up is to wrap a `BasicTextField` in `OutlinedTextFieldDefaults.DecorationBox` with a custom `contentPadding` (preserves both the compact height AND the outlined-pill styling — but ~30 lines of M3 ceremony, deferred until needed).

## Test plan
- [x] `./gradlew :app:compileDebugKotlin` passes (only pre-existing deprecation warnings)
- [x] `./gradlew :app:testDebugUnitTest` passes
- [x] Manual: typed "Daily" into the filter on the Playlists tab — descenders fully visible (was clipped to upper half of glyphs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)