### PR TITLE
auto: fix dispatch crash from inconsistent currentTrack/items snapshot

### DIFF
--- a/app/src/main/java/com/parachord/android/playback/PlaybackService.kt
+++ b/app/src/main/java/com/parachord/android/playback/PlaybackService.kt
@@ -1493,9 +1493,38 @@ class PlaybackService : MediaLibraryService() {
             }
             dispatching = true
             try {
-                val combined = buildList {
-                    currentTrack?.let { add(it) }
-                    addAll(upNext)
+                // INVARIANT: items.isEmpty() iff currentTrack == null. We
+                // MUST NOT emit a snapshot with upNext populated but no
+                // current track. Reason: our [getCurrentMediaItemIndex]
+                // returns C.INDEX_UNSET (-1) when [queueSnapshot.currentMediaId]
+                // is null. Media3 IPCs the timeline + currentMediaItemIndex
+                // together to the controller (Android Auto), and the
+                // controller's PlayerInfo.getCurrentMediaItem calls
+                // timeline.getWindow(currentMediaItemIndex, ...) — i.e.
+                // timeline.getWindow(-1, ...) when current is null.
+                // [QueueTimeline.getWindow] doesn't bounds-check (Media3
+                // contractually shouldn't call with -1 if the timeline is
+                // non-empty), so an inconsistent snapshot crashes the
+                // controller process with IndexOutOfBoundsException.
+                //
+                // Race window that hits this: user taps Collection Radio →
+                // [PlaybackController.playQueue] → [QueueManager.setQueue]
+                // emits a new snapshot with upNext = N immediately, but
+                // [PlaybackStateHolder.currentTrack] doesn't update until
+                // the routed handler starts playback ~30-100ms later. The
+                // combine in [queueSnapshotJob] fires on the upNext
+                // emission first, with currentTrack still null.
+                //
+                // Fix: when currentTrack is null, emit an empty timeline.
+                // The queue becomes visible to Auto once the current
+                // track lands.
+                val combined: List<TrackEntity> = if (currentTrack != null) {
+                    buildList {
+                        add(currentTrack)
+                        addAll(upNext)
+                    }
+                } else {
+                    emptyList()
                 }
                 val items = combined.map { it.toAutoMediaItem() }
                 val durationsUs = LongArray(combined.size) { i ->

--- a/app/src/main/java/com/parachord/android/playback/QueueTimeline.kt
+++ b/app/src/main/java/com/parachord/android/playback/QueueTimeline.kt
@@ -62,6 +62,24 @@ class QueueTimeline(
         window: Window,
         defaultPositionProjectionUs: Long,
     ): Window {
+        // Defensive bounds check. Media3 contractually shouldn't call
+        // getWindow with an out-of-range index — but it does crash if
+        // [ExternalPlaybackForwardingPlayer]'s snapshot is ever
+        // inconsistent (timeline.size > 0 with currentMediaItemIndex =
+        // INDEX_UNSET; controller-side PlayerInfo.getCurrentMediaItem
+        // then calls timeline.getWindow(-1, ...)). The wrapper enforces
+        // the consistency invariant — this is the second line of defense
+        // so that any future regression there throws a clear,
+        // QueueTimeline-attributed error instead of an opaque ArrayList
+        // IndexOutOfBoundsException in a Media3 stack frame.
+        if (windowIndex < 0 || windowIndex >= items.size) {
+            throw IndexOutOfBoundsException(
+                "QueueTimeline.getWindow: windowIndex=$windowIndex out of range [0, ${items.size}). " +
+                    "Caller passed an invalid index — check that " +
+                    "ExternalPlaybackForwardingPlayer.updateQueueSnapshot kept the " +
+                    "current-track / items-list invariant (items empty iff currentTrack null)."
+            )
+        }
         val item = items[windowIndex]
         val durationUs = durationsUs[windowIndex]
         return window.set(
@@ -83,6 +101,11 @@ class QueueTimeline(
     }
 
     override fun getPeriod(periodIndex: Int, period: Period, setIds: Boolean): Period {
+        if (periodIndex < 0 || periodIndex >= items.size) {
+            throw IndexOutOfBoundsException(
+                "QueueTimeline.getPeriod: periodIndex=$periodIndex out of range [0, ${items.size})."
+            )
+        }
         val uid = if (setIds) uidAt(periodIndex) else null
         return period.set(
             /* id = */ uid,

--- a/app/src/test/java/com/parachord/android/playback/ForwardingPlayerSnapshotTest.kt
+++ b/app/src/test/java/com/parachord/android/playback/ForwardingPlayerSnapshotTest.kt
@@ -178,6 +178,61 @@ class ForwardingPlayerSnapshotTest {
         assertEquals(C.INDEX_UNSET, wrapper.currentMediaItemIndex)
     }
 
+    @Test fun `null current with non-empty upNext emits empty timeline (Auto IPC crash regression)`() {
+        // Regression test for the in-car dispatch crash:
+        //   FATAL EXCEPTION: java.lang.IndexOutOfBoundsException: Index -1 out of bounds for length 2644
+        //       at com.parachord.android.playback.QueueTimeline.getWindow(QueueTimeline.kt:65)
+        //       at androidx.media3.session.PlayerInfo.getCurrentMediaItem(PlayerInfo.java:782)
+        //
+        // Race window when a browse-tree action dispatches: QueueManager.snapshot
+        // emits with upNext populated before PlaybackStateHolder.currentTrack
+        // lands (~30-100ms gap while the routed handler starts playback).
+        // Without this guard, the snapshot would have items.size = 2644 but
+        // currentMediaItemIndex = INDEX_UNSET. Media3 IPCs that inconsistent
+        // state to Auto's controller, which then calls timeline.getWindow(-1)
+        // and crashes the controller process.
+        //
+        // Invariant: items.isEmpty() iff currentTrack == null.
+        val delegate = mockk<androidx.media3.exoplayer.ExoPlayer>(relaxed = true)
+        every { delegate.currentTimeline } returns Timeline.EMPTY
+        val controller = mockk<PlaybackController>(relaxed = true)
+        val stateHolder = PlaybackStateHolder()
+        val wrapper = PlaybackService.ExternalPlaybackForwardingPlayer(delegate, controller, stateHolder)
+
+        wrapper.updateQueueSnapshot(
+            currentTrack = null,
+            upNext = listOf(track("u1"), track("u2"), track("u3")),
+        )
+
+        // Without the fix: mediaItemCount = 3 + currentMediaItemIndex = -1 → crash.
+        // With the fix: empty timeline, consistent state.
+        assertEquals(0, wrapper.mediaItemCount)
+        assertEquals(C.INDEX_UNSET, wrapper.currentMediaItemIndex)
+        assertNull(wrapper.currentMediaItem)
+        assertEquals(0, wrapper.currentTimeline.windowCount)
+    }
+
+    @Test fun `upNext becomes visible once currentTrack lands`() {
+        // Continuation of the race-window scenario: first snapshot has
+        // upNext but no current (gets suppressed), then a follow-up snapshot
+        // with both current AND upNext should expose the full queue.
+        val delegate = mockk<androidx.media3.exoplayer.ExoPlayer>(relaxed = true)
+        every { delegate.currentTimeline } returns Timeline.EMPTY
+        val controller = mockk<PlaybackController>(relaxed = true)
+        val stateHolder = PlaybackStateHolder()
+        val wrapper = PlaybackService.ExternalPlaybackForwardingPlayer(delegate, controller, stateHolder)
+
+        // First emission: upNext only — should be suppressed
+        wrapper.updateQueueSnapshot(currentTrack = null, upNext = listOf(track("u1"), track("u2")))
+        assertEquals(0, wrapper.mediaItemCount)
+
+        // Second emission: current + upNext arrives — should be visible
+        wrapper.updateQueueSnapshot(currentTrack = track("current"), upNext = listOf(track("u1"), track("u2")))
+        assertEquals(3, wrapper.mediaItemCount)
+        assertEquals(0, wrapper.currentMediaItemIndex)
+        assertEquals("current", wrapper.currentMediaItem?.mediaId)
+    }
+
     @Test fun `current to null transition fires onMediaItemTransition with null item`() {
         val delegate = mockk<androidx.media3.exoplayer.ExoPlayer>(relaxed = true)
         every { delegate.currentTimeline } returns Timeline.EMPTY


### PR DESCRIPTION
## Summary

In-car tap on a browse-tree action (Playlist, Collection Radio, search result) crashed Auto's controller process with:

```
FATAL EXCEPTION: java.lang.IndexOutOfBoundsException: Index -1 out of bounds for length 2644
    at com.parachord.android.playback.QueueTimeline.getWindow(QueueTimeline.kt:65)
    at androidx.media3.session.PlayerInfo.getCurrentMediaItem(PlayerInfo.java:782)
    at androidx.media3.session.MediaControllerImplBase.onPlayerInfoChanged(...)
```

## Race window

When the user taps a browse-tree action:

1. `dispatchBrowseTreeAction` → `PlaybackController.playQueue(N tracks)`
2. `QueueManager.setQueue()` immediately emits a new snapshot with `upNext = N`
3. The `combine` in `queueSnapshotJob` fires on that emission with `PlaybackStateHolder.currentTrack` **still null** — the routed handler hasn't started playback yet (~30-100ms async gap)
4. `updateQueueSnapshot` built `items = [] + upNext = N items`, but `getCurrentMediaItemIndex()` returned `C.INDEX_UNSET (-1)` because `queueSnapshot.currentMediaId` was null
5. Media3 IPCs that inconsistent state to Auto's controller (timeline with N items + currentMediaItemIndex = -1)
6. Controller calls `getCurrentMediaItem` → `timeline.getWindow(-1, ...)` → `ArrayList.get(-1)` → crash

A Media3 `Timeline` can't legitimately have items with no current position. The bug was on our side — emitting a snapshot that violates this invariant.

## Fix

**Primary** — `updateQueueSnapshot` enforces the invariant: when `currentTrack` is null, `items` is empty (don't expose upNext-only). The queue becomes visible to Auto once the current track actually lands.

**Defense in depth** — `QueueTimeline.getWindow` / `getPeriod` now throw an informative `IndexOutOfBoundsException` with a QueueTimeline-attributed message, so any future regression in the wrapper's invariant surfaces loudly and recognizably instead of as an opaque ArrayList exception in a Media3 stack frame.

## Test plan
- [x] `./gradlew :app:testDebugUnitTest` — passes; 2 new regression tests pin the invariant
- [x] Race-window logcat trace (`Browse: starting playlist hosted-xspf-... (288 tracks)` followed immediately by `FATAL EXCEPTION ... QueueTimeline.getWindow(QueueTimeline.kt:65)`) collected from the user's in-car drive
- [ ] Manual on-device after install: tap any browse-tree action in Android Auto → playback starts; no error toast, no controller-process crash

🤖 Generated with [Claude Code](https://claude.com/claude-code)