### PR TITLE
fix(lastfm): guardedGet silently dropped all params (Android + iOS)

### DIFF
--- a/shared/src/commonMain/kotlin/com/parachord/shared/api/LastFmClient.kt
+++ b/shared/src/commonMain/kotlin/com/parachord/shared/api/LastFmClient.kt
@@ -1,15 +1,16 @@
 package com.parachord.shared.api
 
 import io.ktor.client.HttpClient
-import io.ktor.client.call.body
 import io.ktor.client.request.HttpRequestBuilder
 import io.ktor.client.request.get
 import io.ktor.client.request.parameter
 import io.ktor.client.statement.HttpResponse
+import io.ktor.client.statement.bodyAsText
 import kotlinx.serialization.KSerializer
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.builtins.ListSerializer
+import kotlinx.serialization.json.Json
 import kotlinx.serialization.descriptors.SerialDescriptor
 import kotlinx.serialization.descriptors.buildClassSerialDescriptor
 import kotlinx.serialization.encoding.Decoder
@@ -61,74 +62,90 @@ class LastFmClient(private val httpClient: HttpClient) {
     private val gate = RateLimitGate(tag = "LastFmClient")
 
     /**
+     * Explicit Json for decoding the response body via the per-call
+     * [KSerializer] passed to [guardedGet], rather than Ktor's
+     * `response.body<reified T>()`. The compiler-generated serializer resolves
+     * at the call site and still honors the per-type custom serializers below.
+     */
+    private val json = Json {
+        ignoreUnknownKeys = true
+        isLenient = true
+        coerceInputValues = true
+    }
+
+    /**
      * Wraps every GET against [BASE_URL] in the rate-limit gate. Methods
      * just supply their `method=` + endpoint params — `format=json` is
      * always set here so it can't be forgotten at a callsite.
      */
-    private suspend inline fun <reified T> guardedGet(
+    private suspend inline fun <T> guardedGet(
+        deserializer: KSerializer<T>,
         crossinline build: HttpRequestBuilder.() -> Unit,
     ): T = gate.withPermit(exceptionFactory = { LastFmRateLimitedException(it) }) {
         val response: HttpResponse = httpClient.get(BASE_URL) {
-            build()
+            apply(build)   // bind `build`'s receiver explicitly to this builder —
+                           // a bare `build()` fails to bind on BOTH JVM and
+                           // Native here and silently drops every param (Last.fm
+                           // error 6). See LastFmClientParamsTest.
             parameter("format", "json")
         }
         gate.handleResponse(response) { LastFmRateLimitedException(it) }
-        response.body()
+        json.decodeFromString(deserializer, response.bodyAsText())
     }
 
     suspend fun searchTracks(track: String, apiKey: String, limit: Int = 20): LfmTrackSearchResponse =
-        guardedGet { parameter("method", "track.search"); parameter("track", track); parameter("api_key", apiKey); parameter("limit", limit) }
+        guardedGet(LfmTrackSearchResponse.serializer()) { parameter("method", "track.search"); parameter("track", track); parameter("api_key", apiKey); parameter("limit", limit) }
 
     suspend fun searchAlbums(album: String, apiKey: String, limit: Int = 10): LfmAlbumSearchResponse =
-        guardedGet { parameter("method", "album.search"); parameter("album", album); parameter("api_key", apiKey); parameter("limit", limit) }
+        guardedGet(LfmAlbumSearchResponse.serializer()) { parameter("method", "album.search"); parameter("album", album); parameter("api_key", apiKey); parameter("limit", limit) }
 
     suspend fun searchArtists(artist: String, apiKey: String, limit: Int = 10): LfmArtistSearchResponse =
-        guardedGet { parameter("method", "artist.search"); parameter("artist", artist); parameter("api_key", apiKey); parameter("limit", limit) }
+        guardedGet(LfmArtistSearchResponse.serializer()) { parameter("method", "artist.search"); parameter("artist", artist); parameter("api_key", apiKey); parameter("limit", limit) }
 
     suspend fun getArtistInfo(artist: String, apiKey: String): LfmArtistInfoResponse =
-        guardedGet { parameter("method", "artist.getinfo"); parameter("artist", artist); parameter("api_key", apiKey) }
+        guardedGet(LfmArtistInfoResponse.serializer()) { parameter("method", "artist.getinfo"); parameter("artist", artist); parameter("api_key", apiKey) }
 
     suspend fun getSimilarArtists(artist: String, apiKey: String, limit: Int = 20): LfmSimilarArtistsResponse =
-        guardedGet { parameter("method", "artist.getsimilar"); parameter("artist", artist); parameter("api_key", apiKey); parameter("limit", limit) }
+        guardedGet(LfmSimilarArtistsResponse.serializer()) { parameter("method", "artist.getsimilar"); parameter("artist", artist); parameter("api_key", apiKey); parameter("limit", limit) }
 
     suspend fun getArtistTopTracks(artist: String, apiKey: String, limit: Int = 10): LfmTopTracksResponse =
-        guardedGet { parameter("method", "artist.gettoptracks"); parameter("artist", artist); parameter("api_key", apiKey); parameter("limit", limit) }
+        guardedGet(LfmTopTracksResponse.serializer()) { parameter("method", "artist.gettoptracks"); parameter("artist", artist); parameter("api_key", apiKey); parameter("limit", limit) }
 
     suspend fun getArtistTopAlbums(artist: String, apiKey: String, limit: Int = 50): LfmTopAlbumsResponse =
-        guardedGet { parameter("method", "artist.gettopalbums"); parameter("artist", artist); parameter("api_key", apiKey); parameter("limit", limit) }
+        guardedGet(LfmTopAlbumsResponse.serializer()) { parameter("method", "artist.gettopalbums"); parameter("artist", artist); parameter("api_key", apiKey); parameter("limit", limit) }
 
     suspend fun getTrackInfo(track: String, artist: String, apiKey: String): LfmTrackInfoResponse =
-        guardedGet { parameter("method", "track.getInfo"); parameter("track", track); parameter("artist", artist); parameter("api_key", apiKey) }
+        guardedGet(LfmTrackInfoResponse.serializer()) { parameter("method", "track.getInfo"); parameter("track", track); parameter("artist", artist); parameter("api_key", apiKey) }
 
     suspend fun getSimilarTracks(track: String, artist: String, apiKey: String, limit: Int = 20): LfmSimilarTracksResponse =
-        guardedGet { parameter("method", "track.getsimilar"); parameter("track", track); parameter("artist", artist); parameter("api_key", apiKey); parameter("limit", limit) }
+        guardedGet(LfmSimilarTracksResponse.serializer()) { parameter("method", "track.getsimilar"); parameter("track", track); parameter("artist", artist); parameter("api_key", apiKey); parameter("limit", limit) }
 
     suspend fun getAlbumInfo(album: String, artist: String, apiKey: String): LfmAlbumInfoResponse =
-        guardedGet { parameter("method", "album.getinfo"); parameter("album", album); parameter("artist", artist); parameter("api_key", apiKey) }
+        guardedGet(LfmAlbumInfoResponse.serializer()) { parameter("method", "album.getinfo"); parameter("album", album); parameter("artist", artist); parameter("api_key", apiKey) }
 
     suspend fun getUserInfo(user: String, apiKey: String): LfmUserInfoResponse =
-        guardedGet { parameter("method", "user.getinfo"); parameter("user", user); parameter("api_key", apiKey) }
+        guardedGet(LfmUserInfoResponse.serializer()) { parameter("method", "user.getinfo"); parameter("user", user); parameter("api_key", apiKey) }
 
     suspend fun getUserTopTracks(user: String, apiKey: String, period: String = "overall", limit: Int = 50): LfmUserTopTracksResponse =
-        guardedGet { parameter("method", "user.gettoptracks"); parameter("user", user); parameter("period", period); parameter("limit", limit); parameter("api_key", apiKey) }
+        guardedGet(LfmUserTopTracksResponse.serializer()) { parameter("method", "user.gettoptracks"); parameter("user", user); parameter("period", period); parameter("limit", limit); parameter("api_key", apiKey) }
 
     suspend fun getUserTopAlbums(user: String, apiKey: String, period: String = "overall", limit: Int = 50): LfmUserTopAlbumsResponse =
-        guardedGet { parameter("method", "user.gettopalbums"); parameter("user", user); parameter("period", period); parameter("limit", limit); parameter("api_key", apiKey) }
+        guardedGet(LfmUserTopAlbumsResponse.serializer()) { parameter("method", "user.gettopalbums"); parameter("user", user); parameter("period", period); parameter("limit", limit); parameter("api_key", apiKey) }
 
     suspend fun getUserTopArtists(user: String, apiKey: String, period: String = "overall", limit: Int = 50): LfmUserTopArtistsResponse =
-        guardedGet { parameter("method", "user.gettopartists"); parameter("user", user); parameter("period", period); parameter("limit", limit); parameter("api_key", apiKey) }
+        guardedGet(LfmUserTopArtistsResponse.serializer()) { parameter("method", "user.gettopartists"); parameter("user", user); parameter("period", period); parameter("limit", limit); parameter("api_key", apiKey) }
 
     suspend fun getUserRecentTracks(user: String, apiKey: String, limit: Int = 50): LfmUserRecentTracksResponse =
-        guardedGet { parameter("method", "user.getrecenttracks"); parameter("user", user); parameter("limit", limit); parameter("api_key", apiKey) }
+        guardedGet(LfmUserRecentTracksResponse.serializer()) { parameter("method", "user.getrecenttracks"); parameter("user", user); parameter("limit", limit); parameter("api_key", apiKey) }
 
     suspend fun getUserFriends(user: String, apiKey: String, limit: Int = 200): LfmUserFriendsResponse =
-        guardedGet { parameter("method", "user.getfriends"); parameter("user", user); parameter("limit", limit); parameter("api_key", apiKey) }
+        guardedGet(LfmUserFriendsResponse.serializer()) { parameter("method", "user.getfriends"); parameter("user", user); parameter("limit", limit); parameter("api_key", apiKey) }
 
     suspend fun getChartTopTracks(apiKey: String, limit: Int = 50): LfmChartTopTracksResponse =
-        guardedGet { parameter("method", "chart.gettoptracks"); parameter("limit", limit); parameter("api_key", apiKey) }
+        guardedGet(LfmChartTopTracksResponse.serializer()) { parameter("method", "chart.gettoptracks"); parameter("limit", limit); parameter("api_key", apiKey) }
 
     suspend fun getGeoTopTracks(country: String, apiKey: String, limit: Int = 50): LfmGeoTopTracksResponse =
-        guardedGet { parameter("method", "geo.gettoptracks"); parameter("country", country); parameter("limit", limit); parameter("api_key", apiKey) }
+        guardedGet(LfmGeoTopTracksResponse.serializer()) { parameter("method", "geo.gettoptracks"); parameter("country", country); parameter("limit", limit); parameter("api_key", apiKey) }
 }
 
 // ── Response Models ──────────────────────────────────────────────────

--- a/shared/src/commonTest/kotlin/com/parachord/shared/api/LastFmClientParamsTest.kt
+++ b/shared/src/commonTest/kotlin/com/parachord/shared/api/LastFmClientParamsTest.kt
@@ -1,0 +1,44 @@
+package com.parachord.shared.api
+
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.mock.MockEngine
+import io.ktor.client.engine.mock.respond
+import io.ktor.http.HttpHeaders
+import io.ktor.http.headersOf
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertContains
+
+/**
+ * Regression test for the Kotlin/Native `crossinline build()` receiver-binding
+ * bug in [LastFmClient.guardedGet]: a bare `build()` silently dropped every
+ * query param on Native, so Last.fm replied `error 6` and all iOS Last.fm
+ * features came back empty. The fix binds the receiver via `apply(build)`.
+ *
+ * This is a `commonTest`, so it runs on BOTH the JVM (Android) and Native
+ * (iOS) targets — proving the params survive on each platform.
+ */
+class LastFmClientParamsTest {
+
+    @Test
+    fun getArtistTopTracks_sendsAllParams() = runTest {
+        var capturedUrl = ""
+        val mock = MockEngine { request ->
+            capturedUrl = request.url.toString()
+            respond(
+                content = """{"toptracks":{"track":[]}}""",
+                headers = headersOf(HttpHeaders.ContentType, "application/json"),
+            )
+        }
+        val client = LastFmClient(HttpClient(mock))
+
+        client.getArtistTopTracks(artist = "The National", apiKey = "TESTKEY123", limit = 5)
+
+        // Before the fix these were ALL missing on Native (only format=json went out).
+        assertContains(capturedUrl, "method=artist.gettoptracks")
+        assertContains(capturedUrl, "api_key=TESTKEY123")
+        assertContains(capturedUrl, "artist=The")
+        assertContains(capturedUrl, "limit=5")
+        assertContains(capturedUrl, "format=json")
+    }
+}


### PR DESCRIPTION
`LastFmClient.guardedGet` built each request with a bare `build()` inside the Ktor `get {}` block. That does **not** bind the lambda's receiver to the request builder, so it silently no-ops — every Last.fm request went out with only `format=json` and **no** `method`/`artist`/`api_key`. Last.fm returns 400 error 6 ("missing a required parameter"), which deserializes to an all-null body, so **every** Last.fm call (artist top tracks/info, charts, user recent tracks, friends, …) came back empty.

Affects **both** Android (JVM) and iOS (Native) — latent since the KMP/Ktor cutover. Masked on Android because Spotify supplied the metadata Last.fm silently failed to provide, and the Last.fm chart/friends sources are non-default.

**Fix:** bind the receiver explicitly with `apply(build)`, and decode via the explicit per-call `KSerializer<T>` passed to `guardedGet` (compile-time serializer; still honors the per-type custom serializers). Adds `LastFmClientParamsTest` as a regression guard.

**Tests:** `LastFmClientParamsTest` (FAILS with bare `build()`, PASSES with the fix) on `:shared:testDebugUnitTest`; `:shared:compileKotlinIosSimulatorArm64` green.

**Provenance:** the shared `LastFmClient` change is cherry-picked from local commit `5728545`; the iOS-only `IosContainer` key-trim hunk from that commit is intentionally omitted here and lands with the iOS branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)