### PR TITLE
feat: ListenBrainzSyncProvider — two-way playlist sync (closes #156)

### DIFF
--- a/app/src/main/java/com/parachord/android/di/AndroidModule.kt
+++ b/app/src/main/java/com/parachord/android/di/AndroidModule.kt
@@ -52,6 +52,7 @@ import com.parachord.android.resolver.TrackResolverCache
 import com.parachord.android.sync.AppleMusicSyncProvider
 import com.parachord.android.sync.SpotifySyncProvider
 import com.parachord.android.sync.SyncEngine
+import com.parachord.shared.sync.ListenBrainzSyncProvider
 import com.parachord.android.sync.SyncScheduler
 import com.parachord.android.ui.MainViewModel
 import com.parachord.android.ui.screens.album.AlbumViewModel
@@ -807,6 +808,7 @@ val androidModule = module {
     // changes required here.
     singleOf(::SpotifySyncProvider) bind com.parachord.shared.sync.SyncProvider::class
     singleOf(::AppleMusicSyncProvider) bind com.parachord.shared.sync.SyncProvider::class
+    singleOf(::ListenBrainzSyncProvider) bind com.parachord.shared.sync.SyncProvider::class
     single<List<com.parachord.shared.sync.SyncProvider>> { getAll() }
     singleOf(::SyncScheduler)
     singleOf(::HostedPlaylistPoller)

--- a/app/src/main/java/com/parachord/android/di/AndroidModule.kt
+++ b/app/src/main/java/com/parachord/android/di/AndroidModule.kt
@@ -263,6 +263,15 @@ val androidModule = module {
         } catch (_: Exception) {
             // Column already present (idempotent on repeat launches).
         }
+        // ListenBrainz playlist sync (#156): trackRecordingMbid carries the
+        // recording MBID per-row so LB push/pull can identify tracks by MBID
+        // (LB's only stable ID). New installs get the column from
+        // PlaylistTrack.sq's CREATE TABLE; existing installs need this ALTER.
+        try {
+            driver.execute(null, "ALTER TABLE playlist_tracks ADD COLUMN trackRecordingMbid TEXT", 0)
+        } catch (_: Exception) {
+            // Column already present (idempotent on repeat launches).
+        }
         com.parachord.shared.db.ParachordDb(driver)
     }
 

--- a/app/src/main/java/com/parachord/android/resolver/TrackResolverCache.kt
+++ b/app/src/main/java/com/parachord/android/resolver/TrackResolverCache.kt
@@ -275,6 +275,7 @@ class TrackResolverCache constructor(
                     spotifyUri = spotifyUri,
                     appleMusicId = appleMusicId,
                     soundcloudId = soundcloudId,
+                    recordingMbid = null,
                 )
             } catch (e: Exception) {
                 Log.w(TAG, "Failed to backfill playlist_track resolver IDs for '${track.title}': ${e.message}")

--- a/app/src/main/java/com/parachord/android/ui/screens/settings/SettingsScreen.kt
+++ b/app/src/main/java/com/parachord/android/ui/screens/settings/SettingsScreen.kt
@@ -212,6 +212,7 @@ fun SettingsScreen(
     val appleMusicConfigured by viewModel.appleMusicConfigured.collectAsStateWithLifecycle()
     val appleMusicAuthorized by viewModel.appleMusicAuthorized.collectAsStateWithLifecycle()
     val appleMusicSyncEnabled by viewModel.appleMusicSyncEnabled.collectAsStateWithLifecycle()
+    val listenBrainzSyncEnabled by viewModel.listenBrainzSyncEnabled.collectAsStateWithLifecycle()
     val appleMusicConnecting by viewModel.appleMusicConnecting.collectAsStateWithLifecycle()
     val persistQueue by viewModel.persistQueue.collectAsStateWithLifecycle()
     val libreFmAuthError by viewModel.libreFmAuthError.collectAsStateWithLifecycle()
@@ -321,6 +322,9 @@ fun SettingsScreen(
                     appleMusicAuthorized = appleMusicAuthorized,
                     appleMusicSyncEnabled = appleMusicSyncEnabled,
                     onSetAppleMusicSyncEnabled = { viewModel.setAppleMusicSyncEnabled(it) },
+                    listenBrainzConnected = listenBrainzConnected,
+                    listenBrainzSyncEnabled = listenBrainzSyncEnabled,
+                    onSetListenBrainzSyncEnabled = { viewModel.setListenBrainzSyncEnabled(it) },
                 )
                 2 -> AboutTab()
             }
@@ -2744,6 +2748,9 @@ private fun GeneralTab(
     appleMusicAuthorized: Boolean,
     appleMusicSyncEnabled: Boolean,
     onSetAppleMusicSyncEnabled: (Boolean) -> Unit,
+    listenBrainzConnected: Boolean,
+    listenBrainzSyncEnabled: Boolean,
+    onSetListenBrainzSyncEnabled: (Boolean) -> Unit,
 ) {
     val syncViewModel: SyncViewModel = koinViewModel()
     val syncEnabled by syncViewModel.syncEnabled.collectAsStateWithLifecycle()
@@ -2990,6 +2997,35 @@ private fun GeneralTab(
                         }
                     }
                 }
+            }
+        }
+
+        // ── ListenBrainz Sync section (Task 19) ──────────────────────
+        // Only shown when LB is authorized (token present). Toggle
+        // writes to enabled_sync_providers, which the multi-provider
+        // sync engine reads on every cycle. Loved tracks already sync
+        // separately via the scrobbler love-push pipeline — this
+        // controls playlist sync (pushing Parachord-curated playlists
+        // up to the user's LB profile).
+        if (listenBrainzConnected) {
+            item { Spacer(modifier = Modifier.height(8.dp)) }
+            item { SectionHeader("ListenBrainz Sync") }
+            item {
+                ListItem(
+                    headlineContent = { Text("ListenBrainz Sync") },
+                    supportingContent = {
+                        Text(
+                            "Pushes Parachord-curated playlists to your ListenBrainz profile. " +
+                                "Loved tracks already sync separately via scrobblers.",
+                        )
+                    },
+                    trailingContent = {
+                        Switch(
+                            checked = listenBrainzSyncEnabled,
+                            onCheckedChange = onSetListenBrainzSyncEnabled,
+                        )
+                    },
+                )
             }
         }
     }

--- a/app/src/main/java/com/parachord/android/ui/screens/settings/SettingsViewModel.kt
+++ b/app/src/main/java/com/parachord/android/ui/screens/settings/SettingsViewModel.kt
@@ -326,6 +326,25 @@ class SettingsViewModel constructor(
         }
     }
 
+    // ── ListenBrainz sync (Task 19) ──────────────────────────────────
+    // Mirrors the AM toggle above. Only visible when LB is authorized
+    // (token present). Writes to enabled_sync_providers, which the
+    // multi-provider sync engine reads on every cycle. Loved tracks
+    // continue to sync separately via the scrobbler pipeline — this
+    // toggle controls playlist sync (push Parachord playlists to LB).
+    val listenBrainzSyncEnabled: StateFlow<Boolean> =
+        settingsStore.getEnabledSyncProvidersFlow()
+            .map { "listenbrainz" in it }
+            .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), false)
+
+    fun setListenBrainzSyncEnabled(enabled: Boolean) {
+        viewModelScope.launch {
+            val current = settingsStore.getEnabledSyncProviders()
+            val next = if (enabled) current + "listenbrainz" else current - "listenbrainz"
+            settingsStore.setEnabledSyncProviders(next)
+        }
+    }
+
     // --- SoundCloud ---
 
     /** Whether the user has saved SoundCloud client credentials (BYOK). */

--- a/app/src/test/java/com/parachord/android/sync/HealImportedSyncedFromTest.kt
+++ b/app/src/test/java/com/parachord/android/sync/HealImportedSyncedFromTest.kt
@@ -274,6 +274,73 @@ class HealImportedSyncedFromTest {
     }
 
     @Test
+    fun `heal restores listenbrainz source when playlist ID prefix is listenbrainz`() = runBlocking {
+        val db = TestDatabaseFactory.create()
+        // listenbrainz-<mbid> playlist row, but sync_playlist_source is wrongly
+        // pointing at spotify (corrupt state — e.g. from a bug in a prior client).
+        db.insertPlaylist(id = "listenbrainz-abc123")
+        val sourceDao = SyncPlaylistSourceDao(db)
+        val linkDao = SyncPlaylistLinkDao(db)
+        val playlistDao = PlaylistDao(db)
+
+        sourceDao.upsert(
+            localPlaylistId = "listenbrainz-abc123",
+            providerId = "spotify",
+            externalId = "SP-WRONG",
+            snapshotId = "sp-snap",
+            ownerId = null,
+            syncedAt = 100L,
+        )
+
+        com.parachord.shared.sync.SyncEngine.healImportedSyncedFromMismatch(
+            playlistDao, sourceDao, linkDao,
+        )
+
+        // Source row corrected to listenbrainz with externalId derived from prefix.
+        val src = sourceDao.selectForLocal("listenbrainz-abc123")
+        assertNotNull(src)
+        assertEquals("listenbrainz", src!!.providerId)
+        assertEquals("abc123", src.externalId)
+        assertNull(src.snapshotId) // null so next LB sync repopulates
+
+        // Demoted spotify mapping preserved as a link.
+        val link = linkDao.selectForLink("listenbrainz-abc123", "spotify")
+        assertNotNull(link)
+        assertEquals("SP-WRONG", link!!.externalId)
+        assertEquals("sp-snap", link.snapshotId)
+    }
+
+    @Test
+    fun `healthy listenbrainz playlist is no-op`() = runBlocking {
+        val db = TestDatabaseFactory.create()
+        db.insertPlaylist(id = "listenbrainz-abc123")
+        val sourceDao = SyncPlaylistSourceDao(db)
+        val linkDao = SyncPlaylistLinkDao(db)
+        val playlistDao = PlaylistDao(db)
+
+        sourceDao.upsert(
+            localPlaylistId = "listenbrainz-abc123",
+            providerId = "listenbrainz",
+            externalId = "abc123",
+            snapshotId = "lb-snap",
+            ownerId = null,
+            syncedAt = 100L,
+        )
+
+        com.parachord.shared.sync.SyncEngine.healImportedSyncedFromMismatch(
+            playlistDao, sourceDao, linkDao,
+        )
+
+        val src = sourceDao.selectForLocal("listenbrainz-abc123")
+        assertNotNull(src)
+        assertEquals("listenbrainz", src!!.providerId)
+        assertEquals("abc123", src.externalId)
+        assertEquals("lb-snap", src.snapshotId) // snapshot preserved
+        assertEquals(100L, src.syncedAt)
+        assertTrue(linkDao.selectForLocal("listenbrainz-abc123").isEmpty())
+    }
+
+    @Test
     fun `clears locallyModified flag on healed playlist`() = runBlocking {
         val db = TestDatabaseFactory.create()
         db.insertPlaylist(id = "spotify-X", spotifyId = "X", locallyModified = 1L)

--- a/app/src/test/java/com/parachord/android/sync/ListenBrainzSyncProviderTest.kt
+++ b/app/src/test/java/com/parachord/android/sync/ListenBrainzSyncProviderTest.kt
@@ -1,0 +1,150 @@
+package com.parachord.android.sync
+
+import com.parachord.shared.api.LbPlaylist
+import com.parachord.shared.api.ListenBrainzClient
+import com.parachord.shared.settings.SettingsStore
+import com.parachord.shared.sync.ListenBrainzSyncProvider
+import com.parachord.shared.sync.ListenBrainzUnauthorizedException
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.mockk
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Locks the contract of [ListenBrainzSyncProvider.fetchPlaylists] (Task 10 of
+ * the LB-sync rollout, #156).
+ *
+ * Covers:
+ *  - early-return when token / username unset (provider not configured)
+ *  - kill-switch: 401 trips `authFailedForSession` and subsequent calls
+ *    short-circuit without hitting the client
+ *  - `LbPlaylist` → `SyncedPlaylist` field mapping (mbid, title, annotation,
+ *    lastModifiedAt → snapshotId)
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+class ListenBrainzSyncProviderTest {
+
+    @Test
+    fun `fetchPlaylists returns empty when token unset`() = runTest {
+        val settings: SettingsStore = mockk {
+            coEvery { getListenBrainzToken() } returns null
+        }
+        val provider = ListenBrainzSyncProvider(mockk(), settings, mockk())
+        assertTrue(provider.fetchPlaylists().isEmpty())
+    }
+
+    @Test
+    fun `fetchPlaylists returns empty when token is blank`() = runTest {
+        val settings: SettingsStore = mockk {
+            coEvery { getListenBrainzToken() } returns ""
+        }
+        val provider = ListenBrainzSyncProvider(mockk(), settings, mockk())
+        assertTrue(provider.fetchPlaylists().isEmpty())
+    }
+
+    @Test
+    fun `fetchPlaylists returns empty when username unset`() = runTest {
+        val settings: SettingsStore = mockk {
+            coEvery { getListenBrainzToken() } returns "valid-token"
+            coEvery { getListenBrainzUsername() } returns null
+        }
+        val provider = ListenBrainzSyncProvider(mockk(), settings, mockk())
+        assertTrue(provider.fetchPlaylists().isEmpty())
+    }
+
+    @Test
+    fun `fetchPlaylists returns empty when username is blank`() = runTest {
+        val settings: SettingsStore = mockk {
+            coEvery { getListenBrainzToken() } returns "valid-token"
+            coEvery { getListenBrainzUsername() } returns ""
+        }
+        val provider = ListenBrainzSyncProvider(mockk(), settings, mockk())
+        assertTrue(provider.fetchPlaylists().isEmpty())
+    }
+
+    @Test
+    fun `fetchPlaylists swallows 401 and trips kill-switch`() = runTest {
+        val client: ListenBrainzClient = mockk {
+            coEvery { getUserOwnedPlaylists("test-user") } throws ListenBrainzUnauthorizedException()
+        }
+        val settings: SettingsStore = mockk {
+            coEvery { getListenBrainzToken() } returns "valid-but-server-rejected"
+            coEvery { getListenBrainzUsername() } returns "test-user"
+        }
+        val provider = ListenBrainzSyncProvider(client, settings, mockk())
+        assertTrue(provider.fetchPlaylists().isEmpty())
+        // Second call short-circuits (no second client call) — kill-switch
+        // active means we don't ping the API again until session restart.
+        assertTrue(provider.fetchPlaylists().isEmpty())
+        coVerify(exactly = 1) { client.getUserOwnedPlaylists("test-user") }
+    }
+
+    @Test
+    fun `fetchPlaylists propagates non-401 errors`() = runTest {
+        val client: ListenBrainzClient = mockk {
+            coEvery { getUserOwnedPlaylists("test-user") } throws Exception("HTTP 503")
+        }
+        val settings: SettingsStore = mockk {
+            coEvery { getListenBrainzToken() } returns "tok"
+            coEvery { getListenBrainzUsername() } returns "test-user"
+        }
+        val provider = ListenBrainzSyncProvider(client, settings, mockk())
+        try {
+            provider.fetchPlaylists()
+            error("expected Exception to propagate")
+        } catch (e: Exception) {
+            assertEquals("HTTP 503", e.message)
+        }
+    }
+
+    @Test
+    fun `fetchPlaylists maps LbPlaylist to SyncedPlaylist`() = runTest {
+        val lbPlaylists = listOf(
+            LbPlaylist(
+                mbid = "mbid-1",
+                title = "Playlist 1",
+                annotation = "Desc 1",
+                lastModifiedAt = "2026-05-27T10:00:00Z",
+            ),
+            LbPlaylist(
+                mbid = "mbid-2",
+                title = "Playlist 2",
+                annotation = "",
+                lastModifiedAt = null,
+            ),
+        )
+        val client: ListenBrainzClient = mockk {
+            coEvery { getUserOwnedPlaylists("test-user") } returns lbPlaylists
+        }
+        val settings: SettingsStore = mockk {
+            coEvery { getListenBrainzToken() } returns "tok"
+            coEvery { getListenBrainzUsername() } returns "test-user"
+        }
+        val provider = ListenBrainzSyncProvider(client, settings, mockk())
+        val result = provider.fetchPlaylists()
+        assertEquals(2, result.size)
+
+        // First playlist — full data.
+        assertEquals("mbid-1", result[0].spotifyId)
+        assertEquals("Playlist 1", result[0].entity.name)
+        assertEquals("Desc 1", result[0].entity.description)
+        assertEquals("2026-05-27T10:00:00Z", result[0].snapshotId)
+        assertEquals("listenbrainz-mbid-1", result[0].entity.id)
+        // LB has no notion of unowned playlists in this list endpoint
+        // (it's the user's OWN playlists), so isOwned must be true to
+        // allow push-back.
+        assertTrue(result[0].isOwned)
+
+        // Second playlist — blank annotation → null description, null
+        // lastModifiedAt → null snapshotId.
+        assertEquals("mbid-2", result[1].spotifyId)
+        assertEquals("Playlist 2", result[1].entity.name)
+        assertNull(result[1].entity.description)
+        assertNull(result[1].snapshotId)
+    }
+}

--- a/app/src/test/java/com/parachord/android/sync/ListenBrainzSyncProviderTest.kt
+++ b/app/src/test/java/com/parachord/android/sync/ListenBrainzSyncProviderTest.kt
@@ -8,12 +8,14 @@ import com.parachord.shared.sync.ListenBrainzSyncProvider
 import com.parachord.shared.sync.ListenBrainzUnauthorizedException
 import io.mockk.coEvery
 import io.mockk.coVerify
+import io.mockk.coVerifyOrder
 import io.mockk.mockk
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
+import org.junit.Assert.fail
 import org.junit.Test
 
 /**
@@ -261,5 +263,196 @@ class ListenBrainzSyncProviderTest {
         }
         val provider = ListenBrainzSyncProvider(client, mockk(relaxed = true), mockk())
         assertNull(provider.getPlaylistSnapshotId("mbid"))
+    }
+
+    // ── createPlaylist (Task 12) ───────────────────────────────────────
+
+    @Test
+    fun `createPlaylist returns RemoteCreated with server-assigned MBID`() = runTest {
+        val client: ListenBrainzClient = mockk {
+            coEvery { createPlaylist(any(), any(), any(), any()) } returns "new-mbid-uuid"
+        }
+        val settings: SettingsStore = mockk { coEvery { getListenBrainzToken() } returns "tok" }
+        val provider = ListenBrainzSyncProvider(client, settings, mockk())
+        val result = provider.createPlaylist("Test", "Desc")
+        assertEquals("new-mbid-uuid", result.externalId)
+        // Snapshot is fetched separately via getPlaylistSnapshotId — the create
+        // endpoint returns only the MBID, not a last_modified timestamp.
+        assertNull(result.snapshotId)
+        coVerify { client.createPlaylist("Test", "Desc", true, "tok") }
+    }
+
+    @Test
+    fun `createPlaylist propagates 401 as ListenBrainzUnauthorizedException`() = runTest {
+        // Kill-switch invariant: a 401 from a mutation endpoint should trip
+        // authFailedForSession AND propagate to the caller so SyncEngine knows
+        // the push failed. We can't directly read the @Volatile field from
+        // outside the class — pin the typed-exception propagation instead
+        // (matches the fetchPlaylists defensive 401 test pattern above).
+        val client: ListenBrainzClient = mockk {
+            coEvery { createPlaylist(any(), any(), any(), any()) } throws ListenBrainzUnauthorizedException()
+        }
+        val settings: SettingsStore = mockk { coEvery { getListenBrainzToken() } returns "tok" }
+        val provider = ListenBrainzSyncProvider(client, settings, mockk())
+        try {
+            provider.createPlaylist("Test", "Desc")
+            fail("expected ListenBrainzUnauthorizedException")
+        } catch (e: ListenBrainzUnauthorizedException) { /* ok */ }
+    }
+
+    @Test
+    fun `createPlaylist throws IllegalStateException when token unset`() = runTest {
+        val settings: SettingsStore = mockk { coEvery { getListenBrainzToken() } returns null }
+        val provider = ListenBrainzSyncProvider(mockk(), settings, mockk())
+        try {
+            provider.createPlaylist("Test", null)
+            fail("expected IllegalStateException")
+        } catch (e: IllegalStateException) { /* ok */ }
+    }
+
+    @Test
+    fun `createPlaylist throws IllegalStateException when token blank`() = runTest {
+        val settings: SettingsStore = mockk { coEvery { getListenBrainzToken() } returns "" }
+        val provider = ListenBrainzSyncProvider(mockk(), settings, mockk())
+        try {
+            provider.createPlaylist("Test", null)
+            fail("expected IllegalStateException")
+        } catch (e: IllegalStateException) { /* ok */ }
+    }
+
+    // ── replacePlaylistTracks (Task 12) ────────────────────────────────
+
+    @Test
+    fun `replacePlaylistTracks does delete-all + add-all + returns new snapshot`() = runTest {
+        val client: ListenBrainzClient = mockk(relaxed = true) {
+            coEvery { getPlaylistTracksRich("mbid") } returns listOf(mockk(), mockk(), mockk()) // 3 items
+            coEvery { getPlaylistLastModified("mbid") } returns "2026-05-27T12:00:00Z"
+        }
+        val settings: SettingsStore = mockk { coEvery { getListenBrainzToken() } returns "tok" }
+        val provider = ListenBrainzSyncProvider(client, settings, mockk())
+        val newSnap = provider.replacePlaylistTracks("mbid", listOf("a", "b", "c", "d"))
+        coVerifyOrder {
+            client.getPlaylistTracksRich("mbid")
+            client.deletePlaylistItems("mbid", 0, 3, "tok")
+            client.addPlaylistItems("mbid", listOf("a", "b", "c", "d"), "tok")
+            client.getPlaylistLastModified("mbid")
+        }
+        assertEquals("2026-05-27T12:00:00Z", newSnap)
+    }
+
+    @Test
+    fun `replacePlaylistTracks skips deleteItems when current is empty`() = runTest {
+        val client: ListenBrainzClient = mockk(relaxed = true) {
+            coEvery { getPlaylistTracksRich("mbid") } returns emptyList()
+        }
+        val settings: SettingsStore = mockk { coEvery { getListenBrainzToken() } returns "tok" }
+        val provider = ListenBrainzSyncProvider(client, settings, mockk())
+        provider.replacePlaylistTracks("mbid", listOf("a", "b"))
+        coVerify(exactly = 0) { client.deletePlaylistItems(any(), any(), any(), any()) }
+        coVerify(exactly = 1) { client.addPlaylistItems("mbid", listOf("a", "b"), "tok") }
+    }
+
+    @Test
+    fun `replacePlaylistTracks skips addItems when desired is empty`() = runTest {
+        val client: ListenBrainzClient = mockk(relaxed = true) {
+            coEvery { getPlaylistTracksRich("mbid") } returns listOf(mockk(), mockk())
+        }
+        val settings: SettingsStore = mockk { coEvery { getListenBrainzToken() } returns "tok" }
+        val provider = ListenBrainzSyncProvider(client, settings, mockk())
+        provider.replacePlaylistTracks("mbid", emptyList())
+        coVerify(exactly = 1) { client.deletePlaylistItems("mbid", 0, 2, "tok") }
+        coVerify(exactly = 0) { client.addPlaylistItems(any(), any(), any()) }
+    }
+
+    @Test
+    fun `replacePlaylistTracks throws IllegalStateException when token unset`() = runTest {
+        val settings: SettingsStore = mockk { coEvery { getListenBrainzToken() } returns null }
+        val provider = ListenBrainzSyncProvider(mockk(), settings, mockk())
+        try {
+            provider.replacePlaylistTracks("mbid", listOf("a"))
+            fail("expected IllegalStateException")
+        } catch (e: IllegalStateException) { /* ok */ }
+    }
+
+    @Test
+    fun `replacePlaylistTracks propagates 401 from deletePlaylistItems`() = runTest {
+        val client: ListenBrainzClient = mockk {
+            coEvery { getPlaylistTracksRich("mbid") } returns listOf(mockk(), mockk())
+            coEvery { deletePlaylistItems(any(), any(), any(), any()) } throws ListenBrainzUnauthorizedException()
+        }
+        val settings: SettingsStore = mockk { coEvery { getListenBrainzToken() } returns "tok" }
+        val provider = ListenBrainzSyncProvider(client, settings, mockk())
+        try {
+            provider.replacePlaylistTracks("mbid", listOf("a"))
+            fail("expected ListenBrainzUnauthorizedException")
+        } catch (e: ListenBrainzUnauthorizedException) { /* ok */ }
+    }
+
+    @Test
+    fun `replacePlaylistTracks propagates 401 from addPlaylistItems`() = runTest {
+        val client: ListenBrainzClient = mockk(relaxed = true) {
+            coEvery { getPlaylistTracksRich("mbid") } returns emptyList()
+            coEvery { addPlaylistItems(any(), any(), any()) } throws ListenBrainzUnauthorizedException()
+        }
+        val settings: SettingsStore = mockk { coEvery { getListenBrainzToken() } returns "tok" }
+        val provider = ListenBrainzSyncProvider(client, settings, mockk())
+        try {
+            provider.replacePlaylistTracks("mbid", listOf("a"))
+            fail("expected ListenBrainzUnauthorizedException")
+        } catch (e: ListenBrainzUnauthorizedException) { /* ok */ }
+    }
+
+    // ── updatePlaylistDetails (Task 12) ────────────────────────────────
+
+    @Test
+    fun `updatePlaylistDetails delegates to client editPlaylist`() = runTest {
+        val client: ListenBrainzClient = mockk(relaxed = true)
+        val settings: SettingsStore = mockk { coEvery { getListenBrainzToken() } returns "tok" }
+        val provider = ListenBrainzSyncProvider(client, settings, mockk())
+        provider.updatePlaylistDetails("mbid", "New Name", "New Desc")
+        coVerify(exactly = 1) { client.editPlaylist("mbid", "New Name", "New Desc", "tok") }
+    }
+
+    @Test
+    fun `updatePlaylistDetails forwards a name-only update`() = runTest {
+        val client: ListenBrainzClient = mockk(relaxed = true)
+        val settings: SettingsStore = mockk { coEvery { getListenBrainzToken() } returns "tok" }
+        val provider = ListenBrainzSyncProvider(client, settings, mockk())
+        provider.updatePlaylistDetails("mbid", "New Name", null)
+        coVerify(exactly = 1) { client.editPlaylist("mbid", "New Name", null, "tok") }
+    }
+
+    @Test
+    fun `updatePlaylistDetails no-ops when both name and description are null`() = runTest {
+        val client: ListenBrainzClient = mockk(relaxed = true)
+        val settings: SettingsStore = mockk(relaxed = true)
+        val provider = ListenBrainzSyncProvider(client, settings, mockk())
+        provider.updatePlaylistDetails("mbid", null, null)
+        coVerify(exactly = 0) { client.editPlaylist(any(), any(), any(), any()) }
+        // Don't even read the token — pure short-circuit.
+        coVerify(exactly = 0) { settings.getListenBrainzToken() }
+    }
+
+    @Test
+    fun `updatePlaylistDetails throws IllegalStateException when token unset`() = runTest {
+        val settings: SettingsStore = mockk { coEvery { getListenBrainzToken() } returns null }
+        val provider = ListenBrainzSyncProvider(mockk(), settings, mockk())
+        try {
+            provider.updatePlaylistDetails("mbid", "Name", null)
+            fail("expected IllegalStateException")
+        } catch (e: IllegalStateException) { /* ok */ }
+    }
+
+    @Test
+    fun `updatePlaylistDetails propagates 401 as ListenBrainzUnauthorizedException`() = runTest {
+        val client: ListenBrainzClient = mockk {
+            coEvery { editPlaylist(any(), any(), any(), any()) } throws ListenBrainzUnauthorizedException()
+        }
+        val settings: SettingsStore = mockk { coEvery { getListenBrainzToken() } returns "tok" }
+        val provider = ListenBrainzSyncProvider(client, settings, mockk())
+        try {
+            provider.updatePlaylistDetails("mbid", "Name", null)
+            fail("expected ListenBrainzUnauthorizedException")
+        } catch (e: ListenBrainzUnauthorizedException) { /* ok */ }
     }
 }

--- a/app/src/test/java/com/parachord/android/sync/ListenBrainzSyncProviderTest.kt
+++ b/app/src/test/java/com/parachord/android/sync/ListenBrainzSyncProviderTest.kt
@@ -1,6 +1,7 @@
 package com.parachord.android.sync
 
 import com.parachord.shared.api.LbPlaylist
+import com.parachord.shared.api.LbPlaylistTrack
 import com.parachord.shared.api.ListenBrainzClient
 import com.parachord.shared.settings.SettingsStore
 import com.parachord.shared.sync.ListenBrainzSyncProvider
@@ -191,5 +192,74 @@ class ListenBrainzSyncProviderTest {
         assertEquals("Playlist 2", result[1].entity.name)
         assertNull(result[1].entity.description)
         assertNull(result[1].snapshotId)
+    }
+
+    // ── fetchPlaylistTracks (Task 11) ──────────────────────────────────
+
+    @Test
+    fun `fetchPlaylistTracks delegates to client and maps to PlaylistTrack`() = runTest {
+        val richTracks = listOf(
+            LbPlaylistTrack(
+                id = "mbid-1",
+                title = "Track1",
+                artist = "Artist1",
+                album = "Album1",
+                mbid = "mbid-1",
+            ),
+            LbPlaylistTrack(
+                id = "mbid-2",
+                title = "Track2",
+                artist = "Artist2",
+                album = null,
+                mbid = "mbid-2",
+            ),
+        )
+        val client: ListenBrainzClient = mockk {
+            coEvery { getPlaylistTracksRich("playlist-mbid") } returns richTracks
+        }
+        val provider = ListenBrainzSyncProvider(client, mockk(relaxed = true), mockk())
+        val result = provider.fetchPlaylistTracks("playlist-mbid")
+        assertEquals(2, result.size)
+        assertEquals("Track1", result[0].trackTitle)
+        assertEquals("Artist1", result[0].trackArtist)
+        assertEquals("Album1", result[0].trackAlbum)
+        assertEquals("mbid-1", result[0].trackRecordingMbid)
+        assertEquals(0, result[0].position)
+        assertEquals(1, result[1].position)
+        assertNull(result[1].trackAlbum)
+        // playlistId follows the `<provider>-<externalId>` convention used by
+        // SpotifySyncProvider + AppleMusicSyncProvider. SyncEngine remaps this
+        // to the local id when persisting.
+        assertEquals("listenbrainz-playlist-mbid", result[0].playlistId)
+        assertEquals("listenbrainz-playlist-mbid", result[1].playlistId)
+    }
+
+    @Test
+    fun `fetchPlaylistTracks returns empty list when playlist has no tracks`() = runTest {
+        val client: ListenBrainzClient = mockk {
+            coEvery { getPlaylistTracksRich("mbid") } returns emptyList()
+        }
+        val provider = ListenBrainzSyncProvider(client, mockk(relaxed = true), mockk())
+        assertTrue(provider.fetchPlaylistTracks("mbid").isEmpty())
+    }
+
+    // ── getPlaylistSnapshotId (Task 11) ────────────────────────────────
+
+    @Test
+    fun `getPlaylistSnapshotId returns last_modified_at from client`() = runTest {
+        val client: ListenBrainzClient = mockk {
+            coEvery { getPlaylistLastModified("mbid") } returns "2026-05-27T10:00:00Z"
+        }
+        val provider = ListenBrainzSyncProvider(client, mockk(relaxed = true), mockk())
+        assertEquals("2026-05-27T10:00:00Z", provider.getPlaylistSnapshotId("mbid"))
+    }
+
+    @Test
+    fun `getPlaylistSnapshotId returns null when client returns null`() = runTest {
+        val client: ListenBrainzClient = mockk {
+            coEvery { getPlaylistLastModified("mbid") } returns null
+        }
+        val provider = ListenBrainzSyncProvider(client, mockk(relaxed = true), mockk())
+        assertNull(provider.getPlaylistSnapshotId("mbid"))
     }
 }

--- a/app/src/test/java/com/parachord/android/sync/ListenBrainzSyncProviderTest.kt
+++ b/app/src/test/java/com/parachord/android/sync/ListenBrainzSyncProviderTest.kt
@@ -3,7 +3,10 @@ package com.parachord.android.sync
 import com.parachord.shared.api.LbPlaylist
 import com.parachord.shared.api.LbPlaylistTrack
 import com.parachord.shared.api.ListenBrainzClient
+import com.parachord.shared.api.MbidMapperResult
+import com.parachord.shared.metadata.MbidEnrichmentService
 import com.parachord.shared.settings.SettingsStore
+import com.parachord.shared.sync.DeleteResult
 import com.parachord.shared.sync.ListenBrainzSyncProvider
 import com.parachord.shared.sync.ListenBrainzUnauthorizedException
 import io.mockk.coEvery
@@ -454,5 +457,124 @@ class ListenBrainzSyncProviderTest {
             provider.updatePlaylistDetails("mbid", "Name", null)
             fail("expected ListenBrainzUnauthorizedException")
         } catch (e: ListenBrainzUnauthorizedException) { /* ok */ }
+    }
+
+    // ── deletePlaylist (Task 13) ───────────────────────────────────────
+
+    @Test
+    fun `deletePlaylist returns Success on happy path`() = runTest {
+        val client: ListenBrainzClient = mockk(relaxed = true)
+        val settings: SettingsStore = mockk { coEvery { getListenBrainzToken() } returns "tok" }
+        val provider = ListenBrainzSyncProvider(client, settings, mockk())
+        val result = provider.deletePlaylist("mbid")
+        assertEquals(DeleteResult.Success, result)
+        coVerify(exactly = 1) { client.deletePlaylist("mbid", "tok") }
+    }
+
+    @Test
+    fun `deletePlaylist 401 returns Unsupported (not thrown)`() = runTest {
+        // Per the SyncProvider contract, deletePlaylist must NEVER throw on
+        // documented-unsupported responses. Caller surfaces "remove manually"
+        // UX from Unsupported(401).
+        val client: ListenBrainzClient = mockk {
+            coEvery { deletePlaylist(any(), any()) } throws ListenBrainzUnauthorizedException()
+        }
+        val settings: SettingsStore = mockk { coEvery { getListenBrainzToken() } returns "tok" }
+        val provider = ListenBrainzSyncProvider(client, settings, mockk())
+        val result = provider.deletePlaylist("mbid")
+        assertTrue("expected Unsupported, got $result", result is DeleteResult.Unsupported)
+        assertEquals(401, (result as DeleteResult.Unsupported).status)
+    }
+
+    @Test
+    fun `deletePlaylist returns Failed on other errors`() = runTest {
+        val client: ListenBrainzClient = mockk {
+            coEvery { deletePlaylist(any(), any()) } throws Exception("HTTP 500")
+        }
+        val settings: SettingsStore = mockk { coEvery { getListenBrainzToken() } returns "tok" }
+        val provider = ListenBrainzSyncProvider(client, settings, mockk())
+        val result = provider.deletePlaylist("mbid")
+        assertTrue("expected Failed, got $result", result is DeleteResult.Failed)
+        assertEquals("HTTP 500", (result as DeleteResult.Failed).error.message)
+    }
+
+    @Test
+    fun `deletePlaylist returns Failed when token unset`() = runTest {
+        // Token-unset is a hard config error, but the contract still says
+        // never throw — return Failed instead.
+        val settings: SettingsStore = mockk { coEvery { getListenBrainzToken() } returns null }
+        val provider = ListenBrainzSyncProvider(mockk(), settings, mockk())
+        val result = provider.deletePlaylist("mbid")
+        assertTrue("expected Failed, got $result", result is DeleteResult.Failed)
+        assertTrue((result as DeleteResult.Failed).error is IllegalStateException)
+    }
+
+    @Test
+    fun `deletePlaylist returns Failed when token blank`() = runTest {
+        val settings: SettingsStore = mockk { coEvery { getListenBrainzToken() } returns "" }
+        val provider = ListenBrainzSyncProvider(mockk(), settings, mockk())
+        val result = provider.deletePlaylist("mbid")
+        assertTrue("expected Failed, got $result", result is DeleteResult.Failed)
+    }
+
+    // ── searchForTrackId (Task 13) ─────────────────────────────────────
+
+    @Test
+    fun `searchForTrackId returns recordingMbid from mapper on hit`() = runTest {
+        // mapperLookup signature is (artist, recording) — NOT (title, artist).
+        // The provider must pass them in the right order.
+        val enrichment: MbidEnrichmentService = mockk {
+            coEvery { mapperLookup("Artist", "Title") } returns MbidMapperResult(
+                artistMbid = "artist-mbid",
+                artistCreditName = "Artist",
+                recordingName = "Title",
+                recordingMbid = "mbid-result",
+                releaseName = null,
+                releaseMbid = null,
+                confidence = 0.95,
+            )
+        }
+        val provider = ListenBrainzSyncProvider(mockk(), mockk(relaxed = true), enrichment)
+        assertEquals("mbid-result", provider.searchForTrackId("Title", "Artist"))
+    }
+
+    @Test
+    fun `searchForTrackId returns null on mapper miss`() = runTest {
+        val enrichment: MbidEnrichmentService = mockk {
+            coEvery { mapperLookup(any(), any()) } returns null
+        }
+        val provider = ListenBrainzSyncProvider(mockk(), mockk(relaxed = true), enrichment)
+        assertNull(provider.searchForTrackId("Title", "Artist"))
+    }
+
+    @Test
+    fun `searchForTrackId returns null when mapper throws`() = runTest {
+        // Defensive — mapperLookup already swallows exceptions internally
+        // and returns null, but if it ever stops doing so, the provider
+        // must not propagate the failure (sync engine would abort the
+        // whole hydrate-loop on a single bad lookup).
+        val enrichment: MbidEnrichmentService = mockk {
+            coEvery { mapperLookup(any(), any()) } throws Exception("Network error")
+        }
+        val provider = ListenBrainzSyncProvider(mockk(), mockk(relaxed = true), enrichment)
+        assertNull(provider.searchForTrackId("Title", "Artist"))
+    }
+
+    @Test
+    fun `searchForTrackId returns null when recordingMbid is null`() = runTest {
+        // Mapper sometimes returns a result with artist MBID resolved but
+        // no recording MBID — treat as miss.
+        val enrichment: MbidEnrichmentService = mockk {
+            coEvery { mapperLookup(any(), any()) } returns MbidMapperResult(
+                artistMbid = "artist-mbid",
+                artistCreditName = "Artist",
+                recordingName = null,
+                recordingMbid = null,
+                releaseName = null,
+                releaseMbid = null,
+            )
+        }
+        val provider = ListenBrainzSyncProvider(mockk(), mockk(relaxed = true), enrichment)
+        assertNull(provider.searchForTrackId("Title", "Artist"))
     }
 }

--- a/app/src/test/java/com/parachord/android/sync/ListenBrainzSyncProviderTest.kt
+++ b/app/src/test/java/com/parachord/android/sync/ListenBrainzSyncProviderTest.kt
@@ -68,7 +68,12 @@ class ListenBrainzSyncProviderTest {
     }
 
     @Test
-    fun `fetchPlaylists swallows 401 and trips kill-switch`() = runTest {
+    fun `fetchPlaylists trips kill-switch on ListenBrainzUnauthorizedException (defensive — unauth endpoint today)`() = runTest {
+        // The pull endpoint is unauth today, so the typed exception flows only from
+        // a mocked client. Real 401 paths exit through the generic-Exception arm
+        // (separate test). This pins the kill-switch invariant for the day LB
+        // ever requires auth on this endpoint OR if a mutation lands on the kill-switch
+        // path during a pull cycle.
         val client: ListenBrainzClient = mockk {
             coEvery { getUserOwnedPlaylists("test-user") } throws ListenBrainzUnauthorizedException()
         }
@@ -82,6 +87,46 @@ class ListenBrainzSyncProviderTest {
         // active means we don't ping the API again until session restart.
         assertTrue(provider.fetchPlaylists().isEmpty())
         coVerify(exactly = 1) { client.getUserOwnedPlaylists("test-user") }
+    }
+
+    @Test
+    fun `fetchPlaylists propagates a real 401 from the unauth endpoint as generic Exception (does not trip kill-switch)`() = runTest {
+        val client: ListenBrainzClient = mockk {
+            coEvery { getUserOwnedPlaylists("test-user") } throws Exception("getUserOwnedPlaylists(test-user) failed: HTTP 401 Unauthorized")
+        }
+        val settings: SettingsStore = mockk {
+            coEvery { getListenBrainzToken() } returns "tok"
+            coEvery { getListenBrainzUsername() } returns "test-user"
+        }
+        val provider = ListenBrainzSyncProvider(client, settings, mockk())
+        // First call: generic Exception propagates
+        try {
+            provider.fetchPlaylists()
+            error("expected Exception to propagate")
+        } catch (e: Exception) {
+            assertTrue(e.message?.contains("HTTP 401") == true)
+        }
+        // Second call: kill-switch NOT tripped, client called again
+        try {
+            provider.fetchPlaylists()
+            error("expected Exception to propagate")
+        } catch (e: Exception) {
+            assertTrue(e.message?.contains("HTTP 401") == true)
+        }
+        coVerify(exactly = 2) { client.getUserOwnedPlaylists("test-user") }
+    }
+
+    @Test
+    fun `fetchPlaylists returns empty list when user has no playlists`() = runTest {
+        val client: ListenBrainzClient = mockk {
+            coEvery { getUserOwnedPlaylists("test-user") } returns emptyList()
+        }
+        val settings: SettingsStore = mockk {
+            coEvery { getListenBrainzToken() } returns "tok"
+            coEvery { getListenBrainzUsername() } returns "test-user"
+        }
+        val provider = ListenBrainzSyncProvider(client, settings, mockk())
+        assertTrue(provider.fetchPlaylists().isEmpty())
     }
 
     @Test

--- a/app/src/test/java/com/parachord/android/sync/PushCandidateTest.kt
+++ b/app/src/test/java/com/parachord/android/sync/PushCandidateTest.kt
@@ -52,6 +52,10 @@ class PushCandidateTest {
         return when (providerId) {
             "spotify" -> p.spotifyId == null && baseEligible
             "applemusic" -> baseEligible || p.id.startsWith("spotify-")
+            "listenbrainz" ->
+                baseEligible
+                    || p.id.startsWith("spotify-")
+                    || p.id.startsWith("applemusic-")
             else -> baseEligible
         }
     }
@@ -98,6 +102,32 @@ class PushCandidateTest {
         // applemusic- and aren't local-* or hosted, so the filter
         // returns false for them under AM push too.
         assertFalse(isPushCandidate(playlist("applemusic-abc"), "applemusic"))
+    }
+
+    @Test fun `ListenBrainz pushes local-prefix playlists`() {
+        assertTrue(isPushCandidate(playlist("local-abc"), "listenbrainz"))
+    }
+
+    @Test fun `ListenBrainz pushes hosted XSPF playlists`() {
+        assertTrue(isPushCandidate(playlist("hosted-xyz", sourceUrl = "https://e.xspf"), "listenbrainz"))
+    }
+
+    @Test fun `ListenBrainz pushes Spotify-imported playlists`() {
+        // LB mirrors any source-of-truth playlist; spotify-imported is one
+        // such source. Runtime syncedFrom guard skips when pulling from
+        // Spotify but allows the cross-mirror to LB.
+        assertTrue(isPushCandidate(playlist("spotify-abc", spotifyId = "abc"), "listenbrainz"))
+    }
+
+    @Test fun `ListenBrainz pushes AM-imported playlists`() {
+        // AM is also a source-of-truth provider; LB mirrors from it.
+        assertTrue(isPushCandidate(playlist("applemusic-abc"), "listenbrainz"))
+    }
+
+    @Test fun `ListenBrainz does NOT push unrecognized-prefix playlists`() {
+        // A third provider's import (e.g. a hypothetical tidal-*) doesn't
+        // count as a source-of-truth until added explicitly here.
+        assertFalse(isPushCandidate(playlist("tidal-abc"), "listenbrainz"))
     }
 
     @Test fun `unknown provider falls back to baseline (local + hosted)`() {

--- a/app/src/test/java/com/parachord/android/sync/SyncEngineTrackIdHelpersTest.kt
+++ b/app/src/test/java/com/parachord/android/sync/SyncEngineTrackIdHelpersTest.kt
@@ -1,0 +1,171 @@
+package com.parachord.android.sync
+
+import com.parachord.shared.model.PlaylistTrack
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Pure-helper tests for the per-provider track-ID helpers in SyncEngine:
+ *
+ *   - `extractExternalTrackIds(tracks, providerId)`
+ *   - `missingProviderId(track, providerId)`
+ *   - `applyResolvedId(track, providerId, resolvedId)`
+ *
+ * All three helpers are `private` on SyncEngine; following the [PushCandidateTest]
+ * precedent we pin intended semantics with inline copies of the `when` body. If
+ * the production switch ever drifts from these tests, both must change in
+ * lockstep (the per-provider rules are a cross-platform invariant — desktop
+ * relies on the same dispatch).
+ *
+ * Phase 4 of the LB sync workstream (tasks 14-15) added a `listenbrainz` branch
+ * to each: keyed on `PlaylistTrack.trackRecordingMbid` since LB playlists are
+ * tracklists of MBIDs.
+ */
+class SyncEngineTrackIdHelpersTest {
+
+    private fun track(
+        spotifyUri: String? = null,
+        appleMusicId: String? = null,
+        recordingMbid: String? = null,
+    ): PlaylistTrack = PlaylistTrack(
+        playlistId = "p",
+        position = 0,
+        trackTitle = "Song",
+        trackArtist = "Artist",
+        trackSpotifyUri = spotifyUri,
+        trackAppleMusicId = appleMusicId,
+        trackRecordingMbid = recordingMbid,
+    )
+
+    /** Inline copy of [SyncEngine.extractExternalTrackIds]. */
+    private fun extractExternalTrackIds(
+        tracks: List<PlaylistTrack>,
+        providerId: String,
+    ): List<String> = when (providerId) {
+        "spotify" -> tracks.mapNotNull { it.trackSpotifyUri }
+        "applemusic" -> tracks.mapNotNull { it.trackAppleMusicId }
+        "listenbrainz" -> tracks.mapNotNull { it.trackRecordingMbid }
+        else -> emptyList()
+    }
+
+    /** Inline copy of [SyncEngine.missingProviderId]. */
+    private fun missingProviderId(track: PlaylistTrack, providerId: String): Boolean = when (providerId) {
+        "spotify" -> track.trackSpotifyUri.isNullOrBlank()
+        "applemusic" -> track.trackAppleMusicId.isNullOrBlank()
+        "listenbrainz" -> track.trackRecordingMbid.isNullOrBlank()
+        else -> true
+    }
+
+    /** Inline copy of [SyncEngine.applyResolvedId]. */
+    private fun applyResolvedId(
+        track: PlaylistTrack,
+        providerId: String,
+        resolvedId: String,
+    ): PlaylistTrack = when (providerId) {
+        "spotify" -> {
+            val bareId = resolvedId.removePrefix("spotify:track:")
+            track.copy(
+                trackSpotifyUri = resolvedId,
+                trackSpotifyId = bareId.takeIf { it.isNotBlank() } ?: track.trackSpotifyId,
+            )
+        }
+        "applemusic" -> track.copy(trackAppleMusicId = resolvedId)
+        "listenbrainz" -> track.copy(trackRecordingMbid = resolvedId)
+        else -> track
+    }
+
+    // -- extractExternalTrackIds --
+
+    @Test fun `extract Spotify URIs filters tracks without one`() {
+        val tracks = listOf(
+            track(spotifyUri = "spotify:track:A"),
+            track(spotifyUri = null),
+            track(spotifyUri = "spotify:track:B"),
+        )
+        assertEquals(listOf("spotify:track:A", "spotify:track:B"), extractExternalTrackIds(tracks, "spotify"))
+    }
+
+    @Test fun `extract Apple Music IDs filters tracks without one`() {
+        val tracks = listOf(
+            track(appleMusicId = "12345"),
+            track(appleMusicId = null),
+        )
+        assertEquals(listOf("12345"), extractExternalTrackIds(tracks, "applemusic"))
+    }
+
+    @Test fun `extract ListenBrainz MBIDs filters tracks without one`() {
+        val tracks = listOf(
+            track(recordingMbid = "mbid-1"),
+            track(recordingMbid = null),
+            track(recordingMbid = "mbid-2"),
+            track(recordingMbid = ""), // blank still kept by mapNotNull (only null skipped)
+        )
+        // mapNotNull skips only nulls — empty string passes through. Production
+        // helper documents "tracks without the relevant ID are silently
+        // skipped" which means null-only; downstream LB API will reject empty
+        // string. Hydration step is responsible for filling these in.
+        assertEquals(listOf("mbid-1", "mbid-2", ""), extractExternalTrackIds(tracks, "listenbrainz"))
+    }
+
+    @Test fun `extract for unknown provider returns empty`() {
+        assertTrue(extractExternalTrackIds(listOf(track(spotifyUri = "x")), "tidal").isEmpty())
+    }
+
+    // -- missingProviderId --
+
+    @Test fun `missing for Spotify is true when URI is null or blank`() {
+        assertTrue(missingProviderId(track(spotifyUri = null), "spotify"))
+        assertTrue(missingProviderId(track(spotifyUri = ""), "spotify"))
+        assertFalse(missingProviderId(track(spotifyUri = "spotify:track:X"), "spotify"))
+    }
+
+    @Test fun `missing for Apple Music is true when ID is null or blank`() {
+        assertTrue(missingProviderId(track(appleMusicId = null), "applemusic"))
+        assertTrue(missingProviderId(track(appleMusicId = ""), "applemusic"))
+        assertFalse(missingProviderId(track(appleMusicId = "123"), "applemusic"))
+    }
+
+    @Test fun `missing for ListenBrainz is true when MBID is null or blank`() {
+        assertTrue(missingProviderId(track(recordingMbid = null), "listenbrainz"))
+        assertTrue(missingProviderId(track(recordingMbid = ""), "listenbrainz"))
+        assertFalse(missingProviderId(track(recordingMbid = "abc-mbid"), "listenbrainz"))
+    }
+
+    @Test fun `missing for unknown provider always true`() {
+        // Defensive default — an unknown provider's tracks are by definition
+        // missing whatever ID would be required, so hydration would attempt
+        // a search for every track (which then returns nothing). Better than
+        // silently pushing without IDs.
+        assertTrue(missingProviderId(track(spotifyUri = "x", appleMusicId = "y", recordingMbid = "z"), "tidal"))
+    }
+
+    // -- applyResolvedId --
+
+    @Test fun `apply Spotify URI also derives bare ID`() {
+        val t = applyResolvedId(track(), "spotify", "spotify:track:XYZ")
+        assertEquals("spotify:track:XYZ", t.trackSpotifyUri)
+        assertEquals("XYZ", t.trackSpotifyId)
+    }
+
+    @Test fun `apply Apple Music ID writes only that field`() {
+        val t = applyResolvedId(track(), "applemusic", "999")
+        assertEquals("999", t.trackAppleMusicId)
+        assertEquals(null, t.trackSpotifyUri)
+        assertEquals(null, t.trackRecordingMbid)
+    }
+
+    @Test fun `apply ListenBrainz MBID writes recording MBID only`() {
+        val t = applyResolvedId(track(), "listenbrainz", "abc-1234")
+        assertEquals("abc-1234", t.trackRecordingMbid)
+        assertEquals(null, t.trackSpotifyUri)
+        assertEquals(null, t.trackAppleMusicId)
+    }
+
+    @Test fun `apply for unknown provider returns track unchanged`() {
+        val original = track(spotifyUri = "spotify:track:A")
+        val result = applyResolvedId(original, "tidal", "ignored")
+        assertEquals(original, result)
+    }
+}

--- a/app/src/test/java/com/parachord/shared/sync/SyncProviderShapeTest.kt
+++ b/app/src/test/java/com/parachord/shared/sync/SyncProviderShapeTest.kt
@@ -1,6 +1,9 @@
 package com.parachord.shared.sync
 
+import io.mockk.mockk
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
 import org.junit.Test
 
 /**
@@ -56,5 +59,21 @@ class SyncProviderShapeTest {
         assertEquals("abc", withSnapshot.externalId)
         assertEquals("snap-1", withSnapshot.snapshotId)
         assertEquals(null, withoutSnapshot.snapshotId)
+    }
+
+    @Test
+    fun `LB features struct matches design`() {
+        val provider = ListenBrainzSyncProvider(
+            client = mockk(),
+            settingsStore = mockk(),
+            mbidEnrichmentService = mockk(),
+        )
+        assertEquals(ListenBrainzSyncProvider.PROVIDER_ID, provider.id)
+        assertEquals("ListenBrainz", provider.displayName)
+        assertEquals(SnapshotKind.DateString, provider.features.snapshots)
+        assertFalse(provider.features.supportsFollow)
+        assertTrue(provider.features.supportsPlaylistDelete)
+        assertTrue(provider.features.supportsPlaylistRename)
+        assertTrue(provider.features.supportsTrackReplace)
     }
 }

--- a/docs/plans/2026-05-27-listenbrainz-sync-provider-design.md
+++ b/docs/plans/2026-05-27-listenbrainz-sync-provider-design.md
@@ -1,0 +1,185 @@
+# ListenBrainzSyncProvider — design
+
+Date: 2026-05-27
+Closes (eventually): #156. Unblocks #145 (Achordion playlist-links submit).
+
+## Scope
+
+A third `SyncProvider` implementation — alongside `SpotifySyncProvider` and `AppleMusicSyncProvider` — that two-way-syncs **playlists** between Parachord and ListenBrainz. Loved tracks stay on the existing `LovesPushService` path (no migration). Artist follow + album collection are deferred (V2).
+
+## Architecture
+
+### Schema change
+
+LB keys playlists by MBID and tracks-within-playlist by `recording_mbid`. `PlaylistTrack` today stores `trackSpotifyId` / `trackAppleMusicId` / `trackSoundcloudId` but not `trackRecordingMbid`. Same pattern as the previous provider additions: add a new column, ALTER TABLE wrapped in try/catch in the SQLDelight bind path (precedent: `SyncPlaylistLink.sq`'s in-bind CREATE).
+
+| Change | File |
+|---|---|
+| Add `trackRecordingMbid TEXT` column | `shared/src/commonMain/sqldelight/com/parachord/shared/db/PlaylistTrack.sq` |
+| ALTER TABLE wrapped in try/catch | `app/.../di/AndroidModule.kt` bindDatabase block |
+| `trackRecordingMbid` field on the model | `shared/.../model/PlaylistTrack.kt` |
+| Read/write in DAO | `shared/.../db/dao/PlaylistTrackDao.kt` |
+
+Backfill: organic via the existing `MbidEnrichmentService`. Tracks that lack `trackRecordingMbid` at push time fall through to `searchForTrackId`, which delegates to `MbidEnrichmentService.mapperLookup` and persists the result back via `applyResolvedId`.
+
+### ListenBrainzClient mutations
+
+Today read-only for playlists. Add five mutation endpoints + one read:
+
+```kotlin
+suspend fun createPlaylist(name, description?, isPublic = true, token): String  // returns playlist_mbid
+suspend fun editPlaylist(playlistMbid, name?, description?, token)
+suspend fun addPlaylistItems(playlistMbid, recordingMbids, token)
+suspend fun deletePlaylistItems(playlistMbid, index, count, token)  // for full-replace
+suspend fun deletePlaylist(playlistMbid, token)
+suspend fun getUserOwnedPlaylists(username): List<LbPlaylist>  // augments existing getCreatedForPlaylists
+```
+
+Auth: `Authorization: Token <user_token>` from `SettingsStore.getListenBrainzToken()`. Mutations wrap `executeWithRetry` for rate-limit handling. New exception `ListenBrainzUnauthorizedException` (mirrors `AppleMusicReauthRequiredException`) thrown on 401.
+
+### ListenBrainzSyncProvider impl
+
+New file: `shared/.../sync/ListenBrainzSyncProvider.kt`. Mirrors `AppleMusicSyncProvider`'s shape (session-scoped `authFailedForSession` kill-switch, graceful no-op handling).
+
+```kotlin
+override val features = ProviderFeatures(
+    snapshots = SnapshotKind.DateString,         // LB returns last_modified_at ISO
+    supportsFollow = false,                       // V2
+    supportsPlaylistDelete = true,                // DELETE /1/playlist/{mbid}
+    supportsPlaylistRename = true,                // POST /1/playlist/edit/{mbid}
+    supportsTrackReplace = true,                  // delete-all + add-all
+)
+```
+
+Key methods:
+- `fetchPlaylists` → `getUserOwnedPlaylists(username)` → map to `SyncedPlaylist`
+- `fetchPlaylistTracks` → existing `getPlaylistTracksRich` → map to `PlaylistTrack`
+- `getPlaylistSnapshotId` → `getPlaylistLastModified(mbid)` (small helper, ISO string)
+- `createPlaylist` → `client.createPlaylist` → `RemoteCreated(mbid, snapshotId=null)` (snapshot re-fetched separately)
+- `replacePlaylistTracks` → get current count → `deletePlaylistItems(mbid, 0, count)` → `addPlaylistItems(mbid, new)` → return new `lastModified`. Not atomic, but the two API calls are usually <100ms apart and the playlist isn't user-facing during sync.
+- `updatePlaylistDetails` → `editPlaylist`
+- `deletePlaylist` → try `client.deletePlaylist` → success / 401 → `Unsupported(401)` (kill-switch trips) / other → `Failed(error)`
+- `searchForTrackId(title, artist, album?)` → `mbidEnrichmentService.mapperLookup(title, artist)?.recordingMbid` — handles the catalog-search hydration path for tracks lacking the MBID column
+
+Library surface (`fetchTracks` / `fetchAlbums` / `fetchArtists` / `save*` / `follow*`) inherits no-op defaults.
+
+### SyncEngine wiring
+
+Three helpers in `SyncEngine.kt` need an LB branch:
+
+```kotlin
+extractExternalTrackIds: tracks.mapNotNull { it.trackRecordingMbid }
+missingProviderId: track.trackRecordingMbid.isNullOrBlank()
+applyResolvedId: track.copy(trackRecordingMbid = resolvedId)
+```
+
+Per-provider push candidate filter `isPushCandidate(playlist, providerId)`:
+- LB: `local-*` + hosted XSPF + `spotify-*` + `applemusic-*` (LB mirrors any source-of-truth)
+
+`healImportedSyncedFromMismatch`: extend the recognized ID-prefix list to include `listenbrainz-*`. One-liner. Restores the cross-platform invariant: a sync corruption on either Desktop or Android self-heals on the other client's next launch.
+
+### DI + settings
+
+Single Koin binding in `sharedModule` + injection into SyncEngine's provider list:
+
+```kotlin
+single { ListenBrainzSyncProvider(client = get(), settingsStore = get(), mbidEnrichmentService = get()) }
+single<SyncEngine> {
+    SyncEngine(
+        providers = listOf(get<SpotifySyncProvider>(), get<AppleMusicSyncProvider>(), get<ListenBrainzSyncProvider>()),
+        ...
+    )
+}
+```
+
+`SettingsStore` — add `"listenbrainz"` to `getEnabledSyncProviders()` allowed values (opt-in default-off). Add `getListenBrainzUsername()` if not present.
+
+Settings UI — `Settings → General` shows a "ListenBrainz Sync" toggle row when LB is authorized (token validated). Note: *"Pushes Parachord-curated playlists to your ListenBrainz profile. Loved tracks already sync separately via scrobblers."*
+
+## Multi-client convergence (Desktop ↔ LB ↔ Android)
+
+The existing multi-provider sync engine is provider-agnostic — adding LB as a third provider inherits the convergence guarantees of Spotify/AM, **provided** it plugs into the same three-layer dedup pipeline.
+
+**Local ID convention**:
+- `listenbrainz-<mbid>` for playlists pulled FROM LB
+- `local-<uuid>` for playlists created in Parachord (id stays `local-*` even after pushing to LB and getting assigned an MBID — the MBID lives in `sync_playlist_link["listenbrainz"].externalId`, not in the row's id)
+
+**Three-layer dedup runs on every pull**:
+1. `sync_playlist_link[localId]["listenbrainz"]` match → reuse local row
+2. Defensive name-match (case-insensitive, owned-only) → reuse
+3. Else create new `listenbrainz-<mbid>` row
+
+Catches the "user creates same-name playlist on Desktop AND Android while offline" case — second client to sync finds a name match and links to the existing remote rather than duplicating.
+
+**Cross-provider preservation**. A Spotify-imported playlist (`sync_source.providerId = "spotify"`) that also has LB sync enabled mirrors to both providers. The `isCrossProviderPushMirror` guard handles this with no LB-specific changes; LB-only entry in `sync_playlist_link`.
+
+**Heal extension** — `healImportedSyncedFromMismatch`'s ID-prefix list extends to `listenbrainz-*`. One-liner.
+
+**Snapshot churn.** LB updates `last_modified_at` on every mutation. Worst case: extra pull cycle. Three-layer dedup makes the worst case "extra pull", never "duplicate row".
+
+**Token-failure isolation.** Per-provider `authFailedForSession` kill-switch trips on 401; LB pushes skip for the session while Spotify/AM continue. UI surfaces a re-auth banner on next foreground.
+
+**Convergence smoke test** (manual, post-merge):
+1. Desktop: create "Cross-Sync Test" with 5 tracks. Push to LB.
+2. Android: sync. Expect `listenbrainz-<mbid>` local row with same name + 5 tracks.
+3. Android: add 2 tracks → push to LB.
+4. Desktop: re-sync. Expect 7 tracks.
+5. Desktop: rename → push.
+6. Android: re-sync. Expect rename to propagate (no duplicate).
+7. Android: delete.
+8. Desktop: re-sync. Expect playlist removed from local.
+
+## Tests
+
+`app/src/test/.../sync/ListenBrainzSyncProviderTest.kt` (Robolectric, mockk):
+
+| Test | What it pins |
+|---|---|
+| `fetchPlaylists returns empty when token unset` | Auth gate |
+| `fetchPlaylists swallows 401 by tripping auth-failed kill-switch` | Mirrors AM's pattern |
+| `createPlaylist returns server-assigned MBID` | Round-trip with mock client |
+| `replacePlaylistTracks does delete-all + add-all` | Verify two-step replace |
+| `replacePlaylistTracks no-ops when current and desired both empty` | Skip wasted API calls |
+| `deletePlaylist 401 → DeleteResult.Unsupported (not thrown)` | `SyncProvider` contract |
+| `searchForTrackId returns null for low-confidence mapper hits` | Confidence floor per interface contract |
+| `features struct matches LB's capability surface` | Locks `supportsTrackReplace=true` etc. |
+
+Plus 2 `SyncEngine` tests for the LB branches of `extractExternalTrackIds` / `applyResolvedId`.
+
+## Risks
+
+- **Mapper rate-limit on first sync of a large library.** Even with cache, the first push of a 200-track playlist could hit the mapper 200 times. LB mapper has lax rate limits but worth flagging.
+- **LB API stability.** LB playlists are community-supported; not as battle-tested as Spotify/AM. Expect occasional 5xx; degrade gracefully via try-catch in mutations.
+- **Snapshot pacing.** `last_modified_at` updates on every mutation. Three-layer dedup absorbs the noise.
+- **The `playlist_tracks` ALTER TABLE** runs in `bindDatabase` wrapped in try/catch. Existing installs pick up the new column on app start. New installs get it from the SQLDelight schema.
+
+## Out of scope (V2 candidates)
+
+- Track loves push (already in `LovesPushService`)
+- Artist follow (`POST /1/user/{name}/follow`)
+- LB-imported-playlist support in `PlaylistImportManager` for `jspf://` URLs
+- "Promote local playlist to LB" wizard UX
+
+## File changes
+
+- `shared/src/commonMain/sqldelight/com/parachord/shared/db/PlaylistTrack.sq` — add column
+- `app/.../di/AndroidModule.kt` — ALTER TABLE in bindDatabase + new Koin binding + SyncEngine providers list
+- `shared/.../model/PlaylistTrack.kt` — `trackRecordingMbid` field
+- `shared/.../db/dao/PlaylistTrackDao.kt` — read/write column
+- `shared/.../api/ListenBrainzClient.kt` — 5 mutation methods + `getUserOwnedPlaylists` + new exception
+- `shared/.../sync/ListenBrainzSyncProvider.kt` (new) — provider impl
+- `shared/.../sync/SyncEngine.kt` — LB branches in 3 helpers, push-candidate filter, heal extension
+- `shared/.../settings/SettingsStore.kt` — `listenbrainz` in enabled-providers + `getListenBrainzUsername`
+- `app/.../ui/screens/settings/SettingsScreen.kt` — "ListenBrainz Sync" toggle row
+- `app/src/test/.../sync/ListenBrainzSyncProviderTest.kt` (new)
+
+## Acceptance
+
+- [ ] `./gradlew :shared:testDebugUnitTest :app:testDebugUnitTest` green
+- [ ] Settings → General shows "ListenBrainz Sync" toggle when LB is authorized
+- [ ] Toggle on → next sync pushes local playlists to LB → playlists appear in user's LB profile
+- [ ] Rename local playlist → propagates to LB
+- [ ] Add/remove tracks locally → reflects on LB
+- [ ] Delete local playlist → removed from LB
+- [ ] No regression: Spotify + Apple Music sync paths still work
+- [ ] Convergence smoke test (8 steps above) passes on Desktop ↔ LB ↔ Android

--- a/docs/plans/2026-05-27-listenbrainz-sync-provider.md
+++ b/docs/plans/2026-05-27-listenbrainz-sync-provider.md
@@ -1,0 +1,866 @@
+# ListenBrainzSyncProvider Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Add a third `SyncProvider` implementation that two-way-syncs playlists between Parachord (Android) and ListenBrainz. Closes #156. Unblocks #145.
+
+**Architecture:** Mirrors the existing `SpotifySyncProvider` / `AppleMusicSyncProvider` shape — provider-agnostic `SyncEngine` dispatches on `ProviderFeatures`, never on `id`. New `trackRecordingMbid` column on `playlist_tracks` carries the LB-side track identity. AM-style session kill-switch handles 401s gracefully. Three-layer dedup (link table → name match → create) gives multi-client convergence (Desktop ↔ LB ↔ Android) for free.
+
+**Tech Stack:** Kotlin + SQLDelight + Ktor (LB client) + Koin DI. Tests: JUnit + Robolectric + mockk.
+
+**Design reference:** `docs/plans/2026-05-27-listenbrainz-sync-provider-design.md`.
+
+---
+
+## Phase 1 — Schema + Model
+
+### Task 1: Add `trackRecordingMbid` column to PlaylistTrack.sq
+
+**Files:**
+- Modify: `shared/src/commonMain/sqldelight/com/parachord/shared/db/PlaylistTrack.sq`
+
+**Step 1: Update CREATE TABLE + INSERT + backfill query**
+
+Add `trackRecordingMbid TEXT` column after `trackAppleMusicId`:
+
+```sql
+CREATE TABLE IF NOT EXISTS playlist_tracks (
+    playlistId TEXT NOT NULL,
+    position INTEGER NOT NULL,
+    -- ... existing columns ...
+    trackAppleMusicId TEXT,
+    trackRecordingMbid TEXT,   -- NEW
+    addedAt INTEGER NOT NULL DEFAULT 0,
+    PRIMARY KEY (playlistId, position),
+    FOREIGN KEY (playlistId) REFERENCES playlists(id) ON DELETE CASCADE
+);
+```
+
+Update `insert:` query to include the new column (14 → 15 placeholders):
+
+```sql
+insert:
+INSERT OR REPLACE INTO playlist_tracks (playlistId, position, trackTitle, trackArtist, trackAlbum, trackDuration, trackArtworkUrl, trackSourceUrl, trackResolver, trackSpotifyUri, trackSoundcloudId, trackSpotifyId, trackAppleMusicId, trackRecordingMbid, addedAt)
+VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?);
+```
+
+Extend `backfillResolverIds:` to include the MBID:
+
+```sql
+backfillResolverIds:
+UPDATE playlist_tracks
+SET trackSpotifyId       = COALESCE(trackSpotifyId, ?),
+    trackSpotifyUri      = COALESCE(trackSpotifyUri, ?),
+    trackAppleMusicId    = COALESCE(trackAppleMusicId, ?),
+    trackSoundcloudId    = COALESCE(trackSoundcloudId, ?),
+    trackRecordingMbid   = COALESCE(trackRecordingMbid, ?)
+WHERE playlistId = ? AND position = ?;
+```
+
+**Step 2: Verify SQLDelight regenerates**
+
+```bash
+./gradlew :shared:generateCommonMainParachordDbInterface
+```
+
+Expected: BUILD SUCCESSFUL. The generated Kotlin code at `shared/build/generated/sqldelight/code/parachord/commonMain/com/parachord/shared/db/Playlist_tracks.kt` should now have a `trackRecordingMbid: String?` field.
+
+**Step 3: Commit**
+
+```bash
+git add shared/src/commonMain/sqldelight/com/parachord/shared/db/PlaylistTrack.sq
+git commit -m "schema: add trackRecordingMbid column to playlist_tracks"
+```
+
+---
+
+### Task 2: Add `trackRecordingMbid` to the PlaylistTrack model
+
+**Files:**
+- Modify: `shared/src/commonMain/kotlin/com/parachord/shared/model/PlaylistTrack.kt`
+
+**Step 1: Add field to data class**
+
+After `trackAppleMusicId`, add `val trackRecordingMbid: String? = null,`. Default null so all existing callsites stay compiled.
+
+Also update `availableResolvers` if there's a "musicbrainz" / "listenbrainz" inclusion needed — likely no change, since `availableResolvers` is for content resolvers, not metadata providers.
+
+**Step 2: Compile**
+
+```bash
+./gradlew :shared:compileDebugKotlinAndroid :shared:compileKotlinIosArm64
+```
+
+Expected: BUILD SUCCESSFUL. iOS target included to catch any KMP-stdlib issue early.
+
+**Step 3: Commit**
+
+```bash
+git add shared/src/commonMain/kotlin/com/parachord/shared/model/PlaylistTrack.kt
+git commit -m "model: add trackRecordingMbid field to PlaylistTrack"
+```
+
+---
+
+### Task 3: Update PlaylistTrackDao to read/write the new column
+
+**Files:**
+- Modify: `shared/src/commonMain/kotlin/com/parachord/shared/db/dao/PlaylistTrackDao.kt`
+
+**Step 1: Find existing constructors / mappers**
+
+Grep for the SQL-row → `PlaylistTrack` mapper and the `insert` callsite:
+
+```bash
+grep -n "trackAppleMusicId" shared/src/commonMain/kotlin/com/parachord/shared/db/dao/PlaylistTrackDao.kt
+```
+
+**Step 2: Add `trackRecordingMbid` to the row mapper and insert callsite**
+
+In `Playlist_tracks.toPlaylistTrack()` (around line 23), add the field. In every `db.playlistTrackQueries.insert(...)` call site, pass `pt.trackRecordingMbid`. In `backfillResolverIds` if it's wrapped in Kotlin, add the parameter.
+
+**Step 3: Compile + verify generated DAO code matches**
+
+```bash
+./gradlew :shared:compileDebugKotlinAndroid
+```
+
+Expected: BUILD SUCCESSFUL.
+
+**Step 4: Commit**
+
+```bash
+git add shared/src/commonMain/kotlin/com/parachord/shared/db/dao/PlaylistTrackDao.kt
+git commit -m "dao: read/write trackRecordingMbid column"
+```
+
+---
+
+### Task 4: Add ALTER TABLE migration in AndroidModule
+
+**Files:**
+- Modify: `app/src/main/java/com/parachord/android/di/AndroidModule.kt`
+
+**Step 1: Find the existing in-bind ALTER TABLE block**
+
+Grep for the playlists sourceUrl migration or sync_playlist_link CREATE in the database bind path:
+
+```bash
+grep -n "ALTER TABLE\|CREATE TABLE IF NOT EXISTS" app/src/main/java/com/parachord/android/di/AndroidModule.kt | head -10
+```
+
+**Step 2: Add ALTER TABLE statement wrapped in try/catch**
+
+In the same block, after the existing migrations:
+
+```kotlin
+// Migration: add trackRecordingMbid to playlist_tracks (V13).
+// Wrapped in try/catch — duplicate-column on second launch is the only
+// expected failure, and it's safe to swallow. New installs get the
+// column from PlaylistTrack.sq's CREATE TABLE.
+try {
+    driver.execute(
+        identifier = null,
+        sql = "ALTER TABLE playlist_tracks ADD COLUMN trackRecordingMbid TEXT",
+        parameters = 0,
+    )
+} catch (_: Exception) {
+    // Column already exists — migration already ran.
+}
+```
+
+**Step 3: Compile + install + verify on device**
+
+```bash
+./gradlew installDebug
+adb shell am force-stop com.parachord.android.debug
+```
+
+Then launch Parachord on the device — no crash on startup, no log of "no such column: trackRecordingMbid".
+
+**Step 4: Commit**
+
+```bash
+git add app/src/main/java/com/parachord/android/di/AndroidModule.kt
+git commit -m "db: ALTER TABLE playlist_tracks ADD COLUMN trackRecordingMbid"
+```
+
+---
+
+## Phase 2 — ListenBrainz client mutations
+
+### Task 5: Add `ListenBrainzUnauthorizedException`
+
+**Files:**
+- Create: `shared/src/commonMain/kotlin/com/parachord/shared/sync/ListenBrainzUnauthorizedException.kt`
+
+**Step 1: Write the file**
+
+```kotlin
+package com.parachord.shared.sync
+
+/**
+ * Thrown by [com.parachord.shared.api.ListenBrainzClient] mutation
+ * endpoints when LB returns 401. [ListenBrainzSyncProvider] catches
+ * this and trips its session-scoped auth-failed kill-switch, mirroring
+ * [AppleMusicReauthRequiredException]'s contract.
+ */
+class ListenBrainzUnauthorizedException(message: String = "ListenBrainz returned 401 — token rejected") : Exception(message)
+```
+
+**Step 2: Compile**
+
+```bash
+./gradlew :shared:compileDebugKotlinAndroid
+```
+
+**Step 3: Commit**
+
+```bash
+git add shared/src/commonMain/kotlin/com/parachord/shared/sync/ListenBrainzUnauthorizedException.kt
+git commit -m "sync: add ListenBrainzUnauthorizedException"
+```
+
+---
+
+### Task 6: Add `createPlaylist` + `editPlaylist` + `deletePlaylist` to ListenBrainzClient
+
+**Files:**
+- Modify: `shared/src/commonMain/kotlin/com/parachord/shared/api/ListenBrainzClient.kt`
+
+**Step 1: Write the failing test first**
+
+Create `app/src/test/java/com/parachord/shared/api/ListenBrainzClientMutationTest.kt`. Use Ktor's `MockEngine` to assert request shape:
+
+```kotlin
+@Test fun `createPlaylist sends correct body + auth header`() = runTest {
+    val engine = MockEngine { request ->
+        assertEquals("https://api.listenbrainz.org/1/playlist/create", request.url.toString())
+        assertEquals("Token test-token", request.headers["Authorization"])
+        // ... assert body JSON shape ...
+        respond("""{"playlist_mbid":"12345678-1234-1234-1234-123456789012"}""", HttpStatusCode.OK)
+    }
+    val client = ListenBrainzClient(makeHttpClient(engine))
+    val mbid = client.createPlaylist("Test", description = "Desc", isPublic = true, token = "test-token")
+    assertEquals("12345678-1234-1234-1234-123456789012", mbid)
+}
+
+@Test fun `createPlaylist throws ListenBrainzUnauthorizedException on 401`() = runTest {
+    val engine = MockEngine { respond("", HttpStatusCode.Unauthorized) }
+    val client = ListenBrainzClient(makeHttpClient(engine))
+    assertFailsWith<ListenBrainzUnauthorizedException> {
+        client.createPlaylist("Test", token = "bad")
+    }
+}
+```
+
+Run: `./gradlew :app:testDebugUnitTest --tests "com.parachord.shared.api.ListenBrainzClientMutationTest.*"` — expect FAIL (methods don't exist).
+
+**Step 2: Implement the three mutation methods**
+
+In `ListenBrainzClient.kt`, after `mbidMapperLookup`:
+
+```kotlin
+/** POST /1/playlist/create — returns the assigned playlist MBID. */
+suspend fun createPlaylist(
+    name: String,
+    description: String? = null,
+    isPublic: Boolean = true,
+    token: String,
+): String = executeWithRetry {
+    val response = http.post("$BASE/1/playlist/create") {
+        header(HttpHeaders.Authorization, "Token $token")
+        contentType(ContentType.Application.Json)
+        setBody(buildJsonObject {
+            put("playlist", buildJsonObject {
+                put("title", name)
+                description?.let { put("annotation", it) }
+                put("extension", buildJsonObject {
+                    put("https://musicbrainz.org/doc/jspf#playlist", buildJsonObject {
+                        put("public", isPublic)
+                    })
+                })
+            })
+        }.toString())
+    }
+    if (response.status == HttpStatusCode.Unauthorized) {
+        throw ListenBrainzUnauthorizedException()
+    }
+    val body = response.body<JsonObject>()
+    body["playlist_mbid"]?.jsonPrimitive?.content
+        ?: throw IllegalStateException("LB create-playlist response missing playlist_mbid")
+}
+
+/** POST /1/playlist/edit/{mbid}. */
+suspend fun editPlaylist(playlistMbid: String, name: String?, description: String?, token: String) {
+    // ...
+}
+
+/** DELETE /1/playlist/{mbid}. */
+suspend fun deletePlaylist(playlistMbid: String, token: String) {
+    // ...
+}
+```
+
+(Exact body shape per https://listenbrainz.readthedocs.io/en/latest/users/api/playlist.html)
+
+**Step 3: Run tests, expect PASS**
+
+```bash
+./gradlew :app:testDebugUnitTest --tests "com.parachord.shared.api.ListenBrainzClientMutationTest.*"
+```
+
+**Step 4: Commit**
+
+```bash
+git add shared/src/commonMain/kotlin/com/parachord/shared/api/ListenBrainzClient.kt app/src/test/java/com/parachord/shared/api/ListenBrainzClientMutationTest.kt
+git commit -m "client: add LB playlist create/edit/delete mutations"
+```
+
+---
+
+### Task 7: Add `addPlaylistItems` + `deletePlaylistItems` + `getPlaylistLastModified`
+
+**Files:**
+- Modify: `shared/.../api/ListenBrainzClient.kt`
+- Modify: `app/src/test/java/com/parachord/shared/api/ListenBrainzClientMutationTest.kt`
+
+**Step 1: Write failing tests for the three methods**
+
+Same pattern as Task 6 — MockEngine asserting request URL + body + auth header + 401 handling.
+
+For `addPlaylistItems`:
+- URL: `POST /1/playlist/{mbid}/item/add`
+- Body: `{"playlist": {"track": [{"identifier": "https://musicbrainz.org/recording/<mbid1>"}, ...]}}`
+
+For `deletePlaylistItems`:
+- URL: `POST /1/playlist/{mbid}/item/delete`
+- Body: `{"index": 0, "count": N}`
+
+For `getPlaylistLastModified`:
+- URL: `GET /1/playlist/{mbid}` (existing endpoint, but extract `last_modified_at`)
+- Returns: ISO string or null
+
+Run tests → FAIL.
+
+**Step 2: Implement**
+
+**Step 3: Run tests → PASS**
+
+**Step 4: Commit**
+
+```bash
+git commit -m "client: add LB playlist item add/delete + last-modified getter"
+```
+
+---
+
+### Task 8: Add `getUserOwnedPlaylists` for pull
+
+**Files:**
+- Modify: `shared/.../api/ListenBrainzClient.kt`
+- Modify: test file
+
+**Step 1: Test**
+
+```kotlin
+@Test fun `getUserOwnedPlaylists parses owned playlists list`() = runTest {
+    val engine = MockEngine { request ->
+        assertTrue(request.url.toString().endsWith("/1/user/testuser/playlists"))
+        respond(LB_PLAYLISTS_FIXTURE, HttpStatusCode.OK)
+    }
+    val client = ListenBrainzClient(makeHttpClient(engine))
+    val result = client.getUserOwnedPlaylists("testuser")
+    assertEquals(2, result.size)
+    assertEquals("My Playlist", result[0].title)
+    // ...
+}
+```
+
+**Step 2: Implement** (similar shape to existing `getCreatedForPlaylists`)
+
+**Step 3: Tests pass**
+
+**Step 4: Commit**
+
+```bash
+git commit -m "client: add LB getUserOwnedPlaylists for sync pull"
+```
+
+---
+
+## Phase 3 — ListenBrainzSyncProvider
+
+### Task 9: Stub the provider + features struct + `SyncProviderShapeTest` extension
+
+**Files:**
+- Create: `shared/src/commonMain/kotlin/com/parachord/shared/sync/ListenBrainzSyncProvider.kt`
+- Modify: `app/src/test/java/com/parachord/shared/sync/SyncProviderShapeTest.kt`
+
+**Step 1: Write the stub**
+
+```kotlin
+class ListenBrainzSyncProvider(
+    private val client: ListenBrainzClient,
+    private val settingsStore: SettingsStore,
+    private val mbidEnrichmentService: MbidEnrichmentService,
+) : SyncProvider {
+    companion object { const val PROVIDER_ID = "listenbrainz" }
+
+    override val id = PROVIDER_ID
+    override val displayName = "ListenBrainz"
+    override val features = ProviderFeatures(
+        snapshots = SnapshotKind.DateString,
+        supportsFollow = false,
+        supportsPlaylistDelete = true,
+        supportsPlaylistRename = true,
+        supportsTrackReplace = true,
+    )
+
+    @Volatile private var authFailedForSession = false
+
+    override suspend fun fetchPlaylists(onProgress: ((Int, Int) -> Unit)?) = TODO()
+    override suspend fun fetchPlaylistTracks(externalPlaylistId: String) = TODO()
+    override suspend fun getPlaylistSnapshotId(externalPlaylistId: String) = TODO()
+    override suspend fun createPlaylist(name: String, description: String?) = TODO()
+    override suspend fun replacePlaylistTracks(externalPlaylistId: String, externalTrackIds: List<String>) = TODO()
+    override suspend fun updatePlaylistDetails(externalPlaylistId: String, name: String?, description: String?) = TODO()
+    override suspend fun deletePlaylist(externalPlaylistId: String) = TODO()
+    override suspend fun searchForTrackId(title: String, artist: String, album: String?) = TODO()
+}
+```
+
+**Step 2: Add features struct test**
+
+In `SyncProviderShapeTest.kt`, add a test that pins the `features` struct:
+
+```kotlin
+@Test fun `LB features struct matches design`() {
+    val provider = ListenBrainzSyncProvider(mockk(), mockk(), mockk())
+    assertEquals(SnapshotKind.DateString, provider.features.snapshots)
+    assertFalse(provider.features.supportsFollow)
+    assertTrue(provider.features.supportsPlaylistDelete)
+    assertTrue(provider.features.supportsPlaylistRename)
+    assertTrue(provider.features.supportsTrackReplace)
+}
+```
+
+**Step 3: Compile + test**
+
+```bash
+./gradlew :app:testDebugUnitTest --tests "com.parachord.shared.sync.SyncProviderShapeTest.*"
+```
+
+Expected: PASS.
+
+**Step 4: Commit**
+
+```bash
+git commit -m "sync: stub ListenBrainzSyncProvider + features struct"
+```
+
+---
+
+### Task 10: Implement `fetchPlaylists` (auth gate + kill-switch)
+
+**Files:**
+- Modify: `shared/.../sync/ListenBrainzSyncProvider.kt`
+- Create: `app/src/test/java/com/parachord/android/sync/ListenBrainzSyncProviderTest.kt`
+
+**Step 1: Failing test**
+
+```kotlin
+@Test fun `fetchPlaylists returns empty when token unset`() = runTest {
+    val settings: SettingsStore = mockk { coEvery { getListenBrainzToken() } returns null }
+    val provider = ListenBrainzSyncProvider(mockk(), settings, mockk())
+    assertTrue(provider.fetchPlaylists().isEmpty())
+}
+
+@Test fun `fetchPlaylists swallows 401 and trips kill-switch`() = runTest {
+    val client: ListenBrainzClient = mockk {
+        coEvery { getUserOwnedPlaylists(any()) } throws ListenBrainzUnauthorizedException()
+    }
+    val settings: SettingsStore = mockk {
+        coEvery { getListenBrainzToken() } returns "valid-but-server-rejected"
+        coEvery { getListenBrainzUsername() } returns "test-user"
+    }
+    val provider = ListenBrainzSyncProvider(client, settings, mockk())
+    assertTrue(provider.fetchPlaylists().isEmpty())
+    // After kill-switch trips, second call short-circuits (no client call)
+    assertTrue(provider.fetchPlaylists().isEmpty())
+    coVerify(exactly = 1) { client.getUserOwnedPlaylists(any()) }
+}
+```
+
+**Step 2: Implement** — check kill-switch, check token, call client, catch `ListenBrainzUnauthorizedException` to trip kill-switch and return empty.
+
+**Step 3: Tests pass**
+
+**Step 4: Commit**
+
+```bash
+git commit -m "sync: ListenBrainzSyncProvider fetchPlaylists with kill-switch"
+```
+
+---
+
+### Task 11: Implement `fetchPlaylistTracks` + `getPlaylistSnapshotId`
+
+**Files:**
+- Modify: provider + test
+
+**Step 1: Tests** (similar pattern)
+
+**Step 2: Implement** — `fetchPlaylistTracks` delegates to existing `client.getPlaylistTracksRich`, maps to `PlaylistTrack`. `getPlaylistSnapshotId` calls new `client.getPlaylistLastModified`.
+
+**Step 3: Tests pass**
+
+**Step 4: Commit**
+
+```bash
+git commit -m "sync: LB fetchPlaylistTracks + getPlaylistSnapshotId"
+```
+
+---
+
+### Task 12: Implement `createPlaylist` + `replacePlaylistTracks` + `updatePlaylistDetails`
+
+**Files:**
+- Modify: provider + test
+
+**Step 1: Tests**
+
+```kotlin
+@Test fun `createPlaylist returns RemoteCreated with server-assigned MBID`() = runTest {
+    val client: ListenBrainzClient = mockk {
+        coEvery { createPlaylist(any(), any(), any(), any()) } returns "new-mbid-uuid"
+    }
+    val settings: SettingsStore = mockk { coEvery { getListenBrainzToken() } returns "tok" }
+    val provider = ListenBrainzSyncProvider(client, settings, mockk())
+    val result = provider.createPlaylist("Test", "Desc")
+    assertEquals("new-mbid-uuid", result.externalId)
+    assertNull(result.snapshotId) // re-fetched separately
+}
+
+@Test fun `replacePlaylistTracks does delete-all + add-all`() = runTest {
+    val client: ListenBrainzClient = mockk(relaxed = true) {
+        coEvery { getPlaylistTracksRich("mbid") } returns List(3) { mockk() }
+        coEvery { getPlaylistLastModified("mbid") } returns "2026-05-27T12:00:00Z"
+    }
+    val settings: SettingsStore = mockk { coEvery { getListenBrainzToken() } returns "tok" }
+    val provider = ListenBrainzSyncProvider(client, settings, mockk())
+    val newSnap = provider.replacePlaylistTracks("mbid", listOf("a", "b", "c", "d"))
+    coVerify { client.deletePlaylistItems("mbid", 0, 3, "tok") }
+    coVerify { client.addPlaylistItems("mbid", listOf("a", "b", "c", "d"), "tok") }
+    assertEquals("2026-05-27T12:00:00Z", newSnap)
+}
+
+@Test fun `replacePlaylistTracks skips API calls when both empty`() = runTest {
+    val client: ListenBrainzClient = mockk(relaxed = true) {
+        coEvery { getPlaylistTracksRich("mbid") } returns emptyList()
+    }
+    val settings: SettingsStore = mockk { coEvery { getListenBrainzToken() } returns "tok" }
+    val provider = ListenBrainzSyncProvider(client, settings, mockk())
+    provider.replacePlaylistTracks("mbid", emptyList())
+    coVerify(exactly = 0) { client.deletePlaylistItems(any(), any(), any(), any()) }
+    coVerify(exactly = 0) { client.addPlaylistItems(any(), any(), any()) }
+}
+```
+
+**Step 2: Implement**
+
+**Step 3: Tests pass**
+
+**Step 4: Commit**
+
+```bash
+git commit -m "sync: LB create/replace/updateDetails"
+```
+
+---
+
+### Task 13: Implement `deletePlaylist` + `searchForTrackId`
+
+**Files:**
+- Modify: provider + test
+
+**Step 1: Tests**
+
+```kotlin
+@Test fun `deletePlaylist 401 returns Unsupported (not thrown)`() = runTest {
+    val client: ListenBrainzClient = mockk {
+        coEvery { deletePlaylist(any(), any()) } throws ListenBrainzUnauthorizedException()
+    }
+    val settings: SettingsStore = mockk { coEvery { getListenBrainzToken() } returns "tok" }
+    val provider = ListenBrainzSyncProvider(client, settings, mockk())
+    val result = provider.deletePlaylist("mbid")
+    assertTrue(result is DeleteResult.Unsupported)
+}
+
+@Test fun `searchForTrackId delegates to mapper`() = runTest {
+    val enrichment: MbidEnrichmentService = mockk {
+        coEvery { mapperLookup("Title", "Artist") } returns mockk { every { recordingMbid } returns "mbid-result" }
+    }
+    val settings: SettingsStore = mockk { coEvery { getListenBrainzToken() } returns "tok" }
+    val provider = ListenBrainzSyncProvider(mockk(), settings, enrichment)
+    assertEquals("mbid-result", provider.searchForTrackId("Title", "Artist"))
+}
+
+@Test fun `searchForTrackId returns null when mapper has no match`() = runTest {
+    val enrichment: MbidEnrichmentService = mockk {
+        coEvery { mapperLookup(any(), any()) } returns null
+    }
+    val provider = ListenBrainzSyncProvider(mockk(), mockk(relaxed = true), enrichment)
+    assertNull(provider.searchForTrackId("Title", "Artist"))
+}
+```
+
+**Step 2: Implement**
+
+**Step 3: Tests pass**
+
+**Step 4: Commit**
+
+```bash
+git commit -m "sync: LB deletePlaylist + searchForTrackId"
+```
+
+---
+
+## Phase 4 — SyncEngine wiring
+
+### Task 14: Add LB branches to `extractExternalTrackIds` + `missingProviderId` + `applyResolvedId`
+
+**Files:**
+- Modify: `shared/src/commonMain/kotlin/com/parachord/shared/sync/SyncEngine.kt`
+- Modify: `app/src/test/java/com/parachord/android/sync/SyncEngineTest.kt` (or new test file)
+
+**Step 1: Failing test**
+
+```kotlin
+@Test fun `extractExternalTrackIds for LB returns trackRecordingMbid values`() {
+    // Use reflection or test-only public exposure to call the helper.
+    // ...
+}
+```
+
+**Step 2: Add LB branches** to each of the three helpers per the design.
+
+**Step 3: Tests pass**
+
+**Step 4: Commit**
+
+```bash
+git commit -m "sync: SyncEngine recognizes LB in track-ID helpers"
+```
+
+---
+
+### Task 15: Extend `isPushCandidate` for LB + add to `pushPlaylistsForProvider` dispatch
+
+**Files:**
+- Modify: `SyncEngine.kt`
+- Modify: test file
+
+**Step 1: Failing test** in `PushCandidateTest.kt`:
+
+```kotlin
+@Test fun `LB push candidate includes spotify-prefixed playlists`() {
+    val playlist = Playlist(id = "spotify-abc", ...)
+    assertTrue(SyncEngine.isPushCandidate(playlist, "listenbrainz"))
+}
+```
+
+**Step 2: Implement** — `isPushCandidate(playlist, "listenbrainz") = startsWith("local-") || sourceUrl != null || startsWith("spotify-") || startsWith("applemusic-")`.
+
+**Step 3: Tests pass**
+
+**Step 4: Commit**
+
+```bash
+git commit -m "sync: LB push candidate filter includes provider mirrors"
+```
+
+---
+
+### Task 16: Extend `healImportedSyncedFromMismatch` for `listenbrainz-*` prefix
+
+**Files:**
+- Modify: `SyncEngine.kt`
+- Modify: `app/src/test/java/com/parachord/android/sync/HealImportedSyncedFromTest.kt`
+
+**Step 1: Failing test** — case where a `listenbrainz-mbid-xyz` playlist row has `sync_playlist_source.providerId = "spotify"` (corrupt state); the heal should restore `providerId = "listenbrainz"`.
+
+**Step 2: Implement** — add `"listenbrainz-"` to the prefix list. The implied-provider lookup (`prefix → provider`) extends to LB.
+
+**Step 3: Tests pass**
+
+**Step 4: Commit**
+
+```bash
+git commit -m "sync: healImportedSyncedFromMismatch handles listenbrainz-* prefix"
+```
+
+---
+
+## Phase 5 — DI + Settings + UI
+
+### Task 17: Koin binding for ListenBrainzSyncProvider + inject into SyncEngine providers list
+
+**Files:**
+- Modify: `shared/src/commonMain/kotlin/com/parachord/shared/di/SharedModule.kt` (or wherever `single<SyncEngine>` lives)
+
+**Step 1: Add binding**
+
+```kotlin
+single {
+    ListenBrainzSyncProvider(client = get(), settingsStore = get(), mbidEnrichmentService = get())
+}
+
+single<SyncEngine> {
+    SyncEngine(
+        providers = listOf(
+            get<SpotifySyncProvider>(),
+            get<AppleMusicSyncProvider>(),
+            get<ListenBrainzSyncProvider>(),
+        ),
+        // ...
+    )
+}
+```
+
+**Step 2: Compile + run app**
+
+```bash
+./gradlew :app:compileDebugKotlin installDebug
+adb shell am force-stop com.parachord.android.debug
+```
+
+Launch the app — no Koin missing-binding crash on startup.
+
+**Step 3: Commit**
+
+```bash
+git commit -m "di: register ListenBrainzSyncProvider + add to SyncEngine providers"
+```
+
+---
+
+### Task 18: SettingsStore — `listenbrainz` in enabled-providers + `getListenBrainzUsername`
+
+**Files:**
+- Modify: `shared/src/commonMain/kotlin/com/parachord/shared/settings/SettingsStore.kt`
+
+**Step 1: Tests** (extend existing SettingsStore tests if present, or create minimal ones)
+
+**Step 2: Implement**
+- `getEnabledSyncProviders()` allows `"listenbrainz"` as a valid value
+- Add `getListenBrainzUsername(): String?` reading from existing KvStore key (probably already populated by LB scrobbler auth flow)
+
+**Step 3: Tests pass**
+
+**Step 4: Commit**
+
+```bash
+git commit -m "settings: listenbrainz in enabled-sync-providers + getListenBrainzUsername"
+```
+
+---
+
+### Task 19: Settings UI toggle for LB sync
+
+**Files:**
+- Modify: `app/src/main/java/com/parachord/android/ui/screens/settings/SettingsScreen.kt`
+
+**Step 1: Add toggle row**
+
+In the General settings section, parallel to the "Apple Music Sync" toggle:
+
+```kotlin
+val lbConnected by viewModel.listenBrainzConnected.collectAsStateWithLifecycle()
+val lbSyncEnabled by viewModel.listenBrainzSyncEnabled.collectAsStateWithLifecycle()
+if (lbConnected) {
+    SettingsToggleRow(
+        title = "ListenBrainz Sync",
+        subtitle = "Pushes Parachord-curated playlists to your ListenBrainz profile. Loved tracks already sync separately via scrobblers.",
+        checked = lbSyncEnabled,
+        onCheckedChange = { viewModel.setListenBrainzSyncEnabled(it) },
+    )
+}
+```
+
+**Step 2: ViewModel additions** — `listenBrainzSyncEnabled: StateFlow<Boolean>` reading/writing `getEnabledSyncProviders()`.
+
+**Step 3: Compile + install + verify**
+
+```bash
+./gradlew installDebug
+```
+
+Toggle visible only when LB is authorized. Toggling reflects in `getEnabledSyncProviders()`.
+
+**Step 4: Commit**
+
+```bash
+git commit -m "ui: ListenBrainz Sync toggle in Settings"
+```
+
+---
+
+## Phase 6 — Final verification
+
+### Task 20: Full test suite
+
+**Step 1: Run all tests**
+
+```bash
+./gradlew :app:testDebugUnitTest :shared:testDebugUnitTest
+```
+
+Expected: BUILD SUCCESSFUL, all tests passing including the new LB suite + existing Spotify/AM conformance tests.
+
+**Step 2: If failures, debug and fix.** Don't move on.
+
+**Step 3: Commit any fixes**
+
+---
+
+### Task 21: Install on device + smoke test
+
+**Step 1: Install + force-stop**
+
+```bash
+./gradlew installDebug
+adb shell am force-stop com.parachord.android.debug
+```
+
+**Step 2: Launch app, verify**
+
+- Settings → General → "ListenBrainz Sync" toggle visible (assuming LB is connected)
+- Toggle it on
+- Trigger a sync (Settings → Sync now, OR wait for the next scheduled sync)
+- adb logcat | grep "LB\|ListenBrainz" — verify sync ran, no exceptions
+
+**Step 3: Smoke test the convergence path** (manual, may need to coordinate with desktop):
+
+1. Create a local playlist with 3 tracks on Android
+2. Trigger sync — check on LB website (listenbrainz.org/user/<name>/playlists) that the playlist appeared
+3. On desktop with LB sync enabled, trigger sync — verify the playlist appears locally
+4. Add a track on desktop, sync, verify it appears on Android after the next Android sync
+5. Delete on Android, sync, verify it's gone from LB and desktop's next sync removes it locally
+
+**Step 4: Open PR**
+
+```bash
+git push -u origin feat/listenbrainz-sync-provider-156
+gh pr create --title "feat: ListenBrainzSyncProvider — two-way playlist sync (closes #156)" --body ...
+```
+
+---
+
+## Design / spec references
+- `docs/plans/2026-05-27-listenbrainz-sync-provider-design.md` — full design
+- CLAUDE.md § "Multi-Provider Sync — Apple Music + Spotify (Phases 1–6.5 + Collection)" — convergence model
+- `shared/.../sync/SyncProvider.kt` — interface contract
+- `shared/.../sync/AppleMusicSyncProvider.kt` — reference impl for kill-switch + best-effort patterns
+- LB playlist API: https://listenbrainz.readthedocs.io/en/latest/users/api/playlist.html

--- a/shared/src/commonMain/kotlin/com/parachord/shared/api/ListenBrainzClient.kt
+++ b/shared/src/commonMain/kotlin/com/parachord/shared/api/ListenBrainzClient.kt
@@ -439,6 +439,47 @@ class ListenBrainzClient(private val httpClient: HttpClient) {
         }
     }
 
+    /**
+     * GET /1/user/{userName}/playlists — owned playlists, not the system
+     * `createdfor` playlists already exposed via [getCreatedForPlaylists].
+     *
+     * Returns the user's playlists as a list of [LbPlaylist] entries. Each
+     * entry carries playlist MBID (extracted from the `identifier` URL's
+     * trailing segment) + title + annotation (description) +
+     * last_modified_at (from the JSPF extension).
+     *
+     * Unauth — public playlists are world-readable. The `Token` header is
+     * NOT sent. 404 → empty list (treat as "user has no playlists or does
+     * not exist"); other non-2xx → throws [Exception].
+     */
+    suspend fun getUserOwnedPlaylists(userName: String): List<LbPlaylist> {
+        val response = httpClient.get("$BASE_URL/1/user/$userName/playlists")
+        if (response.status == HttpStatusCode.NotFound) return emptyList()
+        if (!response.status.isSuccess()) {
+            val text = response.bodyAsText().take(200)
+            throw Exception("getUserOwnedPlaylists($userName) failed: HTTP ${response.status.value} $text")
+        }
+        return try {
+            val parsed = json.decodeFromString<CreatedForListWire>(response.bodyAsText())
+            parsed.playlists.mapNotNull { wrapper ->
+                val pl = wrapper.playlist ?: return@mapNotNull null
+                val mbid = pl.identifier?.substringAfterLast("/")?.ifBlank { null }
+                    ?: return@mapNotNull null
+                LbPlaylist(
+                    mbid = mbid,
+                    title = pl.title.orEmpty(),
+                    annotation = pl.annotation.orEmpty(),
+                    lastModifiedAt = pl.lastModifiedAt?.ifBlank { null },
+                )
+            }
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Throwable) {
+            Log.w(TAG, "Failed to parse owned playlists for $userName", e)
+            emptyList()
+        }
+    }
+
     /** Fetch recent listens for a user. */
     suspend fun getRecentListens(
         username: String,
@@ -861,6 +902,21 @@ private data class PlaylistMetaWire(
     val title: String? = null,
     val date: String? = null,
     val annotation: String? = null,
+    val extension: PlaylistMetaExtensionWire? = null,
+) {
+    val lastModifiedAt: String?
+        get() = extension?.jspfPlaylist?.lastModifiedAt
+}
+
+@Serializable
+private data class PlaylistMetaExtensionWire(
+    @SerialName("https://musicbrainz.org/doc/jspf#playlist")
+    val jspfPlaylist: JspfPlaylistMetaWire? = null,
+)
+
+@Serializable
+private data class JspfPlaylistMetaWire(
+    @SerialName("last_modified_at") val lastModifiedAt: String? = null,
 )
 
 @Serializable

--- a/shared/src/commonMain/kotlin/com/parachord/shared/api/ListenBrainzClient.kt
+++ b/shared/src/commonMain/kotlin/com/parachord/shared/api/ListenBrainzClient.kt
@@ -18,7 +18,10 @@ import kotlinx.coroutines.delay
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.buildJsonArray
 import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
 import kotlinx.serialization.json.put
 
 /**
@@ -299,6 +302,140 @@ class ListenBrainzClient(private val httpClient: HttpClient) {
         if (!response.status.isSuccess()) {
             val text = response.bodyAsText().take(200)
             throw Exception("deletePlaylist($playlistMbid) failed: HTTP ${response.status.value} $text")
+        }
+    }
+
+    /**
+     * POST /1/playlist/{playlistMbid}/item/add — append recording MBIDs.
+     *
+     * Per LB JSPF spec, recordings are identified by full MusicBrainz URI
+     * (`https://musicbrainz.org/recording/<mbid>`). Body shape:
+     *
+     *   {"playlist": {"track": [{"identifier": "https://..."}, ...]}}
+     *
+     * No-op (no HTTP request) when [recordingMbids] is empty.
+     *
+     * Wrapped in [executeWithRetry]. Throws [ListenBrainzUnauthorizedException]
+     * on HTTP 401.
+     */
+    suspend fun addPlaylistItems(
+        playlistMbid: String,
+        recordingMbids: List<String>,
+        token: String,
+    ) {
+        if (recordingMbids.isEmpty()) return
+        val body = buildJsonObject {
+            put(
+                "playlist",
+                buildJsonObject {
+                    put(
+                        "track",
+                        buildJsonArray {
+                            for (mbid in recordingMbids) {
+                                add(
+                                    buildJsonObject {
+                                        put("identifier", "https://musicbrainz.org/recording/$mbid")
+                                    },
+                                )
+                            }
+                        },
+                    )
+                },
+            )
+        }
+        val response = executeWithRetry {
+            httpClient.post("$BASE_URL/1/playlist/$playlistMbid/item/add") {
+                header("Authorization", "Token $token")
+                contentType(io.ktor.http.ContentType.Application.Json)
+                setBody(body)
+            }
+        }
+        if (response.status == HttpStatusCode.Unauthorized) {
+            throw ListenBrainzUnauthorizedException(
+                "ListenBrainz returned 401 on addPlaylistItems — token rejected",
+            )
+        }
+        if (!response.status.isSuccess()) {
+            val text = response.bodyAsText().take(200)
+            throw Exception("addPlaylistItems($playlistMbid) failed: HTTP ${response.status.value} $text")
+        }
+    }
+
+    /**
+     * POST /1/playlist/{playlistMbid}/item/delete — remove items by position range.
+     *
+     * `index` is the 0-based starting position; `count` is the number of items
+     * to remove. To full-replace, call this with (0, currentTrackCount) then
+     * [addPlaylistItems] with the new list.
+     *
+     * No-op (no HTTP request) when [count] is `<= 0`.
+     *
+     * Wrapped in [executeWithRetry]. Throws [ListenBrainzUnauthorizedException]
+     * on HTTP 401.
+     */
+    suspend fun deletePlaylistItems(
+        playlistMbid: String,
+        index: Int,
+        count: Int,
+        token: String,
+    ) {
+        if (count <= 0) return
+        val body = buildJsonObject {
+            put("index", index)
+            put("count", count)
+        }
+        val response = executeWithRetry {
+            httpClient.post("$BASE_URL/1/playlist/$playlistMbid/item/delete") {
+                header("Authorization", "Token $token")
+                contentType(io.ktor.http.ContentType.Application.Json)
+                setBody(body)
+            }
+        }
+        if (response.status == HttpStatusCode.Unauthorized) {
+            throw ListenBrainzUnauthorizedException(
+                "ListenBrainz returned 401 on deletePlaylistItems — token rejected",
+            )
+        }
+        if (!response.status.isSuccess()) {
+            val text = response.bodyAsText().take(200)
+            throw Exception("deletePlaylistItems($playlistMbid) failed: HTTP ${response.status.value} $text")
+        }
+    }
+
+    /**
+     * GET /1/playlist/{playlistMbid} — extract only the `last_modified_at`
+     * timestamp from the JSPF extension.
+     *
+     * Used by `ListenBrainzSyncProvider.getPlaylistSnapshotId` to detect
+     * remote changes since the local snapshot. Returns `null` when:
+     *  - The playlist returns 404 (deleted / never existed)
+     *  - The `last_modified_at` field is absent
+     *
+     * Reads `playlist.extension["https://musicbrainz.org/doc/jspf#playlist"]
+     * .last_modified_at` (JSPF extension structure LB uses).
+     *
+     * No auth required — public LB playlists are publicly readable, and the
+     * caller may be checking other users' shared playlists. Non-2xx errors
+     * other than 404 propagate as [Exception].
+     */
+    suspend fun getPlaylistLastModified(playlistMbid: String): String? {
+        val response = httpClient.get("$BASE_URL/1/playlist/$playlistMbid")
+        if (response.status == HttpStatusCode.NotFound) return null
+        if (!response.status.isSuccess()) {
+            val text = response.bodyAsText().take(200)
+            throw Exception("getPlaylistLastModified($playlistMbid) failed: HTTP ${response.status.value} $text")
+        }
+        return try {
+            val root = Json.parseToJsonElement(response.bodyAsText()).jsonObject
+            val playlist = root["playlist"]?.jsonObject ?: return null
+            val ext = playlist["extension"]?.jsonObject ?: return null
+            val jspf = ext["https://musicbrainz.org/doc/jspf#playlist"]?.jsonObject ?: return null
+            jspf["last_modified_at"]?.jsonPrimitive?.content?.ifBlank { null }
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Throwable) {
+            Log.w(TAG, "Failed to parse last_modified_at for $playlistMbid", e)
+            null
         }
     }
 

--- a/shared/src/commonMain/kotlin/com/parachord/shared/api/ListenBrainzClient.kt
+++ b/shared/src/commonMain/kotlin/com/parachord/shared/api/ListenBrainzClient.kt
@@ -450,33 +450,35 @@ class ListenBrainzClient(private val httpClient: HttpClient) {
      *
      * Unauth — public playlists are world-readable. The `Token` header is
      * NOT sent. 404 → empty list (treat as "user has no playlists or does
-     * not exist"); other non-2xx → throws [Exception].
+     * not exist"); other non-2xx → throws [Exception]. Parse failures
+     * propagate as well — the caller ([ListenBrainzSyncProvider.fetchPlaylists])
+     * needs to distinguish "user has no playlists" (empty list) from "LB is
+     * broken right now" (exception) so a malformed response doesn't wipe the
+     * local mirror.
+     *
+     * Wrapped in [executeWithRetry] for 429/503 backoff, matching the other
+     * read paths in this client.
      */
     suspend fun getUserOwnedPlaylists(userName: String): List<LbPlaylist> {
-        val response = httpClient.get("$BASE_URL/1/user/$userName/playlists")
+        val response = executeWithRetry {
+            httpClient.get("$BASE_URL/1/user/$userName/playlists")
+        }
         if (response.status == HttpStatusCode.NotFound) return emptyList()
         if (!response.status.isSuccess()) {
             val text = response.bodyAsText().take(200)
             throw Exception("getUserOwnedPlaylists($userName) failed: HTTP ${response.status.value} $text")
         }
-        return try {
-            val parsed = json.decodeFromString<CreatedForListWire>(response.bodyAsText())
-            parsed.playlists.mapNotNull { wrapper ->
-                val pl = wrapper.playlist ?: return@mapNotNull null
-                val mbid = pl.identifier?.substringAfterLast("/")?.ifBlank { null }
-                    ?: return@mapNotNull null
-                LbPlaylist(
-                    mbid = mbid,
-                    title = pl.title.orEmpty(),
-                    annotation = pl.annotation.orEmpty(),
-                    lastModifiedAt = pl.lastModifiedAt?.ifBlank { null },
-                )
-            }
-        } catch (e: CancellationException) {
-            throw e
-        } catch (e: Throwable) {
-            Log.w(TAG, "Failed to parse owned playlists for $userName", e)
-            emptyList()
+        val parsed = json.decodeFromString<CreatedForListWire>(response.bodyAsText())
+        return parsed.playlists.mapNotNull { wrapper ->
+            val pl = wrapper.playlist ?: return@mapNotNull null
+            val mbid = pl.identifier?.substringAfterLast("/")?.ifBlank { null }
+                ?: return@mapNotNull null
+            LbPlaylist(
+                mbid = mbid,
+                title = pl.title.orEmpty(),
+                annotation = pl.annotation.orEmpty(),
+                lastModifiedAt = pl.lastModifiedAt?.ifBlank { null },
+            )
         }
     }
 

--- a/shared/src/commonMain/kotlin/com/parachord/shared/api/ListenBrainzClient.kt
+++ b/shared/src/commonMain/kotlin/com/parachord/shared/api/ListenBrainzClient.kt
@@ -1,6 +1,7 @@
 package com.parachord.shared.api
 
 import com.parachord.shared.platform.Log
+import com.parachord.shared.sync.ListenBrainzUnauthorizedException
 import io.ktor.client.HttpClient
 import io.ktor.client.request.get
 import io.ktor.client.request.header
@@ -17,6 +18,7 @@ import kotlinx.coroutines.delay
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.buildJsonObject
 import kotlinx.serialization.json.put
 
 /**
@@ -162,6 +164,141 @@ class ListenBrainzClient(private val httpClient: HttpClient) {
         } catch (e: Throwable) {
             Log.w(TAG, "submitRecordingFeedback failed for $recordingMbid: ${e.message}")
             throw e
+        }
+    }
+
+    /**
+     * POST /1/playlist/create — create a new JSPF playlist owned by the
+     * token's user. Returns the assigned playlist MBID.
+     *
+     * Body shape per LB JSPF playlist spec
+     * (https://listenbrainz.readthedocs.io/en/latest/users/api/playlist.html):
+     *
+     *   {"playlist": {
+     *      "title": "...",
+     *      "annotation": "...?",
+     *      "extension": {
+     *        "https://musicbrainz.org/doc/jspf#playlist": { "public": true }
+     *      }
+     *   }}
+     *
+     * Response: `{"playlist_mbid": "<uuid>", "status": "ok"}`.
+     *
+     * Wrapped in [executeWithRetry] for 429/503 backoff, mirroring
+     * [submitRecordingFeedback]. Throws [ListenBrainzUnauthorizedException]
+     * on HTTP 401 so [ListenBrainzSyncProvider] can trip its session-scoped
+     * auth-failed kill-switch (matches AM reauth contract).
+     */
+    suspend fun createPlaylist(
+        name: String,
+        description: String? = null,
+        isPublic: Boolean = true,
+        token: String,
+    ): String {
+        val body = buildJsonObject {
+            put(
+                "playlist",
+                buildJsonObject {
+                    put("title", name)
+                    if (description != null) put("annotation", description)
+                    put(
+                        "extension",
+                        buildJsonObject {
+                            put(
+                                "https://musicbrainz.org/doc/jspf#playlist",
+                                buildJsonObject { put("public", isPublic) },
+                            )
+                        },
+                    )
+                },
+            )
+        }
+        val response = executeWithRetry {
+            httpClient.post("$BASE_URL/1/playlist/create") {
+                header("Authorization", "Token $token")
+                contentType(io.ktor.http.ContentType.Application.Json)
+                setBody(body)
+            }
+        }
+        if (response.status == HttpStatusCode.Unauthorized) {
+            throw ListenBrainzUnauthorizedException(
+                "ListenBrainz returned 401 on createPlaylist — token rejected",
+            )
+        }
+        if (!response.status.isSuccess()) {
+            val text = response.bodyAsText().take(200)
+            throw Exception("createPlaylist failed: HTTP ${response.status.value} $text")
+        }
+        val parsed = json.decodeFromString<CreatePlaylistWire>(response.bodyAsText())
+        return parsed.playlistMbid
+            ?: throw Exception("createPlaylist response missing playlist_mbid")
+    }
+
+    /**
+     * POST /1/playlist/edit/{playlistMbid} — rename + description.
+     *
+     * Best-effort. LB rejects edits to non-owned playlists with 403/404
+     * (caller should treat those as no-op rather than crashing the sync
+     * cycle). Body shape is the same as [createPlaylist] but only includes
+     * fields that are non-null — LB ignores absent fields and leaves them
+     * unchanged.
+     *
+     * Throws [ListenBrainzUnauthorizedException] on HTTP 401.
+     */
+    suspend fun editPlaylist(
+        playlistMbid: String,
+        name: String?,
+        description: String?,
+        token: String,
+    ) {
+        val body = buildJsonObject {
+            put(
+                "playlist",
+                buildJsonObject {
+                    if (name != null) put("title", name)
+                    if (description != null) put("annotation", description)
+                },
+            )
+        }
+        val response = executeWithRetry {
+            httpClient.post("$BASE_URL/1/playlist/edit/$playlistMbid") {
+                header("Authorization", "Token $token")
+                contentType(io.ktor.http.ContentType.Application.Json)
+                setBody(body)
+            }
+        }
+        if (response.status == HttpStatusCode.Unauthorized) {
+            throw ListenBrainzUnauthorizedException(
+                "ListenBrainz returned 401 on editPlaylist — token rejected",
+            )
+        }
+        if (!response.status.isSuccess()) {
+            val text = response.bodyAsText().take(200)
+            throw Exception("editPlaylist($playlistMbid) failed: HTTP ${response.status.value} $text")
+        }
+    }
+
+    /**
+     * POST /1/playlist/{playlistMbid}/delete — soft-deletes from the
+     * user's profile. LB's REST surface uses POST for delete, not the
+     * HTTP DELETE verb. No body required.
+     *
+     * Throws [ListenBrainzUnauthorizedException] on HTTP 401.
+     */
+    suspend fun deletePlaylist(playlistMbid: String, token: String) {
+        val response = executeWithRetry {
+            httpClient.post("$BASE_URL/1/playlist/$playlistMbid/delete") {
+                header("Authorization", "Token $token")
+            }
+        }
+        if (response.status == HttpStatusCode.Unauthorized) {
+            throw ListenBrainzUnauthorizedException(
+                "ListenBrainz returned 401 on deletePlaylist — token rejected",
+            )
+        }
+        if (!response.status.isSuccess()) {
+            val text = response.bodyAsText().take(200)
+            throw Exception("deletePlaylist($playlistMbid) failed: HTTP ${response.status.value} $text")
         }
     }
 
@@ -497,6 +634,12 @@ class ListenBrainzClient(private val httpClient: HttpClient) {
 }
 
 // ── Wire-format models (private, @Serializable) ──────────────────────────────
+
+@Serializable
+private data class CreatePlaylistWire(
+    @SerialName("playlist_mbid") val playlistMbid: String? = null,
+    val status: String? = null,
+)
 
 @Serializable
 private data class ValidateTokenWire(

--- a/shared/src/commonMain/kotlin/com/parachord/shared/api/ListenBrainzModels.kt
+++ b/shared/src/commonMain/kotlin/com/parachord/shared/api/ListenBrainzModels.kt
@@ -50,6 +50,18 @@ data class LbCreatedForPlaylist(
     val annotation: String = "",
 )
 
+/**
+ * A user-owned playlist as returned by `GET /1/user/{userName}/playlists`.
+ * Distinct from [LbCreatedForPlaylist] (the system-generated `createdfor`
+ * playlists like Weekly Jams).
+ */
+data class LbPlaylist(
+    val mbid: String,
+    val title: String,
+    val annotation: String = "",
+    val lastModifiedAt: String? = null,
+)
+
 /** A track from a ListenBrainz playlist with album art info. */
 data class LbPlaylistTrack(
     val id: String,

--- a/shared/src/commonMain/kotlin/com/parachord/shared/db/dao/PlaylistTrackDao.kt
+++ b/shared/src/commonMain/kotlin/com/parachord/shared/db/dao/PlaylistTrackDao.kt
@@ -34,6 +34,7 @@ class PlaylistTrackDao(private val db: ParachordDb) {
         trackSoundcloudId = trackSoundcloudId,
         trackSpotifyId = trackSpotifyId,
         trackAppleMusicId = trackAppleMusicId,
+        trackRecordingMbid = trackRecordingMbid,
         addedAt = addedAt,
     )
 
@@ -72,6 +73,7 @@ class PlaylistTrackDao(private val db: ParachordDb) {
                     trackSoundcloudId = track.trackSoundcloudId,
                     trackSpotifyId = track.trackSpotifyId,
                     trackAppleMusicId = track.trackAppleMusicId,
+                    trackRecordingMbid = track.trackRecordingMbid,
                     addedAt = track.addedAt,
                 )
             }
@@ -114,15 +116,17 @@ class PlaylistTrackDao(private val db: ParachordDb) {
         spotifyUri: String?,
         appleMusicId: String?,
         soundcloudId: String?,
+        recordingMbid: String?,
     ): Unit = withContext(Dispatchers.Default) {
-        // SQLDelight generates positional `value`, `value_`, `value__`, `value___`
-        // for the four COALESCE params; keep the order matching the SQL
-        // (Spotify ID, Spotify URI, Apple Music ID, SoundCloud ID).
+        // SQLDelight generates positional `value`, `value_`, `value__`, `value___`, `value____`
+        // for the five COALESCE params; keep the order matching the SQL
+        // (Spotify ID, Spotify URI, Apple Music ID, SoundCloud ID, Recording MBID).
         queries.backfillResolverIds(
             value = spotifyId,
             value_ = spotifyUri,
             value__ = appleMusicId,
             value___ = soundcloudId,
+            value____ = recordingMbid,
             playlistId = playlistId,
             position = position.toLong(),
         )
@@ -147,6 +151,7 @@ class PlaylistTrackDao(private val db: ParachordDb) {
                     trackSoundcloudId = track.trackSoundcloudId,
                     trackSpotifyId = track.trackSpotifyId,
                     trackAppleMusicId = track.trackAppleMusicId,
+                    trackRecordingMbid = track.trackRecordingMbid,
                     addedAt = track.addedAt,
                 )
             }

--- a/shared/src/commonMain/kotlin/com/parachord/shared/metadata/MbidEnrichmentService.kt
+++ b/shared/src/commonMain/kotlin/com/parachord/shared/metadata/MbidEnrichmentService.kt
@@ -234,7 +234,18 @@ class MbidEnrichmentService(
         }
     }
 
-    private suspend fun mapperLookup(artist: String, recording: String): MbidMapperResult? {
+    /**
+     * Lookup an MBID for the given (artist, recording) pair via the LB mapper.
+     *
+     * Returns null when the mapper has no high-confidence match (its own
+     * internal confidence floor) OR when the lookup throws. Exceptions are
+     * swallowed and logged — callers (including [ListenBrainzSyncProvider.searchForTrackId])
+     * treat null as "no match, skip the track".
+     *
+     * Note arg order: `(artist, recording)` — matches the underlying
+     * `ListenBrainzClient.mbidMapperLookup` signature, NOT `(title, artist)`.
+     */
+    suspend fun mapperLookup(artist: String, recording: String): MbidMapperResult? {
         return try {
             listenBrainzClient.mbidMapperLookup(artist, recording)
         } catch (e: Exception) {

--- a/shared/src/commonMain/kotlin/com/parachord/shared/model/PlaylistTrack.kt
+++ b/shared/src/commonMain/kotlin/com/parachord/shared/model/PlaylistTrack.kt
@@ -14,6 +14,7 @@ data class PlaylistTrack(
     val trackSoundcloudId: String? = null,
     val trackSpotifyId: String? = null,
     val trackAppleMusicId: String? = null,
+    val trackRecordingMbid: String? = null,
     val addedAt: Long = 0L,
 ) {
     fun availableResolvers(resolverOrder: List<String> = emptyList()): List<String> {

--- a/shared/src/commonMain/kotlin/com/parachord/shared/sync/ListenBrainzSyncProvider.kt
+++ b/shared/src/commonMain/kotlin/com/parachord/shared/sync/ListenBrainzSyncProvider.kt
@@ -2,7 +2,9 @@ package com.parachord.shared.sync
 
 import com.parachord.shared.api.ListenBrainzClient
 import com.parachord.shared.metadata.MbidEnrichmentService
+import com.parachord.shared.model.Playlist
 import com.parachord.shared.model.PlaylistTrack
+import com.parachord.shared.platform.currentTimeMillis
 import com.parachord.shared.settings.SettingsStore
 import kotlin.concurrent.Volatile
 
@@ -53,7 +55,64 @@ class ListenBrainzSyncProvider(
 
     override suspend fun fetchPlaylists(
         onProgress: ((current: Int, total: Int) -> Unit)?,
-    ): List<SyncedPlaylist> = TODO("Task 10")
+    ): List<SyncedPlaylist> {
+        // Kill-switch active — short-circuit until session restart so we
+        // don't hammer LB with calls we know will 401 again. Mirrors AM's
+        // `amPutUnsupportedForSession` / `amPatchUnsupportedForSession`
+        // pattern.
+        if (authFailedForSession) return emptyList()
+
+        // Provider not configured — token + username are both required.
+        // Treat unconfigured as "no playlists" (NOT an error) so SyncEngine
+        // can iterate every enabled provider blindly.
+        val token = settingsStore.getListenBrainzToken()
+        if (token.isNullOrBlank()) return emptyList()
+        val username = settingsStore.getListenBrainzUsername()
+        if (username.isNullOrBlank()) return emptyList()
+
+        val lbPlaylists = try {
+            client.getUserOwnedPlaylists(username)
+        } catch (e: ListenBrainzUnauthorizedException) {
+            // Trip the session-scoped kill-switch. Non-401 errors propagate
+            // so SyncEngine can decide whether to surface them to the user.
+            authFailedForSession = true
+            return emptyList()
+        }
+        return lbPlaylists.map { it.toSyncedPlaylist() }
+    }
+
+    private fun com.parachord.shared.api.LbPlaylist.toSyncedPlaylist(): SyncedPlaylist {
+        // SyncedPlaylist's `spotifyId` slot carries the provider's external
+        // id (the field name is Spotify-shaped by historical accident; AM
+        // does the same). The LB playlist MBID lives here.
+        val description = annotation.ifBlank { null }
+        val playlistEntity = Playlist(
+            id = "listenbrainz-$mbid",
+            name = title,
+            description = description,
+            artworkUrl = null,
+            trackCount = 0,
+            createdAt = 0L,
+            updatedAt = currentTimeMillis(),
+            spotifyId = null,
+            snapshotId = lastModifiedAt,
+            lastModified = 0L,
+            locallyModified = false,
+            ownerName = null,
+            sourceUrl = null,
+            sourceContentHash = null,
+            localOnly = false,
+        )
+        return SyncedPlaylist(
+            entity = playlistEntity,
+            spotifyId = mbid,
+            snapshotId = lastModifiedAt,
+            trackCount = 0,
+            // The `/1/user/{userName}/playlists` endpoint returns only the
+            // user's OWN playlists — every entry here is owned + mutable.
+            isOwned = true,
+        )
+    }
 
     override suspend fun fetchPlaylistTracks(
         externalPlaylistId: String,

--- a/shared/src/commonMain/kotlin/com/parachord/shared/sync/ListenBrainzSyncProvider.kt
+++ b/shared/src/commonMain/kotlin/com/parachord/shared/sync/ListenBrainzSyncProvider.kt
@@ -152,18 +152,96 @@ class ListenBrainzSyncProvider(
     override suspend fun createPlaylist(
         name: String,
         description: String?,
-    ): RemoteCreated = TODO("Task 12")
+    ): RemoteCreated {
+        // Mutations require auth — unlike pulls. Throw so SyncEngine knows
+        // the push can't proceed; this is a hard config error (not "no playlists").
+        val token = settingsStore.getListenBrainzToken()
+        if (token.isNullOrBlank()) {
+            throw IllegalStateException("ListenBrainz token not configured")
+        }
+        val mbid = try {
+            client.createPlaylist(name = name, description = description, isPublic = true, token = token)
+        } catch (e: ListenBrainzUnauthorizedException) {
+            Log.w(TAG, "LB createPlaylist 401 — tripping kill-switch", e)
+            authFailedForSession = true
+            throw e // propagate so SyncEngine knows the push failed
+        }
+        // Snapshot is fetched separately via getPlaylistSnapshotId — the create
+        // endpoint returns only the MBID, not a last_modified timestamp.
+        return RemoteCreated(externalId = mbid, snapshotId = null)
+    }
 
     override suspend fun replacePlaylistTracks(
         externalPlaylistId: String,
         externalTrackIds: List<String>,
-    ): String? = TODO("Task 12")
+    ): String? {
+        val token = settingsStore.getListenBrainzToken()
+        if (token.isNullOrBlank()) {
+            throw IllegalStateException("ListenBrainz token not configured")
+        }
+
+        try {
+            // Get current track count to know how many to delete.
+            val currentTracks = client.getPlaylistTracksRich(externalPlaylistId)
+            val currentCount = currentTracks.size
+
+            // Step 1: delete all existing items (if any).
+            // NOTE: this is NOT atomic — between step 1 and step 2 the playlist
+            // appears empty to other LB clients. Acceptable per the design
+            // (mirrors how AM POST-appends after PUT degradation).
+            if (currentCount > 0) {
+                client.deletePlaylistItems(
+                    playlistMbid = externalPlaylistId,
+                    index = 0,
+                    count = currentCount,
+                    token = token,
+                )
+            }
+
+            // Step 2: add desired items (if any).
+            if (externalTrackIds.isNotEmpty()) {
+                client.addPlaylistItems(
+                    playlistMbid = externalPlaylistId,
+                    recordingMbids = externalTrackIds,
+                    token = token,
+                )
+            }
+
+            // Step 3: re-fetch and return the new snapshot.
+            return client.getPlaylistLastModified(externalPlaylistId)
+        } catch (e: ListenBrainzUnauthorizedException) {
+            Log.w(TAG, "LB replacePlaylistTracks 401 — tripping kill-switch", e)
+            authFailedForSession = true
+            throw e
+        }
+    }
 
     override suspend fun updatePlaylistDetails(
         externalPlaylistId: String,
         name: String?,
         description: String?,
-    ): Unit = TODO("Task 12")
+    ) {
+        // No-op when both are null — nothing to update.
+        if (name == null && description == null) return
+
+        val token = settingsStore.getListenBrainzToken()
+        if (token.isNullOrBlank()) {
+            throw IllegalStateException("ListenBrainz token not configured")
+        }
+
+        try {
+            client.editPlaylist(
+                playlistMbid = externalPlaylistId,
+                name = name,
+                description = description,
+                token = token,
+            )
+        } catch (e: ListenBrainzUnauthorizedException) {
+            Log.w(TAG, "LB updatePlaylistDetails 401 — tripping kill-switch", e)
+            authFailedForSession = true
+            throw e
+        }
+    }
 
     override suspend fun deletePlaylist(
         externalPlaylistId: String,

--- a/shared/src/commonMain/kotlin/com/parachord/shared/sync/ListenBrainzSyncProvider.kt
+++ b/shared/src/commonMain/kotlin/com/parachord/shared/sync/ListenBrainzSyncProvider.kt
@@ -1,0 +1,94 @@
+package com.parachord.shared.sync
+
+import com.parachord.shared.api.ListenBrainzClient
+import com.parachord.shared.metadata.MbidEnrichmentService
+import com.parachord.shared.model.PlaylistTrack
+import com.parachord.shared.settings.SettingsStore
+import kotlin.concurrent.Volatile
+
+/**
+ * Two-way playlist sync between Parachord and ListenBrainz.
+ *
+ * Mirrors [AppleMusicSyncProvider]'s shape — session-scoped
+ * `authFailedForSession` kill-switch on 401, graceful no-op handling
+ * for the not-yet-supported surface (tracks / albums / artists fall
+ * back to inherited defaults).
+ *
+ * V1 scope: playlists only (push + pull). Loved tracks stay on
+ * [com.parachord.android.playback.LovesPushService]. Library surface
+ * (saved tracks/albums, followed artists) inherits the no-op
+ * defaults from [SyncProvider].
+ *
+ * See `docs/plans/2026-05-27-listenbrainz-sync-provider-design.md`.
+ */
+class ListenBrainzSyncProvider(
+    private val client: ListenBrainzClient,
+    private val settingsStore: SettingsStore,
+    private val mbidEnrichmentService: MbidEnrichmentService,
+) : SyncProvider {
+    companion object {
+        const val PROVIDER_ID = "listenbrainz"
+    }
+
+    override val id: String = PROVIDER_ID
+    override val displayName: String = "ListenBrainz"
+
+    override val features: ProviderFeatures = ProviderFeatures(
+        snapshots = SnapshotKind.DateString,         // LB returns last_modified_at ISO string
+        supportsFollow = false,                       // V2
+        supportsPlaylistDelete = true,                // POST /1/playlist/{mbid}/delete
+        supportsPlaylistRename = true,                // POST /1/playlist/edit/{mbid}
+        supportsTrackReplace = true,                  // delete-all + add-all
+    )
+
+    /**
+     * Session-scoped kill-switch. Tripped by a 401 from any mutation
+     * endpoint; remaining LB pushes in the session short-circuit until
+     * the user re-authenticates. Mirrors the AM pattern.
+     */
+    @Volatile
+    private var authFailedForSession: Boolean = false
+
+    // ── Playlist surface — all TODO for now, implemented in Tasks 10-13 ─
+
+    override suspend fun fetchPlaylists(
+        onProgress: ((current: Int, total: Int) -> Unit)?,
+    ): List<SyncedPlaylist> = TODO("Task 10")
+
+    override suspend fun fetchPlaylistTracks(
+        externalPlaylistId: String,
+    ): List<PlaylistTrack> = TODO("Task 11")
+
+    override suspend fun getPlaylistSnapshotId(
+        externalPlaylistId: String,
+    ): String? = TODO("Task 11")
+
+    override suspend fun createPlaylist(
+        name: String,
+        description: String?,
+    ): RemoteCreated = TODO("Task 12")
+
+    override suspend fun replacePlaylistTracks(
+        externalPlaylistId: String,
+        externalTrackIds: List<String>,
+    ): String? = TODO("Task 12")
+
+    override suspend fun updatePlaylistDetails(
+        externalPlaylistId: String,
+        name: String?,
+        description: String?,
+    ): Unit = TODO("Task 12")
+
+    override suspend fun deletePlaylist(
+        externalPlaylistId: String,
+    ): DeleteResult = TODO("Task 13")
+
+    override suspend fun searchForTrackId(
+        title: String,
+        artist: String,
+        album: String?,
+    ): String? = TODO("Task 13")
+
+    // Library surface (saveTracks, saveAlbums, fetchArtists, etc.) intentionally
+    // inherits the no-op defaults from SyncProvider.
+}

--- a/shared/src/commonMain/kotlin/com/parachord/shared/sync/ListenBrainzSyncProvider.kt
+++ b/shared/src/commonMain/kotlin/com/parachord/shared/sync/ListenBrainzSyncProvider.kt
@@ -124,11 +124,30 @@ class ListenBrainzSyncProvider(
 
     override suspend fun fetchPlaylistTracks(
         externalPlaylistId: String,
-    ): List<PlaylistTrack> = TODO("Task 11")
+    ): List<PlaylistTrack> {
+        // playlistId follows the `<provider>-<externalId>` convention used by
+        // SpotifySyncProvider + AppleMusicSyncProvider. SyncEngine remaps this
+        // to the local id when persisting; this value is a stable, locally
+        // recognisable placeholder.
+        val localPlaylistId = "listenbrainz-$externalPlaylistId"
+        val richTracks = client.getPlaylistTracksRich(externalPlaylistId)
+        return richTracks.mapIndexed { index, t ->
+            PlaylistTrack(
+                playlistId = localPlaylistId,
+                position = index,
+                trackTitle = t.title,
+                trackArtist = t.artist,
+                trackAlbum = t.album,
+                trackDuration = t.durationMs,
+                trackArtworkUrl = t.albumArt,
+                trackRecordingMbid = t.mbid,
+            )
+        }
+    }
 
     override suspend fun getPlaylistSnapshotId(
         externalPlaylistId: String,
-    ): String? = TODO("Task 11")
+    ): String? = client.getPlaylistLastModified(externalPlaylistId)
 
     override suspend fun createPlaylist(
         name: String,

--- a/shared/src/commonMain/kotlin/com/parachord/shared/sync/ListenBrainzSyncProvider.kt
+++ b/shared/src/commonMain/kotlin/com/parachord/shared/sync/ListenBrainzSyncProvider.kt
@@ -245,13 +245,53 @@ class ListenBrainzSyncProvider(
 
     override suspend fun deletePlaylist(
         externalPlaylistId: String,
-    ): DeleteResult = TODO("Task 13")
+    ): DeleteResult {
+        val token = settingsStore.getListenBrainzToken()
+        if (token.isNullOrBlank()) {
+            return DeleteResult.Failed(IllegalStateException("ListenBrainz token not configured"))
+        }
+        return try {
+            client.deletePlaylist(externalPlaylistId, token)
+            DeleteResult.Success
+        } catch (e: ListenBrainzUnauthorizedException) {
+            // Per the SyncProvider contract, deletePlaylist must NEVER throw on
+            // documented-unsupported responses. For LB the 401 is an auth issue
+            // (not "API doesn't support delete"), but the user can't recover
+            // without re-auth — surface to UI as Unsupported(401) so they get
+            // the "remove manually in {provider}" toast (matches AM pattern).
+            Log.w(TAG, "LB deletePlaylist 401 — tripping kill-switch", e)
+            authFailedForSession = true
+            DeleteResult.Unsupported(401)
+        } catch (e: Throwable) {
+            // Re-throw cancellation per KMP convention — coroutine cancellation
+            // must propagate, never be swallowed.
+            if (e is kotlinx.coroutines.CancellationException) throw e
+            Log.e(TAG, "LB deletePlaylist failed", e)
+            DeleteResult.Failed(e)
+        }
+    }
 
     override suspend fun searchForTrackId(
         title: String,
         artist: String,
         album: String?,
-    ): String? = TODO("Task 13")
+    ): String? {
+        // Delegate to the existing MBID mapper. Returns the canonical
+        // recording MBID for the title+artist pair, or null if no high-
+        // confidence match was found (the LB mapper applies its own internal
+        // confidence floor — we don't need to apply MIN_CONFIDENCE_THRESHOLD
+        // here).
+        //
+        // Note arg order: mapperLookup is (artist, recording) — NOT (title, artist).
+        val result = try {
+            mbidEnrichmentService.mapperLookup(artist, title)
+        } catch (e: Throwable) {
+            if (e is kotlinx.coroutines.CancellationException) throw e
+            Log.w(TAG, "LB searchForTrackId mapper lookup failed for '$title' / '$artist'", e)
+            return null
+        }
+        return result?.recordingMbid
+    }
 
     // Library surface (saveTracks, saveAlbums, fetchArtists, etc.) intentionally
     // inherits the no-op defaults from SyncProvider.

--- a/shared/src/commonMain/kotlin/com/parachord/shared/sync/ListenBrainzSyncProvider.kt
+++ b/shared/src/commonMain/kotlin/com/parachord/shared/sync/ListenBrainzSyncProvider.kt
@@ -4,6 +4,7 @@ import com.parachord.shared.api.ListenBrainzClient
 import com.parachord.shared.metadata.MbidEnrichmentService
 import com.parachord.shared.model.Playlist
 import com.parachord.shared.model.PlaylistTrack
+import com.parachord.shared.platform.Log
 import com.parachord.shared.platform.currentTimeMillis
 import com.parachord.shared.settings.SettingsStore
 import kotlin.concurrent.Volatile
@@ -30,6 +31,7 @@ class ListenBrainzSyncProvider(
 ) : SyncProvider {
     companion object {
         const val PROVIDER_ID = "listenbrainz"
+        private const val TAG = "ListenBrainzSyncProvider"
     }
 
     override val id: String = PROVIDER_ID
@@ -73,8 +75,14 @@ class ListenBrainzSyncProvider(
         val lbPlaylists = try {
             client.getUserOwnedPlaylists(username)
         } catch (e: ListenBrainzUnauthorizedException) {
-            // Trip the session-scoped kill-switch. Non-401 errors propagate
-            // so SyncEngine can decide whether to surface them to the user.
+            // Defensive — getUserOwnedPlaylists is unauth today (LB public playlists
+            // are world-readable), so this catch is mostly for symmetry with the
+            // AM provider and future-proofing in case LB starts requiring auth on
+            // this endpoint. Real 401s today land in the generic-Exception path
+            // below and propagate to SyncEngine. The kill-switch primarily exists
+            // to trip from the *mutation* endpoints (createPlaylist, replacePlaylist
+            // tracks, etc.) which DO send Token and DO translate 401.
+            Log.w(TAG, "LB fetchPlaylists 401 — tripping kill-switch", e)
             authFailedForSession = true
             return emptyList()
         }

--- a/shared/src/commonMain/kotlin/com/parachord/shared/sync/ListenBrainzUnauthorizedException.kt
+++ b/shared/src/commonMain/kotlin/com/parachord/shared/sync/ListenBrainzUnauthorizedException.kt
@@ -1,0 +1,11 @@
+package com.parachord.shared.sync
+
+/**
+ * Thrown by [com.parachord.shared.api.ListenBrainzClient] mutation
+ * endpoints when LB returns 401. [ListenBrainzSyncProvider] catches
+ * this and trips its session-scoped auth-failed kill-switch, mirroring
+ * [AppleMusicReauthRequiredException]'s contract.
+ */
+class ListenBrainzUnauthorizedException(
+    message: String = "ListenBrainz returned 401 — token rejected",
+) : Exception(message)

--- a/shared/src/commonMain/kotlin/com/parachord/shared/sync/SyncEngine.kt
+++ b/shared/src/commonMain/kotlin/com/parachord/shared/sync/SyncEngine.kt
@@ -140,7 +140,8 @@ class SyncEngine constructor(
          *
          * Idempotent. Runs every launch. No-op on healthy data (no log unless N > 0).
          *
-         * For each playlist row whose `id` starts with `spotify-` or `applemusic-`:
+         * For each playlist row whose `id` starts with `spotify-`, `applemusic-`,
+         * or `listenbrainz-`:
          *   1. Derive `impliedProvider` from the prefix and `externalIdFromPrefix`
          *      from the substring after it.
          *   2. Read the current `sync_playlist_source` row.
@@ -171,6 +172,7 @@ class SyncEngine constructor(
             val supportedProviders = listOf(
                 SpotifySyncProvider.PROVIDER_ID,
                 AppleMusicSyncProvider.PROVIDER_ID,
+                ListenBrainzSyncProvider.PROVIDER_ID,
             )
             var healed = 0
             for (playlist in playlistDao.getAllSync()) {
@@ -1905,6 +1907,13 @@ class SyncEngine constructor(
                 playlist.spotifyId == null && baseEligible
             AppleMusicSyncProvider.PROVIDER_ID ->
                 baseEligible || playlist.id.startsWith("spotify-")
+            ListenBrainzSyncProvider.PROVIDER_ID ->
+                // LB mirrors any source-of-truth playlist: local-*, hosted XSPF,
+                // spotify-*, applemusic-*. The runtime `syncedFrom` guard skips
+                // listenbrainz-imported playlists when targeting LB.
+                baseEligible
+                    || playlist.id.startsWith("spotify-")
+                    || playlist.id.startsWith("applemusic-")
             else -> baseEligible
         }
     }
@@ -1921,6 +1930,7 @@ class SyncEngine constructor(
     ): List<String> = when (providerId) {
         SpotifySyncProvider.PROVIDER_ID -> tracks.mapNotNull { it.trackSpotifyUri }
         AppleMusicSyncProvider.PROVIDER_ID -> tracks.mapNotNull { it.trackAppleMusicId }
+        ListenBrainzSyncProvider.PROVIDER_ID -> tracks.mapNotNull { it.trackRecordingMbid }
         else -> emptyList()
     }
 
@@ -1932,6 +1942,7 @@ class SyncEngine constructor(
     private fun missingProviderId(track: PlaylistTrack, providerId: String): Boolean = when (providerId) {
         SpotifySyncProvider.PROVIDER_ID -> track.trackSpotifyUri.isNullOrBlank()
         AppleMusicSyncProvider.PROVIDER_ID -> track.trackAppleMusicId.isNullOrBlank()
+        ListenBrainzSyncProvider.PROVIDER_ID -> track.trackRecordingMbid.isNullOrBlank()
         else -> true
     }
 
@@ -1955,6 +1966,7 @@ class SyncEngine constructor(
             )
         }
         AppleMusicSyncProvider.PROVIDER_ID -> track.copy(trackAppleMusicId = resolvedId)
+        ListenBrainzSyncProvider.PROVIDER_ID -> track.copy(trackRecordingMbid = resolvedId)
         else -> track
     }
 

--- a/shared/src/commonMain/sqldelight/com/parachord/shared/db/PlaylistTrack.sq
+++ b/shared/src/commonMain/sqldelight/com/parachord/shared/db/PlaylistTrack.sq
@@ -12,6 +12,7 @@ CREATE TABLE IF NOT EXISTS playlist_tracks (
     trackSoundcloudId TEXT,
     trackSpotifyId TEXT,
     trackAppleMusicId TEXT,
+    trackRecordingMbid TEXT,
     addedAt INTEGER NOT NULL DEFAULT 0,
     PRIMARY KEY (playlistId, position),
     FOREIGN KEY (playlistId) REFERENCES playlists(id) ON DELETE CASCADE
@@ -26,8 +27,8 @@ getMaxPosition:
 SELECT COALESCE(MAX(position), -1) FROM playlist_tracks WHERE playlistId = ?;
 
 insert:
-INSERT OR REPLACE INTO playlist_tracks (playlistId, position, trackTitle, trackArtist, trackAlbum, trackDuration, trackArtworkUrl, trackSourceUrl, trackResolver, trackSpotifyUri, trackSoundcloudId, trackSpotifyId, trackAppleMusicId, addedAt)
-VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?);
+INSERT OR REPLACE INTO playlist_tracks (playlistId, position, trackTitle, trackArtist, trackAlbum, trackDuration, trackArtworkUrl, trackSourceUrl, trackResolver, trackSpotifyUri, trackSoundcloudId, trackSpotifyId, trackAppleMusicId, trackRecordingMbid, addedAt)
+VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?);
 
 deleteByPlaylistId:
 DELETE FROM playlist_tracks WHERE playlistId = ?;
@@ -47,9 +48,10 @@ WHERE playlistId = ? AND position = ?
 -- fills in slots that were null.
 backfillResolverIds:
 UPDATE playlist_tracks
-SET trackSpotifyId    = COALESCE(trackSpotifyId, ?),
-    trackSpotifyUri   = COALESCE(trackSpotifyUri, ?),
-    trackAppleMusicId = COALESCE(trackAppleMusicId, ?),
-    trackSoundcloudId = COALESCE(trackSoundcloudId, ?)
+SET trackSpotifyId       = COALESCE(trackSpotifyId, ?),
+    trackSpotifyUri      = COALESCE(trackSpotifyUri, ?),
+    trackAppleMusicId    = COALESCE(trackAppleMusicId, ?),
+    trackSoundcloudId    = COALESCE(trackSoundcloudId, ?),
+    trackRecordingMbid   = COALESCE(trackRecordingMbid, ?)
 WHERE playlistId = ? AND position = ?;
 

--- a/shared/src/commonTest/kotlin/com/parachord/shared/api/ListenBrainzClientMutationTest.kt
+++ b/shared/src/commonTest/kotlin/com/parachord/shared/api/ListenBrainzClientMutationTest.kt
@@ -439,4 +439,94 @@ class ListenBrainzClientMutationTest {
         )
         assertNull(result)
     }
+
+    // ── getUserOwnedPlaylists ────────────────────────────────────────────────
+
+    private val LB_PLAYLISTS_FIXTURE = """
+        {
+          "playlist_count": 2,
+          "playlists": [
+            {
+              "playlist": {
+                "identifier": "https://listenbrainz.org/playlist/11111111-1111-1111-1111-111111111111",
+                "title": "My Playlist",
+                "annotation": "Description One",
+                "extension": {
+                  "https://musicbrainz.org/doc/jspf#playlist": {
+                    "last_modified_at": "2026-05-27T10:30:00.000000+00:00",
+                    "public": true,
+                    "creator": "testuser"
+                  }
+                }
+              }
+            },
+            {
+              "playlist": {
+                "identifier": "https://listenbrainz.org/playlist/22222222-2222-2222-2222-222222222222",
+                "title": "Another Playlist",
+                "annotation": "",
+                "extension": {
+                  "https://musicbrainz.org/doc/jspf#playlist": {
+                    "last_modified_at": "2026-05-26T08:15:00.000000+00:00",
+                    "public": true,
+                    "creator": "testuser"
+                  }
+                }
+              }
+            }
+          ]
+        }
+    """.trimIndent()
+
+    @Test
+    fun `getUserOwnedPlaylists parses playlist list with MBID extracted from identifier URL`() = runTest {
+        var seenUrl: String? = null
+        var seenAuth: String? = null
+        val engine = MockEngine { request ->
+            seenUrl = request.url.toString()
+            seenAuth = request.headers["Authorization"]
+            respond(LB_PLAYLISTS_FIXTURE, HttpStatusCode.OK, jsonHeaders)
+        }
+        val result = client(engine).getUserOwnedPlaylists("testuser")
+        assertEquals(
+            "https://api.listenbrainz.org/1/user/testuser/playlists",
+            seenUrl,
+        )
+        assertNull(seenAuth)
+        assertEquals(2, result.size)
+        assertEquals("11111111-1111-1111-1111-111111111111", result[0].mbid)
+        assertEquals("My Playlist", result[0].title)
+        assertEquals("Description One", result[0].annotation)
+        assertEquals("2026-05-27T10:30:00.000000+00:00", result[0].lastModifiedAt)
+        assertEquals("22222222-2222-2222-2222-222222222222", result[1].mbid)
+        assertEquals("Another Playlist", result[1].title)
+    }
+
+    @Test
+    fun `getUserOwnedPlaylists returns empty list on 404`() = runTest {
+        val engine = MockEngine { respond("", HttpStatusCode.NotFound) }
+        val result = client(engine).getUserOwnedPlaylists("missinguser")
+        assertEquals(emptyList(), result)
+    }
+
+    @Test
+    fun `getUserOwnedPlaylists returns empty list when no playlists present`() = runTest {
+        val engine = MockEngine {
+            respond(
+                """{"playlist_count": 0, "playlists": []}""",
+                HttpStatusCode.OK,
+                jsonHeaders,
+            )
+        }
+        val result = client(engine).getUserOwnedPlaylists("emptyuser")
+        assertEquals(emptyList(), result)
+    }
+
+    @Test
+    fun `getUserOwnedPlaylists throws on 500`() = runTest {
+        val engine = MockEngine { respond("oops", HttpStatusCode.InternalServerError) }
+        assertFailsWith<Exception> {
+            client(engine).getUserOwnedPlaylists("testuser")
+        }
+    }
 }

--- a/shared/src/commonTest/kotlin/com/parachord/shared/api/ListenBrainzClientMutationTest.kt
+++ b/shared/src/commonTest/kotlin/com/parachord/shared/api/ListenBrainzClientMutationTest.kt
@@ -15,12 +15,15 @@ import kotlinx.coroutines.test.runTest
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.boolean
+import kotlinx.serialization.json.int
+import kotlinx.serialization.json.jsonArray
 import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.jsonPrimitive
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
 import kotlin.test.assertFalse
+import kotlin.test.assertNull
 import kotlin.test.assertTrue
 
 /**
@@ -233,5 +236,207 @@ class ListenBrainzClientMutationTest {
                 token = "bad",
             )
         }
+    }
+
+    // ── addPlaylistItems ─────────────────────────────────────────────────────
+
+    @Test
+    fun `addPlaylistItems sends list of MB recording URIs in JSPF body`() = runTest {
+        var seenUrl: String? = null
+        var seenAuth: String? = null
+        var seenMethod: HttpMethod? = null
+        var seenBody: JsonObject? = null
+        val engine = MockEngine { request ->
+            seenUrl = request.url.toString()
+            seenAuth = request.headers["Authorization"]
+            seenMethod = request.method
+            seenBody = bodyJson(request)
+            respond("""{"status":"ok"}""", HttpStatusCode.OK, jsonHeaders)
+        }
+
+        client(engine).addPlaylistItems(
+            playlistMbid = "abcd1234-1111-2222-3333-444455556666",
+            recordingMbids = listOf(
+                "11111111-1111-1111-1111-111111111111",
+                "22222222-2222-2222-2222-222222222222",
+            ),
+            token = "tok",
+        )
+
+        assertEquals(
+            "https://api.listenbrainz.org/1/playlist/abcd1234-1111-2222-3333-444455556666/item/add",
+            seenUrl,
+        )
+        assertEquals(HttpMethod.Post, seenMethod)
+        assertEquals("Token tok", seenAuth)
+        val tracks = seenBody!!["playlist"]!!.jsonObject["track"]!!.jsonArray
+        assertEquals(2, tracks.size)
+        assertEquals(
+            "https://musicbrainz.org/recording/11111111-1111-1111-1111-111111111111",
+            tracks[0].jsonObject["identifier"]!!.jsonPrimitive.content,
+        )
+        assertEquals(
+            "https://musicbrainz.org/recording/22222222-2222-2222-2222-222222222222",
+            tracks[1].jsonObject["identifier"]!!.jsonPrimitive.content,
+        )
+    }
+
+    @Test
+    fun `addPlaylistItems short-circuits when list is empty`() = runTest {
+        var callCount = 0
+        val engine = MockEngine {
+            callCount++
+            respond("""{"status":"ok"}""", HttpStatusCode.OK, jsonHeaders)
+        }
+        client(engine).addPlaylistItems(
+            playlistMbid = "abcd1234-1111-2222-3333-444455556666",
+            recordingMbids = emptyList(),
+            token = "tok",
+        )
+        assertEquals(0, callCount)
+    }
+
+    @Test
+    fun `addPlaylistItems throws on 401`() = runTest {
+        val engine = MockEngine { respond("", HttpStatusCode.Unauthorized) }
+        assertFailsWith<ListenBrainzUnauthorizedException> {
+            client(engine).addPlaylistItems(
+                playlistMbid = "abcd1234-1111-2222-3333-444455556666",
+                recordingMbids = listOf("11111111-1111-1111-1111-111111111111"),
+                token = "bad",
+            )
+        }
+    }
+
+    // ── deletePlaylistItems ──────────────────────────────────────────────────
+
+    @Test
+    fun `deletePlaylistItems sends index and count`() = runTest {
+        var seenUrl: String? = null
+        var seenAuth: String? = null
+        var seenMethod: HttpMethod? = null
+        var seenBody: JsonObject? = null
+        val engine = MockEngine { request ->
+            seenUrl = request.url.toString()
+            seenAuth = request.headers["Authorization"]
+            seenMethod = request.method
+            seenBody = bodyJson(request)
+            respond("""{"status":"ok"}""", HttpStatusCode.OK, jsonHeaders)
+        }
+
+        client(engine).deletePlaylistItems(
+            playlistMbid = "abcd1234-1111-2222-3333-444455556666",
+            index = 0,
+            count = 5,
+            token = "tok",
+        )
+
+        assertEquals(
+            "https://api.listenbrainz.org/1/playlist/abcd1234-1111-2222-3333-444455556666/item/delete",
+            seenUrl,
+        )
+        assertEquals(HttpMethod.Post, seenMethod)
+        assertEquals("Token tok", seenAuth)
+        assertEquals(0, seenBody!!["index"]!!.jsonPrimitive.int)
+        assertEquals(5, seenBody!!["count"]!!.jsonPrimitive.int)
+    }
+
+    @Test
+    fun `deletePlaylistItems short-circuits when count is zero`() = runTest {
+        var callCount = 0
+        val engine = MockEngine {
+            callCount++
+            respond("""{"status":"ok"}""", HttpStatusCode.OK, jsonHeaders)
+        }
+        client(engine).deletePlaylistItems(
+            playlistMbid = "abcd1234-1111-2222-3333-444455556666",
+            index = 0,
+            count = 0,
+            token = "tok",
+        )
+        assertEquals(0, callCount)
+    }
+
+    @Test
+    fun `deletePlaylistItems throws on 401`() = runTest {
+        val engine = MockEngine { respond("", HttpStatusCode.Unauthorized) }
+        assertFailsWith<ListenBrainzUnauthorizedException> {
+            client(engine).deletePlaylistItems(
+                playlistMbid = "abcd1234-1111-2222-3333-444455556666",
+                index = 0,
+                count = 3,
+                token = "bad",
+            )
+        }
+    }
+
+    // ── getPlaylistLastModified ──────────────────────────────────────────────
+
+    @Test
+    fun `getPlaylistLastModified extracts last_modified_at from JSPF extension`() = runTest {
+        var seenUrl: String? = null
+        val engine = MockEngine { request ->
+            seenUrl = request.url.toString()
+            respond(
+                """
+                {
+                  "playlist": {
+                    "title": "X",
+                    "extension": {
+                      "https://musicbrainz.org/doc/jspf#playlist": {
+                        "last_modified_at": "2026-05-27T12:34:56.000000+00:00",
+                        "public": true
+                      }
+                    }
+                  }
+                }
+                """.trimIndent(),
+                HttpStatusCode.OK,
+                jsonHeaders,
+            )
+        }
+        val result = client(engine).getPlaylistLastModified(
+            playlistMbid = "abcd1234-1111-2222-3333-444455556666",
+        )
+        assertEquals(
+            "https://api.listenbrainz.org/1/playlist/abcd1234-1111-2222-3333-444455556666",
+            seenUrl,
+        )
+        assertEquals("2026-05-27T12:34:56.000000+00:00", result)
+    }
+
+    @Test
+    fun `getPlaylistLastModified returns null on 404`() = runTest {
+        val engine = MockEngine { respond("", HttpStatusCode.NotFound) }
+        val result = client(engine).getPlaylistLastModified(
+            playlistMbid = "abcd1234-1111-2222-3333-444455556666",
+        )
+        assertNull(result)
+    }
+
+    @Test
+    fun `getPlaylistLastModified returns null when field missing`() = runTest {
+        val engine = MockEngine {
+            respond(
+                """
+                {
+                  "playlist": {
+                    "title": "X",
+                    "extension": {
+                      "https://musicbrainz.org/doc/jspf#playlist": {
+                        "public": true
+                      }
+                    }
+                  }
+                }
+                """.trimIndent(),
+                HttpStatusCode.OK,
+                jsonHeaders,
+            )
+        }
+        val result = client(engine).getPlaylistLastModified(
+            playlistMbid = "abcd1234-1111-2222-3333-444455556666",
+        )
+        assertNull(result)
     }
 }

--- a/shared/src/commonTest/kotlin/com/parachord/shared/api/ListenBrainzClientMutationTest.kt
+++ b/shared/src/commonTest/kotlin/com/parachord/shared/api/ListenBrainzClientMutationTest.kt
@@ -529,4 +529,52 @@ class ListenBrainzClientMutationTest {
             client(engine).getUserOwnedPlaylists("testuser")
         }
     }
+
+    @Test
+    fun `getUserOwnedPlaylists returns null lastModifiedAt when extension absent`() = runTest {
+        // LB doesn't always include the extension block — verify we tolerate it
+        // and produce null lastModifiedAt rather than crashing.
+        val fixture = """
+            {
+              "playlist_count": 2,
+              "playlists": [
+                {
+                  "playlist": {
+                    "identifier": "https://listenbrainz.org/playlist/33333333-3333-3333-3333-333333333333",
+                    "title": "Bare Playlist",
+                    "annotation": ""
+                  }
+                },
+                {
+                  "playlist": {
+                    "identifier": "https://listenbrainz.org/playlist/44444444-4444-4444-4444-444444444444",
+                    "title": "Null Extension Playlist",
+                    "annotation": "",
+                    "extension": null
+                  }
+                }
+              ]
+            }
+        """.trimIndent()
+        val engine = MockEngine { respond(fixture, HttpStatusCode.OK, jsonHeaders) }
+        val result = client(engine).getUserOwnedPlaylists("testuser")
+        assertEquals(2, result.size)
+        assertEquals("33333333-3333-3333-3333-333333333333", result[0].mbid)
+        assertEquals("Bare Playlist", result[0].title)
+        assertNull(result[0].lastModifiedAt)
+        assertEquals("44444444-4444-4444-4444-444444444444", result[1].mbid)
+        assertEquals("Null Extension Playlist", result[1].title)
+        assertNull(result[1].lastModifiedAt)
+    }
+
+    @Test
+    fun `getUserOwnedPlaylists propagates parse failures (malformed JSON)`() = runTest {
+        // Parse failures must throw, not swallow to empty list — otherwise the
+        // sync provider can't distinguish "user has no playlists" from "LB
+        // returned garbage" and would wipe the local mirror.
+        val engine = MockEngine { respond("not json at all{", HttpStatusCode.OK, jsonHeaders) }
+        assertFailsWith<Exception> {
+            client(engine).getUserOwnedPlaylists("testuser")
+        }
+    }
 }

--- a/shared/src/commonTest/kotlin/com/parachord/shared/api/ListenBrainzClientMutationTest.kt
+++ b/shared/src/commonTest/kotlin/com/parachord/shared/api/ListenBrainzClientMutationTest.kt
@@ -1,0 +1,237 @@
+package com.parachord.shared.api
+
+import com.parachord.shared.sync.ListenBrainzUnauthorizedException
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.mock.MockEngine
+import io.ktor.client.engine.mock.respond
+import io.ktor.client.engine.mock.toByteArray
+import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
+import io.ktor.client.request.HttpRequestData
+import io.ktor.http.HttpMethod
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.headersOf
+import io.ktor.serialization.kotlinx.json.json
+import kotlinx.coroutines.test.runTest
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.boolean
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/**
+ * MockEngine tests for [ListenBrainzClient] playlist mutation endpoints
+ * added in Phase 2 of the ListenBrainz sync provider work (issue #156,
+ * Task 6).
+ *
+ * Endpoints under test:
+ *  - POST /1/playlist/create
+ *  - POST /1/playlist/edit/{mbid}
+ *  - POST /1/playlist/{mbid}/delete
+ *
+ * Each method must:
+ *  - send `Authorization: Token <token>` header
+ *  - throw [ListenBrainzUnauthorizedException] on HTTP 401
+ *  - shape the body per the LB JSPF spec (create/edit only)
+ */
+class ListenBrainzClientMutationTest {
+
+    private val jsonHeaders = headersOf("Content-Type", "application/json")
+
+    private fun client(engine: MockEngine) = ListenBrainzClient(
+        HttpClient(engine) {
+            install(ContentNegotiation) { json() }
+        },
+    )
+
+    private suspend fun bodyJson(request: HttpRequestData): JsonObject {
+        val text = request.body.toByteArray().decodeToString()
+        return Json.parseToJsonElement(text).jsonObject
+    }
+
+    // ── createPlaylist ───────────────────────────────────────────────────────
+
+    @Test
+    fun createPlaylist_sendsCorrectRequestAndParsesMbid() = runTest {
+        var seenUrl: String? = null
+        var seenAuth: String? = null
+        var seenMethod: HttpMethod? = null
+        var seenBody: JsonObject? = null
+        val engine = MockEngine { request ->
+            seenUrl = request.url.toString()
+            seenAuth = request.headers["Authorization"]
+            seenMethod = request.method
+            seenBody = bodyJson(request)
+            respond(
+                """{"playlist_mbid":"12345678-1234-1234-1234-123456789012","status":"ok"}""",
+                HttpStatusCode.OK,
+                jsonHeaders,
+            )
+        }
+
+        val mbid = client(engine).createPlaylist(
+            name = "Test Playlist",
+            description = "A test",
+            isPublic = true,
+            token = "tok",
+        )
+
+        assertEquals("12345678-1234-1234-1234-123456789012", mbid)
+        assertEquals("https://api.listenbrainz.org/1/playlist/create", seenUrl)
+        assertEquals(HttpMethod.Post, seenMethod)
+        assertEquals("Token tok", seenAuth)
+
+        val playlist = seenBody!!["playlist"]!!.jsonObject
+        assertEquals("Test Playlist", playlist["title"]!!.jsonPrimitive.content)
+        assertEquals("A test", playlist["annotation"]!!.jsonPrimitive.content)
+        val ext = playlist["extension"]!!.jsonObject
+        val jspfExt = ext["https://musicbrainz.org/doc/jspf#playlist"]!!.jsonObject
+        assertTrue(jspfExt["public"]!!.jsonPrimitive.boolean)
+    }
+
+    @Test
+    fun createPlaylist_omitsDescriptionWhenNull() = runTest {
+        var seenBody: JsonObject? = null
+        val engine = MockEngine { request ->
+            seenBody = bodyJson(request)
+            respond(
+                """{"playlist_mbid":"aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee","status":"ok"}""",
+                HttpStatusCode.OK,
+                jsonHeaders,
+            )
+        }
+        client(engine).createPlaylist(name = "No-Desc", description = null, token = "tok")
+        val playlist = seenBody!!["playlist"]!!.jsonObject
+        assertEquals("No-Desc", playlist["title"]!!.jsonPrimitive.content)
+        assertFalse(playlist.containsKey("annotation"))
+    }
+
+    @Test
+    fun createPlaylist_privateFlag() = runTest {
+        var seenBody: JsonObject? = null
+        val engine = MockEngine { request ->
+            seenBody = bodyJson(request)
+            respond(
+                """{"playlist_mbid":"aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee","status":"ok"}""",
+                HttpStatusCode.OK,
+                jsonHeaders,
+            )
+        }
+        client(engine).createPlaylist(name = "Priv", isPublic = false, token = "tok")
+        val ext = seenBody!!["playlist"]!!.jsonObject["extension"]!!.jsonObject
+        val jspfExt = ext["https://musicbrainz.org/doc/jspf#playlist"]!!.jsonObject
+        assertFalse(jspfExt["public"]!!.jsonPrimitive.boolean)
+    }
+
+    @Test
+    fun createPlaylist_throwsUnauthorizedOn401() = runTest {
+        val engine = MockEngine { respond("", HttpStatusCode.Unauthorized) }
+        assertFailsWith<ListenBrainzUnauthorizedException> {
+            client(engine).createPlaylist("Test", token = "bad-token")
+        }
+    }
+
+    // ── editPlaylist ─────────────────────────────────────────────────────────
+
+    @Test
+    fun editPlaylist_sendsBodyWithOnlyNonNullFields() = runTest {
+        var seenUrl: String? = null
+        var seenAuth: String? = null
+        var seenBody: JsonObject? = null
+        val engine = MockEngine { request ->
+            seenUrl = request.url.toString()
+            seenAuth = request.headers["Authorization"]
+            seenBody = bodyJson(request)
+            respond("""{"status":"ok"}""", HttpStatusCode.OK, jsonHeaders)
+        }
+
+        client(engine).editPlaylist(
+            playlistMbid = "abcd1234-1111-2222-3333-444455556666",
+            name = "Renamed",
+            description = null,
+            token = "tok",
+        )
+
+        assertEquals(
+            "https://api.listenbrainz.org/1/playlist/edit/abcd1234-1111-2222-3333-444455556666",
+            seenUrl,
+        )
+        assertEquals("Token tok", seenAuth)
+        val playlist = seenBody!!["playlist"]!!.jsonObject
+        assertEquals("Renamed", playlist["title"]!!.jsonPrimitive.content)
+        assertFalse(playlist.containsKey("annotation"))
+    }
+
+    @Test
+    fun editPlaylist_includesDescriptionWhenProvided() = runTest {
+        var seenBody: JsonObject? = null
+        val engine = MockEngine { request ->
+            seenBody = bodyJson(request)
+            respond("""{"status":"ok"}""", HttpStatusCode.OK, jsonHeaders)
+        }
+        client(engine).editPlaylist(
+            playlistMbid = "abcd1234-1111-2222-3333-444455556666",
+            name = null,
+            description = "New annotation",
+            token = "tok",
+        )
+        val playlist = seenBody!!["playlist"]!!.jsonObject
+        assertFalse(playlist.containsKey("title"))
+        assertEquals("New annotation", playlist["annotation"]!!.jsonPrimitive.content)
+    }
+
+    @Test
+    fun editPlaylist_throwsUnauthorizedOn401() = runTest {
+        val engine = MockEngine { respond("", HttpStatusCode.Unauthorized) }
+        assertFailsWith<ListenBrainzUnauthorizedException> {
+            client(engine).editPlaylist(
+                playlistMbid = "abcd1234-1111-2222-3333-444455556666",
+                name = "x",
+                description = null,
+                token = "bad",
+            )
+        }
+    }
+
+    // ── deletePlaylist ───────────────────────────────────────────────────────
+
+    @Test
+    fun deletePlaylist_postsToDeleteEndpoint() = runTest {
+        var seenUrl: String? = null
+        var seenAuth: String? = null
+        var seenMethod: HttpMethod? = null
+        val engine = MockEngine { request ->
+            seenUrl = request.url.toString()
+            seenAuth = request.headers["Authorization"]
+            seenMethod = request.method
+            respond("""{"status":"ok"}""", HttpStatusCode.OK, jsonHeaders)
+        }
+
+        client(engine).deletePlaylist(
+            playlistMbid = "abcd1234-1111-2222-3333-444455556666",
+            token = "tok",
+        )
+
+        assertEquals(
+            "https://api.listenbrainz.org/1/playlist/abcd1234-1111-2222-3333-444455556666/delete",
+            seenUrl,
+        )
+        assertEquals(HttpMethod.Post, seenMethod)
+        assertEquals("Token tok", seenAuth)
+    }
+
+    @Test
+    fun deletePlaylist_throwsUnauthorizedOn401() = runTest {
+        val engine = MockEngine { respond("", HttpStatusCode.Unauthorized) }
+        assertFailsWith<ListenBrainzUnauthorizedException> {
+            client(engine).deletePlaylist(
+                playlistMbid = "abcd1234-1111-2222-3333-444455556666",
+                token = "bad",
+            )
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Adds a third `SyncProvider` implementation (`ListenBrainzSyncProvider`) alongside Spotify and Apple Music. Two-way syncs playlists between Parachord and ListenBrainz. V1 scope: playlists only (push + pull). Loved tracks stay on the existing `LovesPushService` path; artist follow + album collection deferred to V2.

Closes #156. Unblocks #145 (Achordion playlist-links submit).

## Architecture

### Schema (Phase 1, Tasks 1-4)

`PlaylistTrack` gains a new `trackRecordingMbid TEXT` column carrying the MusicBrainz recording MBID per playlist track. ALTER TABLE wrapped in try/catch in `AndroidModule.bindDatabase` for existing installs; new installs get it from `PlaylistTrack.sq`'s CREATE TABLE.

### ListenBrainzClient mutations (Phase 2, Tasks 5-8)

Five new endpoints + one read on `ListenBrainzClient`:

| Method | Endpoint | Auth |
|---|---|---|
| `createPlaylist` | `POST /1/playlist/create` | Token |
| `editPlaylist` | `POST /1/playlist/edit/{mbid}` | Token |
| `deletePlaylist` | `POST /1/playlist/{mbid}/delete` | Token |
| `addPlaylistItems` | `POST /1/playlist/{mbid}/item/add` | Token |
| `deletePlaylistItems` | `POST /1/playlist/{mbid}/item/delete` | Token |
| `getPlaylistLastModified` | `GET /1/playlist/{mbid}` (extract `last_modified_at`) | Public |
| `getUserOwnedPlaylists` | `GET /1/user/{name}/playlists` | Public |

All write methods throw a new `ListenBrainzUnauthorizedException` on 401 and wrap in `executeWithRetry` for 429/503 backoff. `addPlaylistItems` / `deletePlaylistItems` short-circuit (no HTTP) when there's nothing to do. **24 MockEngine tests** cover request shape, body assertions, error cases.

### ListenBrainzSyncProvider (Phase 3, Tasks 9-13)

```kotlin
features = ProviderFeatures(
    snapshots = SnapshotKind.DateString,         // last_modified_at ISO
    supportsFollow = false,                       // V2
    supportsPlaylistDelete = true,
    supportsPlaylistRename = true,
    supportsTrackReplace = true,                  // delete-all + add-all
)
```

- Session-scoped `authFailedForSession` kill-switch on 401 from any mutation. Mirrors `AppleMusicSyncProvider`.
- `fetchPlaylists` is unauth (LB public playlists) — defensive 401 catch is documented as "would only fire if LB starts requiring auth on this endpoint." Real 401 propagates as generic Exception.
- `replacePlaylistTracks` is **not atomic** — delete-all + add-all sequence. Acceptable per design; playlist appears briefly empty during sync.
- `searchForTrackId` delegates to the existing `MbidEnrichmentService.mapperLookup(artist, title)` — handles tracks lacking `trackRecordingMbid` at push time. **37 provider tests** including kill-switch propagation, real-vs-mocked 401 handling, all 8 method behaviors.

### SyncEngine wiring (Phase 4, Tasks 14-16)

- LB branches in `extractExternalTrackIds`, `missingProviderId`, `applyResolvedId` (track-ID hydration path)
- `isPushCandidate` for LB accepts `local-*` + hosted XSPF + `spotify-*` + `applemusic-*` (LB mirrors any source-of-truth)
- `healImportedSyncedFromMismatch` recognizes `listenbrainz-*` prefix — extends the cross-platform invariant from CLAUDE.md ("when one client has a sync bug, the other client's launch silently restores it") to LB
- **19 new tests** across `SyncEngineTrackIdHelpersTest`, `PushCandidateTest`, `HealImportedSyncedFromTest`

### DI + Settings + UI (Phase 5, Tasks 17-19)

- Koin: single `singleOf(::ListenBrainzSyncProvider) bind SyncProvider::class` line — picked up by `SyncEngine`'s `getAll<SyncProvider>()` auto-aggregation
- `SettingsStore`: no changes needed — `getEnabledSyncProviders` is free-form (no allowlist), `getListenBrainzUsername` already exists
- Default `enabledSyncProviders` stays `setOf("spotify")` — LB is opt-in
- UI: new "ListenBrainz Sync" toggle in Settings → General, gated by `if (listenBrainzConnected)`. Mirrors AM's pattern.

## Multi-client convergence (Desktop ↔ LB ↔ Android)

Inherits the existing three-layer dedup from `SyncEngine`:

1. `sync_playlist_link[localId]["listenbrainz"]` match → reuse local row
2. Name match (case-insensitive, owned-only) → reuse
3. Create new `listenbrainz-<mbid>` row

`isCrossProviderPushMirror` guard preserves `sync_playlist_source` when a Spotify-imported playlist also has LB sync enabled. `healImportedSyncedFromMismatch` extension restores LB source if either client corrupts it.

Smoke test (manual, post-merge):
1. Desktop creates playlist → push to LB. Android sync → expect `listenbrainz-<mbid>` row.
2. Android adds tracks → push. Desktop sync → expect updates.
3. Desktop renames → push. Android sync → expect rename (no duplicate).
4. Android deletes → push. Desktop sync → expect removal.

## Test plan

- [x] `./gradlew :app:testDebugUnitTest :shared:testDebugUnitTest` — both green
- [x] **80+ new tests** across the LB client, provider, and SyncEngine helpers
- [ ] Manual on-device: enable LB sync in Settings → create local playlist → run sync → playlist appears on listenbrainz.org
- [ ] Manual: add/remove/rename a playlist → reflects on LB
- [ ] Manual: convergence smoke test (Desktop ↔ LB ↔ Android, 4 steps above)
- [ ] No regression: Spotify + Apple Music sync paths still work

## Out of scope (V2 candidates)

- Track loves push (already in `LovesPushService`)
- Artist follow (`POST /1/user/{name}/follow`)
- LB-imported-playlist support in `PlaylistImportManager` for `jspf://` URLs
- "Promote local playlist to LB" wizard UX
- Per-axis sync wizard (the AM-style SyncSetupSheet) — LB is global on/off for now

## References

- Design: `docs/plans/2026-05-27-listenbrainz-sync-provider-design.md`
- Implementation plan: `docs/plans/2026-05-27-listenbrainz-sync-provider.md` (21 tasks)
- LB playlist API: https://listenbrainz.readthedocs.io/en/latest/users/api/playlist.html
- CLAUDE.md § "Multi-Provider Sync" — convergence model + propagation invariants

🤖 Generated with [Claude Code](https://claude.com/claude-code)