### PR TITLE
spotify: persist LOCAL_DEVICE_ID when user picks the phone from the picker

### DIFF
--- a/app/src/main/java/com/parachord/android/playback/handlers/SpotifyPlaybackHandler.kt
+++ b/app/src/main/java/com/parachord/android/playback/handlers/SpotifyPlaybackHandler.kt
@@ -489,8 +489,6 @@ class SpotifyPlaybackHandler constructor(
      */
     private suspend fun resolveLocalDevice(): SpDevice? {
         Log.d(TAG, "Resolving local device: model='${Build.MODEL}', manufacturer='${Build.MANUFACTURER}'")
-        val localModel = Build.MODEL.lowercase()
-        val localManufacturer = Build.MANUFACTURER.lowercase()
 
         // Always ensure Spotify is running on this phone. Remote devices
         // (TVs, computers) can appear in the API without local Spotify running.
@@ -506,12 +504,8 @@ class SpotifyPlaybackHandler constructor(
             pollCount++
             try {
                 val devices = spotifyClient.getDevices().devices
-                val local = devices.firstOrNull { d ->
-                    d.type == "Smartphone" && (
-                        d.name.lowercase().contains(localModel) ||
-                        d.name.lowercase().contains(localManufacturer)
-                    )
-                } ?: devices.firstOrNull { it.type == "Smartphone" }
+                val local = devices.firstOrNull { isLocalRealDevice(it) }
+                    ?: devices.firstOrNull { it.type == "Smartphone" }
 
                 if (local != null) {
                     deviceVerified = true
@@ -755,11 +749,30 @@ class SpotifyPlaybackHandler constructor(
 
         val chosen = deferred.await()
         if (chosen != null) {
-            settingsStore.setPreferredSpotifyDeviceId(chosen.id)
-            Log.d(TAG, "User picked '${chosen.name}', saved as preferred")
+            val stableId = chooseStableId(chosen)
+            settingsStore.setPreferredSpotifyDeviceId(stableId)
+            Log.d(TAG, "User picked '${chosen.name}', saved as preferred id=$stableId")
         }
         return chosen
     }
+
+    /**
+     * Normalize the device ID we persist when the user picks a device from the
+     * picker. Real Spotify device IDs are NOT stable across Spotify process
+     * restarts — saving the real ID for the local phone causes "preferred device
+     * not found" on every cold start, falling through to the phantom-active-remote
+     * trap. For the local phone (synthetic placeholder OR resolved real
+     * smartphone matching Build.MODEL/MANUFACTURER), persist LOCAL_DEVICE_ID
+     * instead so [pickDevice] step 1 honors it on every subsequent session.
+     * Remote devices (TVs, computers, other phones) keep their real IDs —
+     * those don't rotate the same way and explicit-cross-room casts must work.
+     */
+    internal fun chooseStableId(chosen: SpDevice): String =
+        if (isLocalPlaceholder(chosen) || isLocalRealDevice(chosen)) {
+            LOCAL_DEVICE_ID
+        } else {
+            chosen.id
+        }
 
     /**
      * Detect whether the track we started has finished or is about to finish.

--- a/app/src/test/java/com/parachord/android/playback/handlers/SpotifyPlaybackHandlerChooseStableIdTest.kt
+++ b/app/src/test/java/com/parachord/android/playback/handlers/SpotifyPlaybackHandlerChooseStableIdTest.kt
@@ -1,0 +1,141 @@
+package com.parachord.android.playback.handlers
+
+import android.app.Application
+import android.os.Build
+import com.parachord.android.auth.OAuthManager
+import com.parachord.android.data.store.SettingsStore
+import com.parachord.shared.api.SpDevice
+import com.parachord.shared.api.SpotifyClient
+import io.mockk.mockk
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.RuntimeEnvironment
+import org.robolectric.annotation.Config
+import org.robolectric.util.ReflectionHelpers
+
+/**
+ * Tests for [SpotifyPlaybackHandler.chooseStableId]: when the user picks a
+ * device from the picker dialog, we must persist [LOCAL_DEVICE_ID] for the
+ * local phone (synthetic placeholder OR resolved real smartphone matching
+ * Build.MODEL/MANUFACTURER) so the preference survives Spotify process
+ * restarts. Remote devices (TVs, other phones, computers) keep their real IDs.
+ *
+ * Companion to the prefer-local-over-active-remote and sticky-default fixes —
+ * this one addresses the explicit picker path the user keeps hitting in the
+ * "picker keeps resetting" loop.
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(application = Application::class)
+class SpotifyPlaybackHandlerChooseStableIdTest {
+
+    private lateinit var handler: SpotifyPlaybackHandler
+
+    @Before
+    fun setUp() {
+        ReflectionHelpers.setStaticField(Build::class.java, "MODEL", "Pixel 9a")
+        ReflectionHelpers.setStaticField(Build::class.java, "MANUFACTURER", "Google")
+
+        handler = SpotifyPlaybackHandler(
+            spotifyClient = mockk<SpotifyClient>(relaxed = true),
+            settingsStore = mockk<SettingsStore>(relaxed = true),
+            oAuthManager = mockk<OAuthManager>(relaxed = true),
+            context = RuntimeEnvironment.getApplication(),
+        )
+    }
+
+    @Test
+    fun `synthetic placeholder maps to LOCAL_DEVICE_ID`() {
+        val placeholder = SpDevice(
+            id = SpotifyPlaybackHandler.LOCAL_DEVICE_ID,
+            name = "Google Pixel 9a",
+            isActive = false,
+            type = "Smartphone",
+        )
+        assertEquals(SpotifyPlaybackHandler.LOCAL_DEVICE_ID, handler.chooseStableId(placeholder))
+    }
+
+    /**
+     * Common case: Spotify already registered the phone before the picker
+     * opened, so the dialog shows the real device entry (real opaque ID).
+     * Tapping it must still persist LOCAL_DEVICE_ID — the real ID rotates on
+     * every Spotify cold start.
+     */
+    @Test
+    fun `resolved real smartphone matching Build_MODEL maps to LOCAL_DEVICE_ID`() {
+        val phone = SpDevice(
+            id = "real-volatile-id-abc123",
+            name = "Pixel 9a",
+            isActive = true,
+            type = "Smartphone",
+        )
+        assertEquals(SpotifyPlaybackHandler.LOCAL_DEVICE_ID, handler.chooseStableId(phone))
+    }
+
+    @Test
+    fun `resolved real smartphone matching Build_MANUFACTURER maps to LOCAL_DEVICE_ID`() {
+        val phone = SpDevice(
+            id = "real-volatile-id-xyz",
+            name = "My Google Phone",
+            isActive = true,
+            type = "Smartphone",
+        )
+        assertEquals(SpotifyPlaybackHandler.LOCAL_DEVICE_ID, handler.chooseStableId(phone))
+    }
+
+    /**
+     * Different smartphone (e.g., partner's iPhone showing up via family
+     * Premium Connect). Not local — must keep its real ID so cross-device
+     * casts work.
+     */
+    @Test
+    fun `non-matching smartphone keeps real id`() {
+        val otherPhone = SpDevice(
+            id = "iphone-id",
+            name = "Bob's iPhone",
+            isActive = false,
+            type = "Smartphone",
+        )
+        assertEquals("iphone-id", handler.chooseStableId(otherPhone))
+    }
+
+    @Test
+    fun `TV keeps real id`() {
+        val tv = SpDevice(
+            id = "tv-id",
+            name = "Bedroom TV",
+            isActive = true,
+            type = "TV",
+        )
+        assertEquals("tv-id", handler.chooseStableId(tv))
+    }
+
+    @Test
+    fun `Computer keeps real id`() {
+        val laptop = SpDevice(
+            id = "macbook-id",
+            name = "Jeff's MacBook Pro",
+            isActive = false,
+            type = "Computer",
+        )
+        assertEquals("macbook-id", handler.chooseStableId(laptop))
+    }
+
+    /**
+     * Edge case: a non-Smartphone device named "Pixel 9a" (e.g., a Cast target
+     * the user named after their phone). Type guard wins — we only treat
+     * Smartphone-typed devices as candidates for the local-phone normalization.
+     */
+    @Test
+    fun `non-smartphone with matching name keeps real id`() {
+        val castDevice = SpDevice(
+            id = "cast-id",
+            name = "Pixel 9a Cast",
+            isActive = false,
+            type = "CastVideo",
+        )
+        assertEquals("cast-id", handler.chooseStableId(castDevice))
+    }
+}


### PR DESCRIPTION
## Symptom

User keeps picking their phone from the Spotify device picker. Every time Spotify cold-starts (phone reboot, Spotify killed by memory pressure, or user kills it), the preference clears on next sync and audio re-routes to a phantom Bedroom TV instead of the phone. User has to open the picker and choose the phone again. Loop.

## Root cause

`pickDevice` saves `chosen.id` raw at the picker callback. When Spotify Connect is already running on the phone (the common case after a play attempt), the picker dialog shows the **real** device entry — not the synthetic `LOCAL_DEVICE_ID` placeholder — so we persist the real id. Real Spotify device ids are NOT stable across Spotify process restarts. Next cold start, the saved real id is no longer in the device list; `pickDevice` clears the preference, falls through to the already-active phantom remote, and steals playback.

## Fix

Normalize the picked id via a new `chooseStableId()` helper at the picker callback: for the local phone (synthetic placeholder OR real `Smartphone`-typed device whose name contains `Build.MODEL` / `Build.MANUFACTURER`), persist `LOCAL_DEVICE_ID`. Remote devices (TVs, computers, foreign phones) keep their real ids so explicit cross-room casts still work.

Also refactored the duplicated smartphone-match logic in `resolveLocalDevice()` to reuse the existing `isLocalRealDevice()` helper. Behavior-preserving.

## Why this is independent of the other two pickDevice chips

- [d1b0b2f](https://github.com/Parachord/parachord-android/commit/d1b0b2f) — `pickDevice` prefers local over already-active remote (what kicks in WHEN no preference is set)
- [787a108](https://github.com/Parachord/parachord-android/commit/787a108) — sticky `LOCAL_DEVICE_ID` after first successful local play (what sets the preference automatically after an anonymous-play success)
- **This PR** — what makes the preference durable when the user EXPLICITLY picks the phone via the picker dialog

All three solve overlapping but distinct slices of the same loop. This one is the most pointed fix for the symptom users actually report ("the picker keeps resetting").

## What changed

- `SpotifyPlaybackHandler.kt` — new `chooseStableId(chosen)` internal helper; picker callback uses it; `resolveLocalDevice()` now reuses `isLocalRealDevice()` instead of inlining the same lowercase/contains check
- `SpotifyPlaybackHandlerChooseStableIdTest.kt` (new) — 7 Robolectric tests covering placeholder, real-phone-by-Build.MODEL, real-phone-by-Build.MANUFACTURER, foreign smartphone, TV, computer, and the type-guard edge case (non-Smartphone named "Pixel 9a")

## Test plan

- [x] Unit tests pass: `./gradlew :app:testDebugUnitTest --tests "*ChooseStableId*" --tests "*StickyDefault*" --tests "*PickDevice*"` (7 + 5 + 6 = 18 tests, all green)
- [ ] Picker dialog → tap phone (regardless of whether real or synthetic shows) → `getPreferredSpotifyDeviceId()` returns `LOCAL_DEVICE_ID`
- [ ] Kill Spotify (`adb shell am force-stop com.spotify.music`), kill Parachord, reboot phone. Open Parachord, tap play on a Spotify track. Verify audio routes to phone, not phantom TV — without the picker re-appearing
- [ ] Picker → tap Bedroom TV → preference is the TV's actual id (unchanged behavior)
- [ ] Picker → tap MacBook → preference is the MacBook's id (unchanged behavior)
- [ ] No regression: existing real-device preferences still work for cross-room casting

## Out of scope

- The phantom-device problem itself (Spotify's API lies about `isActive`, not fixable client-side)
- Auto-pruning stale real device ids from `preferredDeviceId` after N consecutive "preferred not found" events (separate workstream)

🤖 Generated with [Claude Code](https://claude.com/claude-code)