### PR TITLE
ui: render Achordion brand icon on its Settings plugin tile

### DIFF
--- a/app/src/main/java/com/parachord/android/ui/components/ResolverIcon.kt
+++ b/app/src/main/java/com/parachord/android/ui/components/ResolverIcon.kt
@@ -68,6 +68,7 @@ object ResolverIconColors {
     val seatgeek = Color(0xFFFC4C02)
     val bandsintown = Color(0xFF00B4B3)
     val songkick = Color(0xFFF80046)
+    val achordion = Color(0xFF7C3AED)
 
     fun forResolver(resolver: String?): Color? = when (resolver?.lowercase()) {
         "spotify" -> spotify
@@ -89,6 +90,7 @@ object ResolverIconColors {
         "seatgeek" -> seatgeek
         "bandsintown" -> bandsintown
         "songkick" -> songkick
+        "achordion" -> achordion
         else -> null
     }
 }
@@ -435,6 +437,20 @@ fun ResolverIconSquare(
                 modifier = modifier.size(size).alpha(iconAlpha),
             )
         }
+        return
+    }
+
+    // Achordion uses a multi-color VectorDrawable (dark circle + white C-ring
+    // + white tag bar + small purple cap) — can't go through the path-data
+    // system which only handles white-fill paths. Render the drawable at full
+    // size; its built-in dark circle background sits inside the chip (if a
+    // chip is drawn upstream by PluginTile etc.).
+    if (resolver.lowercase() == "achordion") {
+        Image(
+            painter = painterResource(R.drawable.achordion_icon),
+            contentDescription = "Achordion",
+            modifier = modifier.size(size).alpha(iconAlpha),
+        )
         return
     }
 

--- a/app/src/main/res/drawable/achordion_icon.xml
+++ b/app/src/main/res/drawable/achordion_icon.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+    Achordion brand icon — direct port of achordion/app/icon.svg.
+
+    Multi-color (dark circle + white C-ring + white right bar + small
+    purple cap), so it can't go through the path-data system in
+    ResolverIcon.kt (which only handles white-fill paths). Special-cased
+    in ResolverIconSquare to render via painterResource(R.drawable.achordion_icon)
+    similar to how SoundCloud's PNG drawable is handled.
+-->
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="190"
+    android:viewportHeight="190">
+
+    <!-- Dark blue-gray circle background (#273441), 1-unit white outline. -->
+    <path
+        android:fillColor="#273441"
+        android:strokeColor="#FFFFFF"
+        android:strokeWidth="1"
+        android:pathData="M0.5,95 A94.5,94.5 0 1,1 189.5,95 A94.5,94.5 0 1,1 0.5,95 Z" />
+
+    <!-- White C-shape ring — thick 27-unit stroke; no fill. -->
+    <path
+        android:strokeColor="#FFFFFF"
+        android:strokeWidth="27"
+        android:pathData="M88.5,48.7222 C112.725,48.7222 133.5,69.5684 133.5,96.7222 C133.5,123.876 112.725,144.722 88.5,144.722 C64.2754,144.722 43.5,123.876 43.5,96.7222 C43.5,69.5684 64.2754,48.7222 88.5,48.7222 Z" />
+
+    <!-- White vertical bar (tag on the right of the C). -->
+    <path
+        android:fillColor="#FFFFFF"
+        android:strokeColor="#FFFFFF"
+        android:strokeWidth="1"
+        android:pathData="M122.5,35.7222 h24 v122 h-24 Z" />
+
+    <!-- Purple top cap (#774BE9) with white outline. -->
+    <path
+        android:fillColor="#774BE9"
+        android:strokeColor="#FFFFFF"
+        android:strokeWidth="3"
+        android:pathData="M148.5,29.5 V37.1426 H144.852 V45.5 H122.148 V37.1426 H118.5 V29.5 H148.5 Z" />
+</vector>


### PR DESCRIPTION
## Summary
The Achordion plugin shows up as a featureless purple chip in Settings → Plugins. The chip background renders correctly (from `plugin.bgColor = #7C3AED` in the marketplace manifest), but the white icon foreground is missing entirely.

## Root cause
Achordion is downloaded from the [parachord-plugins marketplace](https://raw.githubusercontent.com/Parachord/parachord-plugins/main/manifest.json) at app start (`PluginSyncService` → `filesDir/plugins/achordion.axe`) and appears as a tile. `SettingsScreen.PluginTile` calls `ResolverIconSquare(resolver = "achordion", showBackground = false)` for the foreground, but `ResolverIconPaths.forResolver("achordion")` returns `null` (Achordion was never added to the lookup tables). The function early-returns at `ResolverIcon.kt:441` → no icon rendered.

## Fix
Three small pieces:

1. **`res/drawable/achordion_icon.xml`** (new) — ports `achordion/app/icon.svg` directly. Achordion's brand is multi-color (dark `#273441` circle + white "C" ring + white right bar + small `#774BE9` cap) and uses both fill *and* stroke, so it can't ride through the white-fill path-data system the other tiles use.

2. **`ResolverIconColors.forResolver("achordion")`** → `#7C3AED` brand purple. Any caller asking for the color gets a non-null answer.

3. **`ResolverIconSquare`** — special-case `"achordion"` to render the VectorDrawable via `painterResource`. Same pattern as the existing SoundCloud branch (which uses a PNG drawable for the same reason).

## Visual

The icon's built-in dark circle sits inside the brand-purple chip with a thin ring of purple visible at the corners. Distinct from the all-white-on-color other tiles, but matches Achordion's actual brand (same as on desktop).

## Test plan
- [x] `./gradlew :app:compileDebugKotlin` passes (only pre-existing deprecation warnings)
- [x] `./gradlew :app:testDebugUnitTest` passes
- [ ] Manual: open Settings → Plugins on a device with the Achordion .axe synced → tile shows the brand icon (previously empty purple chip)

🤖 Generated with [Claude Code](https://claude.com/claude-code)