### PR TITLE
fix(spotify): stop abuse bans from compounding — escalating breaker + kill redundant search

### DIFF
--- a/app/src/main/java/com/parachord/android/resolver/ResolverManager.kt
+++ b/app/src/main/java/com/parachord/android/resolver/ResolverManager.kt
@@ -103,24 +103,35 @@ class ResolverManager constructor(
         query: String,
         targetTitle: String? = null,
         targetArtist: String? = null,
+        /**
+         * Resolver ids to SKIP this run. Used by [resolveWithHints] to avoid
+         * re-searching a resolver it already has an authoritative ID hint for
+         * — notably Spotify, whose search is both redundant (the ID verify
+         * already returns artwork) and a wasted poke that re-arms the abuse
+         * cooldown. Skipped resolvers never reach the network.
+         */
+        excludeResolvers: Set<String> = emptySet(),
     ): List<ResolvedSource> = coroutineScope {
         // Proactively refresh stale tokens before resolving
         ensureTokensFresh()
         val activeResolvers = settingsStore.getActiveResolvers()
 
+        fun enabled(id: String): Boolean =
+            (activeResolvers.isEmpty() || id in activeResolvers) && id !in excludeResolvers
+
         // Build resolver tasks for enabled resolvers only.
         // Empty activeResolvers list means all are enabled (no filtering).
         val tasks = buildList {
-            if (activeResolvers.isEmpty() || "spotify" in activeResolvers) {
+            if (enabled("spotify")) {
                 add(async { resolveSpotify(query) })
             }
-            if (activeResolvers.isEmpty() || "applemusic" in activeResolvers) {
+            if (enabled("applemusic")) {
                 add(async { resolveAppleMusic(query) })
             }
-            if (activeResolvers.isEmpty() || "soundcloud" in activeResolvers) {
+            if (enabled("soundcloud")) {
                 add(async { resolveSoundCloud(query) })
             }
-            if (activeResolvers.isEmpty() || "localfiles" in activeResolvers) {
+            if (enabled("localfiles")) {
                 add(async { resolveLocalFile(targetTitle, targetArtist) })
             }
             // .axe-only resolvers (bandcamp, youtube, etc.) — executed via JsBridge.
@@ -131,7 +142,7 @@ class ResolverManager constructor(
                 .filter { it.capabilities["resolve"] == true && it.id !in nativeResolverIds && it.id !in disabledPlugins }
                 .map { it.id }
             for (resolverId in axeResolverIds) {
-                if (activeResolvers.isEmpty() || resolverId in activeResolvers) {
+                if (enabled(resolverId)) {
                     add(async { resolveViaPlugin(resolverId, query, targetTitle, targetArtist) })
                 }
             }
@@ -178,10 +189,25 @@ class ResolverManager constructor(
 
         // If we have a Spotify ID from metadata, verify it's actually playable
         // before trusting it (metadata IDs can reference tracks unavailable in
-        // the user's market)
+        // the user's market).
         if (spotifyId != null) {
-            val verified = async { verifySpotifyTrack(spotifyId) }
-            val source = verified.await()
+            val source = try {
+                verifySpotifyTrack(spotifyId)
+            } catch (e: com.parachord.shared.api.SpotifyRateLimitedException) {
+                // Spotify is rate-limited. Do NOT drop a known-good ID — that's
+                // what made the Spotify badges vanish across a whole list the
+                // moment the account got 429'd. Emit the cached ID as a source
+                // (playback can use it directly) so the badge persists; artwork
+                // fills in on a later resolve once the cooldown clears.
+                ResolvedSource(
+                    url = "spotify:track:$spotifyId",
+                    sourceType = "spotify",
+                    resolver = "spotify",
+                    spotifyUri = "spotify:track:$spotifyId",
+                    spotifyId = spotifyId,
+                    confidence = 1.0,
+                )
+            }
             if (source != null) {
                 results.add(source)
             }
@@ -230,7 +256,16 @@ class ResolverManager constructor(
         // image-enrichment cascade to RE-ASK metadata providers. Same root
         // cause as the AM-artwork-propagation work in [resolveAppleMusic] /
         // [SpotifyClient.searchTrack].
-        val cascadeResults = resolve(query, targetTitle, targetArtist)
+        // Skip the cascade's Spotify SEARCH when we already produced an
+        // authoritative Spotify source from the ID hint (verified, or the
+        // cached-ID fallback above). The search is redundant — verifySpotifyTrack
+        // already returns artwork — and during an abuse window it's a second
+        // wasted poke that re-arms the cooldown. (AM/SC hints still run their
+        // cascade search for artwork backfill; they aren't the rate-limit
+        // offender. See #176/#177.)
+        val excludeFromCascade =
+            if (results.any { it.resolver == "spotify" }) setOf("spotify") else emptySet()
+        val cascadeResults = resolve(query, targetTitle, targetArtist, excludeResolvers = excludeFromCascade)
         val cascadeByResolver = cascadeResults.associateBy { it.resolver }
         val mergedHints = results.map { hint ->
             if (hint.artworkUrl == null) {
@@ -295,11 +330,10 @@ class ResolverManager constructor(
                 artworkUrl = track.album?.images?.firstOrNull()?.url,
             )
         } catch (e: com.parachord.shared.api.SpotifyRateLimitedException) {
-            // Cooldown active — silently skip. SpotifyClient logs the first 429
-            // of each cooldown cycle; logging per-track here would produce
-            // hundreds of identical lines while a hosted-XSPF playlist's cached
-            // spotifyIds drain through the cooldown.
-            null
+            // Cooldown active — rethrow so the caller (resolveWithHints) can keep
+            // the known-good ID as a source instead of dropping the badge. The
+            // gate already logged the first 429 of the cycle, so no per-track log.
+            throw e
         } catch (e: Exception) {
             Log.w(TAG, "Failed to verify Spotify track $spotifyId: ${e.message}")
             null

--- a/app/src/test/java/com/parachord/android/resolver/ResolverManagerHintsTest.kt
+++ b/app/src/test/java/com/parachord/android/resolver/ResolverManagerHintsTest.kt
@@ -1,0 +1,89 @@
+package com.parachord.android.resolver
+
+import com.parachord.shared.api.SpTrack
+import com.parachord.shared.api.SpotifyClient
+import com.parachord.shared.api.SpotifyRateLimitedException
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+
+/**
+ * Spotify call-volume + badge-persistence behavior of
+ * [ResolverManager.resolveWithHints] (Spotify abuse-ban remediation).
+ *
+ * 1. When a track already has a Spotify ID, the cascade must NOT also fire a
+ *    Spotify *search* — verifying the ID via `getTrack` already yields the
+ *    source (and artwork). The redundant search doubled Spotify load per
+ *    cached track and the result was discarded anyway.
+ * 2. When `getTrack` hits a 429, the known Spotify ID must STILL produce a
+ *    Spotify source so the badge doesn't vanish on a transient rate-limit.
+ */
+class ResolverManagerHintsTest {
+
+    private lateinit var spotifyClient: SpotifyClient
+    private lateinit var resolver: ResolverManager
+
+    @Before
+    fun setUp() {
+        spotifyClient = mockk(relaxed = true)
+        val settingsStore = mockk<com.parachord.shared.settings.SettingsStore>(relaxed = true)
+        val pluginManager = mockk<com.parachord.android.plugin.PluginManager>(relaxed = true)
+
+        coEvery { settingsStore.getActiveResolvers() } returns listOf("spotify")
+        coEvery { settingsStore.getSpotifyAccessToken() } returns "token"
+        coEvery { settingsStore.getDisabledPlugins() } returns emptySet()
+        every { pluginManager.plugins } returns MutableStateFlow(emptyList())
+
+        resolver = ResolverManager(
+            spotifyClient = spotifyClient,
+            settingsStore = settingsStore,
+            oAuthManager = mockk(relaxed = true),
+            okHttpClient = mockk(relaxed = true),
+            json = mockk(relaxed = true),
+            musicKitBridge = mockk(relaxed = true),
+            trackDao = mockk(relaxed = true),
+            pluginManager = pluginManager,
+        )
+    }
+
+    @Test
+    fun `hint with spotify id does not fire a redundant spotify search`() = runTest {
+        coEvery { spotifyClient.getTrack(eq("abc"), any()) } returns SpTrack(id = "abc", isPlayable = true)
+
+        val sources = resolver.resolveWithHints(
+            query = "Song Artist",
+            spotifyId = "abc",
+            targetTitle = "Song",
+            targetArtist = "Artist",
+        )
+
+        assertTrue("expected a spotify source from the verified ID", sources.any { it.resolver == "spotify" })
+        coVerify(exactly = 1) { spotifyClient.getTrack(eq("abc"), any()) }
+        coVerify(exactly = 0) { spotifyClient.searchTrack(any()) }
+    }
+
+    @Test
+    fun `429 on verify keeps the known spotify source so the badge persists`() = runTest {
+        coEvery { spotifyClient.getTrack(eq("abc"), any()) } throws SpotifyRateLimitedException(120L)
+
+        val sources = resolver.resolveWithHints(
+            query = "Song Artist",
+            spotifyId = "abc",
+            targetTitle = "Song",
+            targetArtist = "Artist",
+        )
+
+        val spotify = sources.firstOrNull { it.resolver == "spotify" }
+        assertTrue("rate-limited verify must still emit the known spotify source", spotify != null)
+        assertEquals("abc", spotify!!.spotifyId)
+        // ...and it must not fall through to a search (which would also 429).
+        coVerify(exactly = 0) { spotifyClient.searchTrack(any()) }
+    }
+}

--- a/shared/src/commonMain/kotlin/com/parachord/shared/api/RateLimitGate.kt
+++ b/shared/src/commonMain/kotlin/com/parachord/shared/api/RateLimitGate.kt
@@ -77,8 +77,33 @@ class RateLimitGate(
     private val maxCooldownMs: Long = 60L * 60L * 1000L,
     loadCooldownEpochMs: (() -> Long)? = null,
     private val saveCooldownEpochMs: (suspend (Long) -> Unit)? = null,
+    /**
+     * Escalating circuit breaker. When true, each CONSECUTIVE rate-limited
+     * response doubles the backoff (`base * 2^(strikes-1)`, capped at
+     * [maxCooldownMs]); the first non-rate-limited response resets the
+     * counter. Default false → flat backoff (the original behavior;
+     * LastFm/MusicBrainz keep it).
+     *
+     * Why Spotify opts in: its abuse-mode ban routinely outlasts a flat 1h
+     * cooldown. With a flat cap, every time our local cooldown lapses the
+     * next call re-pokes the still-banned account and Spotify re-extends its
+     * window — so it never clears. Escalation pushes our local cooldown past
+     * Spotify's window after a few consecutive strikes, so we stop poking and
+     * the ban can decay. Pair with a higher [maxCooldownMs] (e.g. 6h).
+     */
+    private val escalateOnRepeat: Boolean = false,
+    /**
+     * Clock source (epoch ms). Injectable so tests can drive the cooldown
+     * deterministically; production passes the real [currentTimeMillis].
+     */
+    private val nowMs: () -> Long = { currentTimeMillis() },
 ) {
     private val limiter = Semaphore(maxConcurrent)
+
+    /** Consecutive rate-limited responses with no intervening success.
+     *  Drives [escalateOnRepeat]. Reset to 0 on any non-rate-limited response. */
+    @Volatile
+    private var consecutiveStrikes: Int = 0
 
     /** Background scope for fire-and-forget cooldown persistence writes.
      *  Kept tiny — only ever does a single `setLong` per 429 cycle. */
@@ -131,11 +156,26 @@ class RateLimitGate(
         isRateLimited: (HttpResponse) -> Boolean = { it.status.value == 429 },
         exceptionFactory: (retryAfterSeconds: Long?) -> Exception,
     ) {
-        if (!isRateLimited(response)) return
+        if (!isRateLimited(response)) {
+            // A clean response ends any consecutive-strike streak. Critical for
+            // the escalating breaker: a recovered call must drop the backoff
+            // back to base so a single later 429 doesn't inherit a long cooldown.
+            consecutiveStrikes = 0
+            return
+        }
+        consecutiveStrikes++
         val retryAfterSec = response.headers["Retry-After"]?.toLongOrNull()
-        val backoffMs = ((retryAfterSec ?: defaultCooldownSec) * 1000L).coerceAtMost(maxCooldownMs)
-        val wasAlreadyLimited = currentTimeMillis() < cooldownUntilMs
-        val newCooldown = currentTimeMillis() + backoffMs
+        val baseMs = (retryAfterSec ?: defaultCooldownSec) * 1000L
+        // Escalate: double per consecutive strike (base * 2^(strikes-1)), capped.
+        // Shift is bounded so the Long can't overflow before the cap clamps it.
+        val backoffMs = if (escalateOnRepeat) {
+            val shift = (consecutiveStrikes - 1).coerceIn(0, 32)
+            (baseMs shl shift).coerceAtMost(maxCooldownMs)
+        } else {
+            baseMs.coerceAtMost(maxCooldownMs)
+        }
+        val wasAlreadyLimited = nowMs() < cooldownUntilMs
+        val newCooldown = nowMs() + backoffMs
         cooldownUntilMs = newCooldown
         // Persist (fire-and-forget) so the cooldown survives a process
         // restart. See class KDoc for why this matters with abuse-window
@@ -144,13 +184,14 @@ class RateLimitGate(
             persistScope.launch { runCatching { save(newCooldown) } }
         }
         if (!wasAlreadyLimited) {
-            Log.w(tag, "$tag rate-limited (HTTP ${response.status.value}). Backing off ${backoffMs / 1000}s; subsequent calls in this window will short-circuit.")
+            val strikeNote = if (escalateOnRepeat && consecutiveStrikes > 1) " (strike #$consecutiveStrikes, escalated)" else ""
+            Log.w(tag, "$tag rate-limited (HTTP ${response.status.value}). Backing off ${backoffMs / 1000}s$strikeNote; subsequent calls in this window will short-circuit.")
         }
         throw exceptionFactory(retryAfterSec)
     }
 
     private fun checkCooldown(exceptionFactory: (retryAfterSeconds: Long?) -> Exception) {
-        val now = currentTimeMillis()
+        val now = nowMs()
         if (now < cooldownUntilMs) {
             throw exceptionFactory(((cooldownUntilMs - now + 999L) / 1000L).coerceAtLeast(1L))
         }
@@ -168,5 +209,5 @@ class RateLimitGate(
      * the cooldown — so it never clears. See the ResolverManager
      * `ensureTokensFresh` KDoc for the original Android post-mortem.
      */
-    fun remainingCooldownMs(): Long = (cooldownUntilMs - currentTimeMillis()).coerceAtLeast(0L)
+    fun remainingCooldownMs(): Long = (cooldownUntilMs - nowMs()).coerceAtLeast(0L)
 }

--- a/shared/src/commonMain/kotlin/com/parachord/shared/api/SpotifyClient.kt
+++ b/shared/src/commonMain/kotlin/com/parachord/shared/api/SpotifyClient.kt
@@ -123,6 +123,15 @@ class SpotifyClient(
         tag = "SpotifyClient",
         loadCooldownEpochMs = loadCooldownEpochMs,
         saveCooldownEpochMs = saveCooldownEpochMs,
+        // Spotify's abuse-mode ban routinely outlasts a flat 1h cooldown
+        // (observed: still 429ing 12+ hours later despite a quiet network).
+        // With a flat cap, each lapse re-pokes the still-banned account and
+        // Spotify re-extends its window — so it never clears. Escalate the
+        // cooldown on consecutive 429s (1h→2h→4h→6h cap) so a persistent ban
+        // pushes our local cooldown past Spotify's window and we stop poking,
+        // letting the ban decay. Resets to base on the first clean response.
+        escalateOnRepeat = true,
+        maxCooldownMs = 6L * 60L * 60L * 1000L,
     )
 
     /**

--- a/shared/src/commonTest/kotlin/com/parachord/shared/api/RateLimitGateTest.kt
+++ b/shared/src/commonTest/kotlin/com/parachord/shared/api/RateLimitGateTest.kt
@@ -1,0 +1,129 @@
+package com.parachord.shared.api
+
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.mock.MockEngine
+import io.ktor.client.engine.mock.respond
+import io.ktor.client.request.get
+import io.ktor.client.statement.HttpResponse
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.headersOf
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertTrue
+
+/**
+ * Unit tests for [RateLimitGate]'s escalating circuit breaker (opt-in).
+ *
+ * Background: Spotify's abuse-mode ban routinely outlasts the 1h `maxCooldownMs`
+ * cap. With a flat cooldown, every time our local cooldown lapses the next call
+ * re-pokes the still-banned account and re-extends Spotify's window — so it
+ * never clears. Escalation doubles the cooldown on each consecutive 429 (reset
+ * on the first success) so a persistent ban quickly pushes our local cooldown
+ * past Spotify's window and we stop poking.
+ */
+class RateLimitGateTest {
+
+    private class TestRateLimited(val retryAfter: Long?) : Exception()
+
+    private suspend fun response(status: HttpStatusCode, retryAfterSec: Long?): HttpResponse {
+        val engine = MockEngine {
+            respond(
+                content = "",
+                status = status,
+                headers = if (retryAfterSec != null) headersOf("Retry-After", retryAfterSec.toString()) else headersOf(),
+            )
+        }
+        return HttpClient(engine).get("http://example.test/")
+    }
+
+    private fun gate(escalate: Boolean, now: () -> Long) = RateLimitGate(
+        tag = "test",
+        defaultCooldownSec = 60L,
+        maxCooldownMs = 6L * 60L * 60L * 1000L, // 6h cap
+        escalateOnRepeat = escalate,
+        nowMs = now,
+    )
+
+    private fun RateLimitGate.feed429(resp: HttpResponse) {
+        assertFailsWith<TestRateLimited> {
+            handleResponse(resp, exceptionFactory = { TestRateLimited(it) })
+        }
+    }
+
+    @Test
+    fun escalating_gate_doubles_cooldown_on_consecutive_429s() = runTest {
+        var now = 0L
+        val g = gate(escalate = true, now = { now })
+        val r = response(HttpStatusCode.TooManyRequests, 60L) // 60s base
+
+        g.feed429(r)
+        val c1 = g.remainingCooldownMs()
+        now += c1 + 1 // let the cooldown lapse, as a real re-poke would
+
+        g.feed429(r)
+        val c2 = g.remainingCooldownMs()
+        now += c2 + 1
+
+        g.feed429(r)
+        val c3 = g.remainingCooldownMs()
+
+        assertEquals(60_000L, c1)
+        assertEquals(120_000L, c2)
+        assertEquals(240_000L, c3)
+        assertTrue(c3 > c2 && c2 > c1)
+    }
+
+    @Test
+    fun success_resets_the_escalation() = runTest {
+        var now = 0L
+        val g = gate(escalate = true, now = { now })
+        val r429 = response(HttpStatusCode.TooManyRequests, 60L)
+
+        g.feed429(r429)
+        now += g.remainingCooldownMs() + 1
+        g.feed429(r429) // strike 2 → 120s
+        assertEquals(120_000L, g.remainingCooldownMs())
+        now += g.remainingCooldownMs() + 1
+
+        // A successful (non-rate-limited) response resets the strike counter.
+        g.handleResponse(response(HttpStatusCode.OK, null), exceptionFactory = { TestRateLimited(it) })
+
+        g.feed429(r429) // back to base
+        assertEquals(60_000L, g.remainingCooldownMs())
+    }
+
+    @Test
+    fun non_escalating_gate_stays_flat() = runTest {
+        var now = 0L
+        val g = gate(escalate = false, now = { now })
+        val r = response(HttpStatusCode.TooManyRequests, 60L)
+
+        g.feed429(r)
+        val c1 = g.remainingCooldownMs()
+        now += c1 + 1
+        g.feed429(r)
+        val c2 = g.remainingCooldownMs()
+
+        assertEquals(60_000L, c1)
+        assertEquals(60_000L, c2) // unchanged — default behavior preserved
+    }
+
+    @Test
+    fun escalation_is_capped_at_maxCooldown() = runTest {
+        var now = 0L
+        val g = gate(escalate = true, now = { now })
+        val r = response(HttpStatusCode.TooManyRequests, 3600L) // 1h base
+        // 1h → 2h → 4h → 6h(cap) → 6h(cap)
+        val seen = mutableListOf<Long>()
+        repeat(5) {
+            g.feed429(r)
+            val rem = g.remainingCooldownMs()
+            seen.add(rem)
+            now += rem + 1
+        }
+        assertEquals(6L * 60L * 60L * 1000L, seen.last())
+        assertTrue(seen.all { it <= 6L * 60L * 60L * 1000L })
+    }
+}


### PR DESCRIPTION
Root-cause fixes for the Spotify abuse-ban that wouldn't clear (a full night of no calls, still 429'd on reconnect, and all Spotify badges vanished). Two complementary fixes; the broader visibility-scoping audit is tracked in #181.

## The problem (diagnosed)
- iOS + Android share one Spotify `client_id`, so rate-limiting is account-wide.
- Yesterday's sustained resolver search volume tripped Spotify's **abuse** mode (long, server-side ban).
- Our local gate capped its cooldown at **1h**, but Spotify's ban outlasts that — so each time our cooldown lapsed, the next call (open/sync) re-poked the still-banned account and Spotify **re-extended** its window. It never cleared.
- Separately, `resolveWithHints` fired a Spotify **search for every track even when the Spotify ID was already known**, then discarded it — doubling Spotify calls per cached track (helped earn the ban), and a 429 on that path **erased good cached Spotify badges**.

## Fix A — escalating circuit breaker (`RateLimitGate`, shared, opt-in)
Consecutive 429s double the cooldown (`base * 2^(strikes-1)`, capped); first clean response resets. Spotify opts in with a **6h cap** (1h→2h→4h→6h) so a persistent ban quickly pushes our local cooldown past Spotify's window — **we stop poking, the ban can decay.** LastFm/MusicBrainz keep the flat 1h behavior (default off). Background sync workers benefit for free (they short-circuit during the now-longer cooldown). Adds an injectable clock for deterministic tests.

## Fix B — don't re-search Spotify when the ID is known; keep badge on 429 (`ResolverManager`, app)
- `resolve()` gains `excludeResolvers`; `resolveWithHints` excludes `"spotify"` from the cascade whenever the ID hint already produced a Spotify source (verify via `getTrack` already returns artwork). **Halves Spotify calls for cached tracks; removes the discarded search.**
- On a 429 during verify, **keep the known Spotify ID as a source** (confidence 1.0) instead of dropping it → badges no longer vanish on a transient rate-limit. `verifySpotifyTrack` rethrows the rate-limit so the caller falls back to the cached ID.
- AM/SC hints still run their cascade search for artwork — they aren't the rate-limit offender.

## Tests
- `RateLimitGateTest` (shared): doubling on consecutive 429s, reset-on-success, cap, and flat-when-off.
- `ResolverManagerHintsTest` (app): hint ⇒ `getTrack` only, no `searchTrack`; 429 ⇒ Spotify source still present, no search fallthrough.
- Full `:shared:testDebugUnitTest` + `:app:testDebugUnitTest` pass; `:shared:compileKotlinIosSimulatorArm64` green.

## Follow-up
- #181 — visibility-scope the remaining ~13 bulk-resolving screens (#177 parity), the broader "don't burst" fix.

## Operator note
The current ban only clears with sustained silence — leave Spotify disconnected (desktop closed too) for several hours, then reconnect once. These fixes prevent the app from re-arming it going forward.

🤖 Generated with [Claude Code](https://claude.com/claude-code)