### PR TITLE
fix(spotify): gate write/mutation methods against the rate-limit cooldown (#176)

### DIFF
--- a/shared/src/commonMain/kotlin/com/parachord/shared/api/SpotifyClient.kt
+++ b/shared/src/commonMain/kotlin/com/parachord/shared/api/SpotifyClient.kt
@@ -104,10 +104,19 @@ class SpotifyClient(
      * triggered an unprotected `/v1/tracks/{id}` call that 429'd, each one
      * extending Spotify's punishment window indefinitely.
      *
-     * Playback-control PUT/DELETE methods (startPlayback, pausePlayback,
-     * etc.) intentionally **do not** route through the gate — the user
-     * needs to be able to skip / pause even during a throttle window. The
-     * gate is for high-volume read traffic, not interactive control.
+     * Library + playlist write methods (saveTracks, removeTracks,
+     * createPlaylist, replacePlaylistTracks, …) ALSO route through the
+     * gate via [gatedSend] (issue #176) so a 429 on a write sets the same
+     * persisted cooldown a read does, and a write can't fire mid-cooldown
+     * to re-arm Spotify's abuse window on the shared `client_id`.
+     *
+     * Only the interactive playback-control PUT/DELETE methods
+     * (startPlayback, pausePlayback, seekPlayback, setVolume,
+     * transferPlayback) and [getDevices] intentionally **do not** route
+     * through the gate — the user needs to be able to skip / pause even
+     * during a throttle window. Those low-volume, user-initiated calls
+     * honor the cooldown advisorily (the playback flow checks the gate's
+     * remaining cooldown and bails before poking a penalized account).
      */
     private val gate = RateLimitGate(
         tag = "SpotifyClient",
@@ -144,6 +153,35 @@ class SpotifyClient(
         gate.handleResponse(response) { SpotifyRateLimitedException(it) }
         response.body()
     }
+
+    /**
+     * Routes a write/mutation request through the same rate-limit gate as
+     * [gatedGet] (issue #176). Acquires a permit (short-circuiting with a
+     * typed [SpotifyRateLimitedException] if the cooldown is active),
+     * issues the request, then calls [RateLimitGate.handleResponse] so a
+     * 429 on a write SETS + persists the cooldown — and throws — exactly
+     * like a 429 on a gated read.
+     *
+     * Why this matters: Spotify's 429s are account-wide and its abuse
+     * window hands back a long `Retry-After` (~1h). If writes stayed
+     * ungated, a write 429 would never arm the cooldown, and a write fired
+     * mid-cooldown (e.g. set by another client on the shared `client_id`)
+     * would poke an already-penalized account and re-arm a fresh ~1h
+     * window. The gate's persisted cooldown is the single source of truth;
+     * every high-volume call — read OR write — must route through it.
+     *
+     * Returns the raw [HttpResponse] for callers that inspect status. The
+     * interactive playback-control PUTs (`play`/`pause`/`seek`/`volume`/
+     * `transferPlayback`) and [getDevices] deliberately stay ungated — the
+     * user must be able to control playback during a throttle window. See
+     * the [gate] KDoc.
+     */
+    private suspend fun gatedSend(request: suspend () -> HttpResponse): HttpResponse =
+        gate.withPermit(exceptionFactory = { SpotifyRateLimitedException(it) }) {
+            val response = request()
+            gate.handleResponse(response) { SpotifyRateLimitedException(it) }
+            response
+        }
 
     // ── Search + Lookup ──────────────────────────────────────────────
 
@@ -256,61 +294,83 @@ class SpotifyClient(
     // ── Library Write ────────────────────────────────────────────────
 
     suspend fun saveTracks(body: SpIdsRequest): HttpResponse =
-        httpClient.put("$BASE/v1/me/tracks") {
-            applyAuth(this); contentType(ContentType.Application.Json); setBody(body)
+        gatedSend {
+            httpClient.put("$BASE/v1/me/tracks") {
+                applyAuth(this); contentType(ContentType.Application.Json); setBody(body)
+            }
         }
 
     suspend fun removeTracks(body: SpIdsRequest): HttpResponse =
-        httpClient.delete("$BASE/v1/me/tracks") {
-            applyAuth(this); contentType(ContentType.Application.Json); setBody(body)
+        gatedSend {
+            httpClient.delete("$BASE/v1/me/tracks") {
+                applyAuth(this); contentType(ContentType.Application.Json); setBody(body)
+            }
         }
 
     suspend fun saveAlbums(body: SpIdsRequest): HttpResponse =
-        httpClient.put("$BASE/v1/me/albums") {
-            applyAuth(this); contentType(ContentType.Application.Json); setBody(body)
+        gatedSend {
+            httpClient.put("$BASE/v1/me/albums") {
+                applyAuth(this); contentType(ContentType.Application.Json); setBody(body)
+            }
         }
 
     suspend fun removeAlbums(body: SpIdsRequest): HttpResponse =
-        httpClient.delete("$BASE/v1/me/albums") {
-            applyAuth(this); contentType(ContentType.Application.Json); setBody(body)
+        gatedSend {
+            httpClient.delete("$BASE/v1/me/albums") {
+                applyAuth(this); contentType(ContentType.Application.Json); setBody(body)
+            }
         }
 
     suspend fun followArtists(body: SpIdsRequest): HttpResponse =
-        httpClient.put("$BASE/v1/me/following") {
-            applyAuth(this); parameter("type", "artist")
-            contentType(ContentType.Application.Json); setBody(body)
+        gatedSend {
+            httpClient.put("$BASE/v1/me/following") {
+                applyAuth(this); parameter("type", "artist")
+                contentType(ContentType.Application.Json); setBody(body)
+            }
         }
 
     suspend fun unfollowArtists(body: SpIdsRequest): HttpResponse =
-        httpClient.delete("$BASE/v1/me/following") {
-            applyAuth(this); parameter("type", "artist")
-            contentType(ContentType.Application.Json); setBody(body)
+        gatedSend {
+            httpClient.delete("$BASE/v1/me/following") {
+                applyAuth(this); parameter("type", "artist")
+                contentType(ContentType.Application.Json); setBody(body)
+            }
         }
 
     // ── Playlist Write ───────────────────────────────────────────────
 
     suspend fun createPlaylist(userId: String, body: SpCreatePlaylistRequest): SpPlaylistFull =
-        httpClient.post("$BASE/v1/users/$userId/playlists") {
-            applyAuth(this); contentType(ContentType.Application.Json); setBody(body)
+        gatedSend {
+            httpClient.post("$BASE/v1/users/$userId/playlists") {
+                applyAuth(this); contentType(ContentType.Application.Json); setBody(body)
+            }
         }.body()
 
     suspend fun replacePlaylistTracks(playlistId: String, body: SpUrisRequest): HttpResponse =
-        httpClient.put("$BASE/v1/playlists/$playlistId/tracks") {
-            applyAuth(this); contentType(ContentType.Application.Json); setBody(body)
+        gatedSend {
+            httpClient.put("$BASE/v1/playlists/$playlistId/tracks") {
+                applyAuth(this); contentType(ContentType.Application.Json); setBody(body)
+            }
         }
 
     suspend fun addPlaylistTracks(playlistId: String, body: SpUrisRequest): HttpResponse =
-        httpClient.post("$BASE/v1/playlists/$playlistId/tracks") {
-            applyAuth(this); contentType(ContentType.Application.Json); setBody(body)
+        gatedSend {
+            httpClient.post("$BASE/v1/playlists/$playlistId/tracks") {
+                applyAuth(this); contentType(ContentType.Application.Json); setBody(body)
+            }
         }
 
     suspend fun updatePlaylistDetails(playlistId: String, body: SpUpdatePlaylistRequest): HttpResponse =
-        httpClient.put("$BASE/v1/playlists/$playlistId") {
-            applyAuth(this); contentType(ContentType.Application.Json); setBody(body)
+        gatedSend {
+            httpClient.put("$BASE/v1/playlists/$playlistId") {
+                applyAuth(this); contentType(ContentType.Application.Json); setBody(body)
+            }
         }
 
     suspend fun unfollowPlaylist(playlistId: String): HttpResponse =
-        httpClient.delete("$BASE/v1/playlists/$playlistId/followers") { applyAuth(this) }
+        gatedSend {
+            httpClient.delete("$BASE/v1/playlists/$playlistId/followers") { applyAuth(this) }
+        }
 }
 
 // ── Response Models ──────────────────────────────────────────────────

--- a/shared/src/commonTest/kotlin/com/parachord/shared/api/SpotifyClientWriteGateTest.kt
+++ b/shared/src/commonTest/kotlin/com/parachord/shared/api/SpotifyClientWriteGateTest.kt
@@ -1,0 +1,129 @@
+package com.parachord.shared.api
+
+import com.parachord.shared.api.auth.AuthCredential
+import com.parachord.shared.api.auth.AuthRealm
+import com.parachord.shared.api.auth.AuthTokenProvider
+import com.parachord.shared.api.auth.OAuthTokenRefresher
+import com.parachord.shared.config.AppConfig
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.mock.MockEngine
+import io.ktor.client.engine.mock.respond
+import io.ktor.http.HttpHeaders
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.headersOf
+import kotlinx.coroutines.test.runTest
+import kotlinx.serialization.json.Json
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+
+/**
+ * MockEngine-based unit tests for the rate-limit gate on Spotify
+ * write/mutation methods (issue #176). A 429 on a write must set the
+ * persisted cooldown and trip the gate exactly like a 429 on a read —
+ * so subsequent gated calls short-circuit during the abuse window
+ * instead of poking an already-rate-limited account.
+ *
+ * The cooldown is asserted *behaviorally* — a subsequent gated write
+ * short-circuits with NO network call — so the test depends only on the
+ * public gate semantics, not on any cooldown-introspection accessor.
+ */
+class SpotifyClientWriteGateTest {
+
+    private val appConfig = AppConfig(
+        userAgent = "Parachord/0.5.0-test (Android; https://parachord.app)",
+        isDebug = false,
+    )
+    private val json = Json { ignoreUnknownKeys = true }
+
+    private val stubAuthProvider = object : AuthTokenProvider {
+        override suspend fun tokenFor(realm: AuthRealm): AuthCredential? =
+            if (realm == AuthRealm.Spotify) AuthCredential.BearerToken("test") else null
+        override suspend fun invalidate(realm: AuthRealm) {}
+    }
+    private val stubTokenRefresher = object : OAuthTokenRefresher {
+        override suspend fun refresh(realm: AuthRealm): AuthCredential.BearerToken? = null
+    }
+
+    private fun buildClient(mock: MockEngine): SpotifyClient {
+        val httpClient = HttpClient(mock) {
+            installSharedPlugins(json, appConfig, stubAuthProvider, stubTokenRefresher)
+        }
+        return SpotifyClient(httpClient, stubAuthProvider)
+    }
+
+    @Test
+    fun saveTracks_on429_tripsGate_andSubsequentWriteShortCircuits() = runTest {
+        var calls = 0
+        val mock = MockEngine {
+            calls++
+            respond(
+                content = "",
+                status = HttpStatusCode.TooManyRequests,
+                headers = headersOf(HttpHeaders.RetryAfter, "120"),
+            )
+        }
+        val client = buildClient(mock)
+
+        // The 429 on the write trips the gate (typed exception)...
+        assertFailsWith<SpotifyRateLimitedException> {
+            client.saveTracks(SpIdsRequest(listOf("a")))
+        }
+        // ...and a subsequent gated write short-circuits WITHOUT a network
+        // call — proving the cooldown was armed by the write's 429.
+        assertFailsWith<SpotifyRateLimitedException> {
+            client.removeTracks(SpIdsRequest(listOf("b")))
+        }
+        assertEquals(
+            1,
+            calls,
+            "second gated write must short-circuit during the cooldown (no network call)",
+        )
+    }
+
+    @Test
+    fun replacePlaylistTracks_on429_tripsGate() = runTest {
+        var calls = 0
+        val mock = MockEngine {
+            calls++
+            respond(
+                content = "",
+                status = HttpStatusCode.TooManyRequests,
+                headers = headersOf(HttpHeaders.RetryAfter, "90"),
+            )
+        }
+        val client = buildClient(mock)
+
+        assertFailsWith<SpotifyRateLimitedException> {
+            client.replacePlaylistTracks("pl1", SpUrisRequest(listOf("spotify:track:x")))
+        }
+        // The armed cooldown short-circuits the next gated write with no call.
+        assertFailsWith<SpotifyRateLimitedException> {
+            client.replacePlaylistTracks("pl1", SpUrisRequest(listOf("spotify:track:y")))
+        }
+        assertEquals(1, calls)
+    }
+
+    @Test
+    fun createPlaylist_onSuccess_doesNotTripGate() = runTest {
+        var calls = 0
+        val mock = MockEngine {
+            calls++
+            respond(
+                content = """{ "id": "pl$calls", "name": "My PL" }""",
+                status = HttpStatusCode.Created,
+                headers = headersOf(HttpHeaders.ContentType, "application/json"),
+            )
+        }
+        val client = buildClient(mock)
+
+        val first = client.createPlaylist("user1", SpCreatePlaylistRequest("My PL", null))
+        assertEquals("pl1", first.id)
+
+        // A 2xx write must NOT arm the cooldown — the next gated write still
+        // reaches the network (no short-circuit).
+        val second = client.createPlaylist("user1", SpCreatePlaylistRequest("My PL", null))
+        assertEquals("pl2", second.id)
+        assertEquals(2, calls, "a 2xx write must not arm the cooldown")
+    }
+}


### PR DESCRIPTION
Closes #176.

## Problem
The shared `SpotifyClient` only routed GET / search / `startPlayback` through the `RateLimitGate`. Every library + playlist **write** (`saveTracks`, `removeTracks`, `saveAlbums`, `removeAlbums`, `followArtists`, `unfollowArtists`, `createPlaylist`, `replacePlaylistTracks`, `addPlaylistTracks`, `updatePlaylistDetails`, `unfollowPlaylist`) called `httpClient.put/post/delete` **raw**, bypassing the gate. So:

1. A 429 on a write never armed the persisted cooldown (only gated calls feed `handleResponse`).
2. A write could fire mid-cooldown — including a cooldown set by a *different* client on the shared `client_id` — poking an already-rate-limited account, which Spotify answers with a fresh ~1h `Retry-After`, re-arming the abuse window.

## Fix
Add a `gatedSend(...)` helper mirroring `gatedGet`: acquire a permit (short-circuit with `SpotifyRateLimitedException` if the cooldown is active), issue the request, then `gate.handleResponse(...)` so a 429 on a write **sets + persists** the cooldown and throws — identical surface to a gated read. Routed every sync mutation through it.

`SpotifyClient` is `shared/commonMain`, so this fixes **both** Android (hourly + 15-min sync push) and iOS (when its Spotify sync lands).

## Scope decision (per the issue's Notes + the issue comment)
The interactive **playback-control** PUTs (`play`/`pause`/`seek`/`volume`/`transferPlayback`) and `getDevices` stay **ungated** by design — the user must be able to skip/pause during a throttle window. They continue to honor the cooldown *advisorily* via `rateLimitRemainingMs()`. `unfollowPlaylist` (the remote playlist-delete path) **is** gated since it's a sync write (one beyond the issue's enumerated list; called out for review).

## Tests
`SpotifyClientWriteGateTest` (MockEngine, commonTest):
- 429 on `saveTracks` arms the cooldown; a subsequent gated write (`removeTracks`) short-circuits with **no** network call.
- 429 on `replacePlaylistTracks` arms the cooldown.
- A 2xx `createPlaylist` does **not** arm the cooldown and returns the decoded body.

Full `:shared:testDebugUnitTest` passes; `:shared:compileKotlinIosSimulatorArm64` green (no JVM-isms).

## No behavior change on the happy path
2xx writes return their `HttpResponse`/decoded body exactly as before. `withRetry` in `SpotifySyncProvider` already lets `SpotifyRateLimitedException` propagate (it only catches `ReauthRequiredException`), so gated writes surface throttling identically to gated reads.

🤖 Generated with [Claude Code](https://claude.com/claude-code)