### PR TITLE
auto: set MediaMetadata.subtitle so Android Auto renders the now-playing card

### DIFF
--- a/app/src/main/java/com/parachord/android/playback/MediaItemMapping.kt
+++ b/app/src/main/java/com/parachord/android/playback/MediaItemMapping.kt
@@ -23,6 +23,7 @@ import com.parachord.android.data.db.entity.TrackEntity
 fun TrackEntity.toAutoMediaItem(): MediaItem {
     val builder = MediaMetadata.Builder()
         .setTitle(title)
+        .setSubtitle(artist)
         .setArtist(artist)
         .setAlbumTitle(album)
         .setMediaType(MediaMetadata.MEDIA_TYPE_MUSIC)

--- a/app/src/main/java/com/parachord/android/playback/PlaybackController.kt
+++ b/app/src/main/java/com/parachord/android/playback/PlaybackController.kt
@@ -776,6 +776,7 @@ class PlaybackController constructor(
                         .setMediaMetadata(
                             MediaMetadata.Builder()
                                 .setTitle(routedTrack.title)
+                                .setSubtitle(routedTrack.artist)
                                 .setArtist(routedTrack.artist)
                                 .setAlbumTitle(routedTrack.album)
                                 .setArtworkUri(artworkUri)


### PR DESCRIPTION
## Summary

- Add `setSubtitle(artist)` alongside `setArtist(artist)` on the MediaItem used as the session's current item during external (Spotify/Apple Music) playback.
- Same fix on `MediaItemMapping.toAutoMediaItem` for the non-external (ExoPlayer) playback path used by the synthetic queue.

## Why

Phone locked, browsing Parachord on Android Auto, user taps a playlist → head unit briefly shows "Getting your selection" then reverts to the browse list with no now-playing UI. Meanwhile in logcat, `PlaybackController` *did* dispatch and Spotify is actually playing in the background.

Captured at the failure moment:

```
SpotifyPlayback: play() via Web API for 'The Sunshine of Your Youth' uri=spotify:track:60U4vYXWg5PtdjECqgEuZN
GH.MediaPlaybackMonitor: Invalid metadata, no title and subtitle.
GH.MediaSuggNotifier: Invalid session state detected.
```

Android Auto's `GH.MediaPlaybackMonitor` (in `com.google.android.projection.gearhead`) inspects the current MediaItem's `mediaMetadata` and requires BOTH `title` AND `subtitle` to be non-null/non-empty before it'll render the now-playing card. `setArtist()` populates `MediaMetadata.artist` but does NOT populate `MediaMetadata.subtitle` — they're separate fields. Auto specifically reads `subtitle`.

Google Assistant doesn't gate on this check, which is why voice-triggered playback worked end-to-end even with the same metadata shape.

Keep both `setSubtitle` and `setArtist` — Auto reads `subtitle`, lock screen and BT car widgets read `artist`. Defense in depth.

## Scope

Per Auto's check: only the session's *current* MediaItem needs `subtitle`. Browse-tree tiles (root, folders, playlist tiles, search result tiles) are intentionally unchanged — they're never the now-playing item directly. Builders touched:

- `PlaybackController.kt` — silence item built when external playback starts (PRIMARY; this is what Auto reads after the async `setMediaItems` replacement arrives)
- `MediaItemMapping.toAutoMediaItem` — synthetic queue items for non-external playback

Not touched (browse tiles, by design):
- `PlaybackService.rootItem`, `browsableFolder`, `playableAction`, `playlistToMediaItem`, `searchResultToMediaItem`
- `PlaybackService.silencePlaceholderFor` — copies its source metadata; for Auto's tap-to-play flow it inherits the browse tile's metadata, but it's replaced ~50ms later by the controller's `setMediaItems` (which is the path this PR fixes)

## Test plan

- [ ] DHU / real car: cold-start play from browse → now-playing card displays with title, artist (as subtitle), artwork
- [ ] No regression: lock screen now-playing UI still shows track info
- [ ] No regression: Bluetooth car widget still shows track info
- [ ] No regression: Google Assistant playback still works
- [ ] No regression: browse tree on Auto still renders playlist/album/artist tiles correctly

## Out of scope (do not bundle)

- Spotify pickDevice routing chips (prefer-local-over-active, sticky-default, picker-id-normalization, prefer-local-over-single-real) — orthogonal; they control WHERE Spotify audio goes, this PR controls whether Auto displays a valid now-playing card.

🤖 Generated with [Claude Code](https://claude.com/claude-code)